### PR TITLE
Fix(images) page partenaires VTT : images non affichées #860ry48nh

### DIFF
--- a/templates/content_html/main-pagelibre-76.html.twig
+++ b/templates/content_html/main-pagelibre-76.html.twig
@@ -147,7 +147,7 @@ Bellecour *</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://www.alltricks.fr/" target="_blank"><img src="/public/build/images/alltricks.jpg" alt="logo Alltricks"/></a><br />
+            <td><a href="https://www.alltricks.fr/" target="_blank"><img src="{{ asset('build/images/alltricks.jpg') }}" alt="logo Alltricks"/></a><br />
             </td>
             <td>
                 <p>Alltricks</p>
@@ -163,7 +163,9 @@ Bellecour *</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://www.cycles-blain.com/" target="_blank"><img src="/public/build/images/cycleblain.png" alt="logo Cycles Blain"/></a><br />
+            <td><a href="https://www.cycles-blain.com/" target="_blank">
+                    <img src="{{ asset('build/images/cycleblain.jpg') }}" alt="logo Cycles Blain"/>
+                </a><br />
             </td>
             <td>
                 <p>Cycles Blain</p>
@@ -185,7 +187,7 @@ Bellecour *</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://cycleservice.fr/" target="_blank"><img src="/public/build/images/cycleservice.png" alt="logo Cycle Service"/></a><br />
+            <td><a href="https://cycleservice.fr/" target="_blank"><img src="{{ asset('build/images/cycleservice.jpg') }}" alt="logo Cycle Service"/></a><br />
             </td>
             <td>
                 <p>Cycle service</p>


### PR DESCRIPTION
### Ticket
https://app.clickup.com/t/860ry48nh

### PR liée
https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/pull/486

### Problème
Chemin d'accès aux images.

### Questionnement 
Historiquement, le chemin d'accès aux images est
``<img src="https://clubalpinlyon.fr/ftp/images/logo-partenaires/auvieuxcampeur.jpg" />``
-> lien absolu = mauvaise pratique problèmes de dépendance, de sécurité, de gestion, de performances.

**Bonne pratique** : utiliser des liens relatifs 
``<img src="{{ asset('build/images/cycleservice.jpg') }}"/>``
Et stocker les images dans ``assets/images`` afin de les retrouver au build de l'app dans ``public/build/images``

### Solution proposée

Utiliser des liens relatifs. 

Cependant, j'aurais aimé clarifier le besoin et voir si vous comptez continuer de passer par le ftp pour la gestion des images ?

MR à valider seulement si la solution choisie est d'utiliser les liens relatifs.
