### PR TITLE
Feat: Ajout date pour liste des sorties

### DIFF
--- a/legacy/scripts/fonctions.php
+++ b/legacy/scripts/fonctions.php
@@ -40,10 +40,18 @@ function display_sorties($id_user, $limit = 10, $title = '')
         echo '<p class="mini">'.$total.' sortie(s) en tout</p>';
         echo '<div style="width:490px">';
         // liste
+        echo '<table id="agenda">';
         while ($handle = $handleSql->fetch_array(\MYSQLI_ASSOC)) {
             $evt = $handle;
+
+            echo '<tr>'
+                    .'<td class="agenda-gauche">'.date('d/m/Y', $evt['tsp_evt']).'</td>'
+                    .'<td>';
             require __DIR__.'/../includes/agenda-evt-debut.php';
+            echo '</td>'
+                .'</tr>';
         }
+        echo '</table>';
         echo '</div><hr />';
     }
 }


### PR DESCRIPTION
Dans la [page de profile simple](https://www.clubalpinlyon.fr/includer.php?p=includes/fiche-profil.php&id_user=112) et dans la [page de profile complet](https://www.clubalpinlyon.fr/user-full/112.html), les sorties sont listées sans date.
Cette PR inclut un tableau contenant la date pour chaque sortie et la sortie à coté.
closes #330 