### PR TITLE
Fix: rollback label complet

### DIFF
--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -73,9 +73,9 @@
                             <span class="cancelled">Sortie annulée</span>
                         {% else %}
                             <span style="color:#4D4D4D">{{ event.commission.title }}
-                            {% if nPlacesRestantesOnline > 0 %}
+                            {# {% if nPlacesRestantesOnline > 0 %}
                                 <span class="label-complet"> complet </span>
-                            {% endif %}
+                            {% endif %} #}
                             </span>
                         {% endif %}
                         <h2>{{ event.titre }}</h2>


### PR DESCRIPTION
apparement, des sorties non completes sont tagguées "complet", il faut donc revoir la logique.
En attendant, je rollback :/