### PR TITLE
Cookie: ajout d'un dot devant le domaine pour que les sous-domaines p…

### DIFF
--- a/app/fonctions.php
+++ b/app/fonctions.php
@@ -503,7 +503,7 @@ function user_login($identifiant, $connectme=true){
         // CRÉATION DU COOKIE POUR RESTER CONNECTÉ
         $cookietoken=md5(rand(100, 999));
         $id_user=intval($handle['id_user']);
-        setcookie('cafuser', $id_user.'-'.$cookietoken, $p_time+(86400*7), '/', '', (isset($_SERVER['HTTPS']) ? true : false), true); // duree : un an
+        setcookie('cafuser', $id_user.'-'.$cookietoken, $p_time+(86400*7), '/', '.clubalpinlyon.fr', (isset($_SERVER['HTTPS']) ? true : false), true); // duree : une semaine
         // sauvegarde du token en BD
         $mysqli->query("UPDATE  `".$pbd."user` SET  `cookietoken_user` =  '$cookietoken' WHERE  `id_user` =$id_user LIMIT 1 ;");
 


### PR DESCRIPTION
…uissent y accéder

J'ai configuré biblio.clubalpinlyon.fr et je souhaiterais pouvoir lire les cookies de www.clubalpinlyon.fr pour vérifier que l'utilisateur est bien connecté et qu'il a le droit d'accéder à l'outil
@romainneutron est-ce que tu y vois un soucis au niveau secu ?