### PR TITLE
Encadrants are not duplicated when modifying an event

### DIFF
--- a/public/app/fonctions.php
+++ b/public/app/fonctions.php
@@ -1132,3 +1132,26 @@ function getArrayFirstValue($array)
 {
     return $array[0];
 }
+
+/**
+ * Function to log into a file on the server
+ * The log file will be available under `XXX.clubalpinlyon.fr/deployments/current/log/`
+ *
+ * @param string | array $log_msg: the value to log
+ */
+function log_to_file($log_msg)
+{
+    $date = new DateTime();
+    $date = $date->format("Y-m-d H:i:s");
+    $env = explode('.', $_SERVER['HTTP_HOST'])[0];
+    $logfile_path = "../log";
+    if (!file_exists($logfile_path))
+    {
+        mkdir($logfile_path, 0777, true);
+    }
+    if (is_array($log_msg)) {
+        $log_msg = implode('|', $log_msg);
+    }
+    $log_file_data = $logfile_path.'/log_'.$env . '_s' . date('d-M-Y') . '.log';
+    file_put_contents($log_file_data, $date . ' >> ' . $log_msg . "\n", FILE_APPEND);
+}

--- a/public/scripts/operations/operations.evt_save.php
+++ b/public/scripts/operations/operations.evt_save.php
@@ -151,7 +151,6 @@ if (!isset($errTab) || 0 === count($errTab)) {
 
         if (!isset($errTab) || 0 === count($errTab)) {
             foreach ($encadrants as $id_user) {
-                $id_user = (int) $id_user;
                 if (!in_array($id_user, $deja_encadrants, true)) {
                     $req = 'INSERT INTO '.$pbd."evt_join(id_evt_join, status_evt_join, evt_evt_join, user_evt_join, role_evt_join, tsp_evt_join)
                                                         VALUES(NULL , 1,               '$id_evt',  '$id_user',  'encadrant', $p_time);";
@@ -159,7 +158,6 @@ if (!isset($errTab) || 0 === count($errTab)) {
                 }
             }
             foreach ($coencadrants as $id_user) {
-                $id_user = (int) $id_user;
                 if (!in_array($id_user, $deja_encadrants, true)) {
                     $req = 'INSERT INTO '.$pbd."evt_join(id_evt_join, status_evt_join, evt_evt_join, user_evt_join, role_evt_join, tsp_evt_join)
                                                         VALUES(NULL , 1, '$id_evt',  '$id_user',  'coencadrant', $p_time);";


### PR DESCRIPTION
the 3rd param of in_array (bool) will verify the type.
Since $new_encadrants contains an array of string and that we cast the id_user into an int, it doesn't match and insert the instructor again.
Another option is to not check the type in the in_array function.