### PR TITLE
Mise en avant du lien vers les autres solutions de location #86bwjpv1u

### DIFF
--- a/templates/minibus/index.html.twig
+++ b/templates/minibus/index.html.twig
@@ -63,7 +63,13 @@
             <hr />
             <h1><span class="bleucaf">En cas d'indisponibilité</span></h1>
             <p>
-                <a href="https://drive.google.com/drive/u/5/folders/1udqJqRRnPnmdxMOmTcTorOWo-m9xyxWy" target="_blank">D'autres solutions de location</a>
+                <a href="https://drive.google.com/drive/u/5/folders/1udqJqRRnPnmdxMOmTcTorOWo-m9xyxWy"
+                   target="_blank"
+                   style="color:blue;"
+                   onmouseover="this.style.color='white'; this.style.backgroundColor='blue';"
+                   onmouseout="this.style.color='blue'; this.style.backgroundColor='transparent';">
+                    <b>Cliquez ici pour accéder aux autres solutions de location</b>
+                </a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Proposition de mise en avant du lien en suivant les recommandations UX:
![image](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/54988392/77fa0cdf-e771-4338-a26d-97296ba4c451)
Effet bleu lors du survol du lien
![image](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/54988392/26d0d583-eb02-454a-8c73-c0914c0cbbb2)
