### PR TITLE
Disable new cycle radio button

### DIFF
--- a/legacy/includes/evt/creer.php
+++ b/legacy/includes/evt/creer.php
@@ -180,7 +180,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
         <?php if (!$_POST['cycle']) { ?>
             <label class="biglabel" for="cycle_parent">
-                <input type="radio" name="cycle" id="cycle_parent" value="parent" <?php if ($_POST['cycle_master_evt']) {
+                <input type="radio" disabled="true" name="cycle" id="cycle_parent" value="parent" <?php if ($_POST['cycle_master_evt']) {
                 echo 'checked="checked"';
             }?> /> Oui, cette sortie est la première d'un cycle,
                 <?php


### PR DESCRIPTION
Since the "cycle" feature is broken (can't change participants for a second event of a cycle), it creates too much trouble, we've decided to disable it.
We'll start by disallowing the creation of new cycles and then, we'll remove the feature entirely once all cycles are over.