### PR TITLE
Feat: supprime les boutons pour ajouter des inscriptions si la sortie…

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -604,8 +604,8 @@
                          </form>
                         {% endif %}
 
-                        {% if not event.publicStatusUnseen %}
-                            {% if allowed('user_see_all') or allowed('evt_join_notme') or allowed('evt_join_doall') %}
+                        {% if allowed('user_see_all') or allowed('evt_join_notme') or allowed('evt_join_doall') %}
+                            {% if not event.publicStatusUnseen %}
                                 <a class="nice2 blue fancyframe" href="/includer.php?p=includes/join_manual.php&amp;id_evt={{ event.id }}" title="">
                                     Inscrire manuellement des adhérents du club
                                 </a>
@@ -613,6 +613,8 @@
                                 <a class="nice2 blue fancyframe" href="/includer.php?p=includes/join_nomad.php&amp;id_evt={{ event.id }}" title="">
                                     Ajouter un adhérent "Nomade"
                                 </a>
+                            {% else %}
+                                <i>Vous pourrez ajouter des participants quand la sortie sera publiée
                             {% endif %}
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION
Lorsqu'une sortie n'est pas encore validée par un responsable de commission, le bouton "Inscrire manuellement des adhérents du club" est disponible et il permet de chercher les utilisateurs, mais au moment de l'ajout, un message "Cette sortie ne semble pas publiée, les inscriptions sont impossible" apparait.
Avec cette PR, le bouton ne s'affiche que si la sortie est publiée.
# avant
![Capture d’écran 2023-05-18 à 17 44 58](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/205134/7fa79b35-c6ec-476a-9d7d-ea701a20763b)
![Capture d’écran 2023-05-18 à 17 45 50](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/205134/33c66664-6d10-4797-9f0a-f81ddb8ed064)
# apres
![Capture d’écran 2023-05-18 à 17 55 06](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/205134/be245248-c378-46c0-879a-232556187f95)
