### PR TITLE
Fix RSS title encoding

### DIFF
--- a/legacy/includes/FeedItem.php
+++ b/legacy/includes/FeedItem.php
@@ -92,7 +92,8 @@
       */
      public function setTitle($title)
      {
-         $this->addElement('title', $title);
+         // Title does not support HTML, let's strip this using htmlentities
+         $this->addElement('title', htmlentities($title));
      }
 
      /**

--- a/legacy/includes/FeedWriter.php
+++ b/legacy/includes/FeedWriter.php
@@ -81,7 +81,7 @@ class FeedWriter
      *
      * @return void
      */
-    public function genarateFeed()
+    public function generateFeed()
     {
         header('Content-type: text/xml');
 
@@ -279,7 +279,7 @@ class FeedWriter
         } else {
             //			$nodeText .= (in_array($tagName, $this->CDATAEncoding))? $tagContent : htmlentities($tagContent);
             //			$nodeText .= (in_array($tagName, $this->CDATAEncoding))? $tagContent : htmlentities($tagContent, ENT_COMPAT, 'UTF-8');
-            $nodeText .= (in_array($tagName, $this->CDATAEncoding, true)) ? $tagContent : str_replace(['&', '”', "'", ''], ['&', '"', "'", '<', '>'], $tagContent);
+            $nodeText .= (in_array($tagName, $this->CDATAEncoding, true)) ? $tagContent : str_replace('”', '"', $tagContent);
         }
 
         $nodeText .= (in_array($tagName, $this->CDATAEncoding, true)) ? "]]></$tagName>" : "</$tagName>";

--- a/legacy/rss.php
+++ b/legacy/rss.php
@@ -200,4 +200,4 @@ foreach ($entryTab as $entry) {
     $CafFeed->addItem($newItem);
 }
 // OK. Everything is done. Now genarate the feed.
-$CafFeed->genarateFeed();
+$CafFeed->generateFeed();


### PR DESCRIPTION
Current feed does not pass validation because invalid title content https://www.clubalpinlyon.fr/rss.xml?mode=articles-alpinisme
We must encode RSS title to avoid this