### PR TITLE
Changement de l'url du fichier des tarifs 2023-2024 sur la page adhésion #86bwhmm54

### DIFF
--- a/templates/content_html/main-pagelibre-63.html.twig
+++ b/templates/content_html/main-pagelibre-63.html.twig
@@ -50,7 +50,7 @@ Ce code change tous les ans.<br /> Attendez de l'avoir reçu pour procéder au r
 <h2 class="bleucaf">Retrait de la carte</h2>
 <p class="erreur">Pour tous,<strong> la carte d'adhérent est disponible au club</strong> quelques jours plus tard où vous pourrez venir la retirer ou nous envoyer une enveloppe timbrée portant votre adresse pour un envoi par courrier.</p>
 <h1 class="bleucaf">Tarifs des cotisations</h1>
-<p><a href="/ftp/telechargements/tarif-adhesion-2023-2024.pdf" target="_blank">Afficher les tarifs 2023-2024</a></p>
+<p><a href="https://caflv-public-files.s3.eu-west-3.amazonaws.com/caflv-tarif-adhesion-2023-2024.pdf" target="_blank">Afficher les tarifs 2023-2024</a></p>
 <p> </p>
 <p>L'adhésion comprends les éléments suivant :</p>
 <ul style="list-style-position: outside; margin-left: 30px;">


### PR DESCRIPTION
Je ne peux pas afficher la page pour vérifier mais il y a juste un changement d'url 
![image](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/54988392/5a9ac7e7-fdb2-4c4d-8b69-def7a4ae8651)
