### PR TITLE
Feat: ajout indicateur de remplissage de la sortie push_to_dev

### DIFF
--- a/public/css/style1.css
+++ b/public/css/style1.css
@@ -413,7 +413,7 @@ form .niveau.editable:hover .input{background-image:none;}
     #organisation_covoiturage td {font-size:10px;}
 }
 
-.label {
+.label-complet {
     display: inline-block;
     padding: .2em .6em .3em;
     font-size: 75%;

--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -74,9 +74,7 @@
                         {% else %}
                             <span style="color:#4D4D4D">{{ event.commission.title }}
                             {% if nPlacesRestantesOnline > 0 %}
-                                <span class="label">
-                                    complet
-                                </span>
+                                <span class="label-complet"> complet </span>
                             {% endif %}
                             </span>
                         </span>


### PR DESCRIPTION
Ajout d'un label "complet" à coté de la sortie dans l'agenda réduit de droite

# avant
![Capture d’écran 2023-05-19 à 08 51 19](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/205134/a63d9343-b3fa-475d-8bb9-304db316247e)


# apres
![Capture d’écran 2023-05-19 à 08 36 47](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/205134/2b299f6d-66e1-46a1-be49-df1d1850e3f4)

fixes #71 