### PR TITLE
Fix des charsets et commentaires de certains champs d'entités 

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -6,7 +6,7 @@ doctrine:
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
         #server_version: '13'
-        schema_filter: ~^(?!caf_bus|caf_bus_lieu_destination|caf_content_html|caf_destination|caf_evt_destination)~
+        schema_filter: ~^(?!caf_bus|caf_bus_lieu_destination|caf_content_html|caf_destination|caf_evt_destination|phpbb)~
         charset: utf8mb4
         default_table_options:
             charset:              utf8mb4

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -82,13 +82,13 @@ class Article
     /**
      * @var string
      */
-    #[ORM\Column(name: 'titre_article', type: 'string', length: 200, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'titre_article', type: 'string', length: 200, nullable: false)]
     private $titre;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'code_article', type: 'string', length: 50, nullable: false, options: ['comment' => 'Pour affichage dans les URL', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'code_article', type: 'string', length: 50, nullable: false, options: ['comment' => 'Pour affichage dans les URL',])]
     private $code;
 
     
@@ -114,7 +114,7 @@ class Article
     /**
      * @var string
      */
-    #[ORM\Column(name: 'cont_article', type: 'text', length: 65535, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'cont_article', type: 'text', length: 65535, nullable: false)]
     private $cont;
 
     /**

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -48,7 +48,7 @@ class Comment
     /**
      * @var string
      */
-    #[ORM\Column(name: 'name_comment', type: 'string', length: 50, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'name_comment', type: 'string', length: 50, nullable: false)]
     private $name;
 
     /**
@@ -60,13 +60,13 @@ class Comment
     /**
      * @var string
      */
-    #[ORM\Column(name: 'cont_comment', type: 'text', length: 65535, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'cont_comment', type: 'text', length: 65535, nullable: false)]
     private $cont;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'parent_type_comment', type: 'string', length: 20, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'parent_type_comment', type: 'string', length: 20, nullable: false)]
     private $parentType;
 
     /**

--- a/src/Entity/Commission.php
+++ b/src/Entity/Commission.php
@@ -39,13 +39,13 @@ class Commission
     /**
      * @var string
      */
-    #[ORM\Column(name: 'code_commission', type: 'string', length: 50, nullable: false, unique: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'code_commission', type: 'string', length: 50, nullable: false, unique: true)]
     private $code;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'title_commission', type: 'string', length: 30, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'title_commission', type: 'string', length: 30, nullable: false)]
     private $title;
 
     public function __construct(string $title, string $code, int $ordre)

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -137,31 +137,31 @@ class Evt
     /**
      * @var string
      */
-    #[ORM\Column(name: 'place_evt', type: 'string', length: 100, nullable: false, options: ['comment' => 'Lieu de RDV covoiturage', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'place_evt', type: 'string', length: 100, nullable: false, options: ['comment' => 'Lieu de RDV covoiturage',])]
     private $place;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'titre_evt', type: 'string', length: 100, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'titre_evt', type: 'string', length: 100, nullable: false)]
     private $titre;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'code_evt', type: 'string', length: 30, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'code_evt', type: 'string', length: 30, nullable: false)]
     private $code;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'massif_evt', type: 'string', length: 100, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'massif_evt', type: 'string', length: 100, nullable: true)]
     private $massif;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'rdv_evt', type: 'string', length: 200, nullable: false, options: ['comment' => 'Lieu détaillé du rdv', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'rdv_evt', type: 'string', length: 200, nullable: false, options: ['comment' => 'Lieu détaillé du rdv',])]
     private $rdv;
 
     /**
@@ -173,7 +173,7 @@ class Evt
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'tarif_detail', type: 'text', length: 65535, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'tarif_detail', type: 'text', length: 65535, nullable: true)]
     private $tarifDetail;
 
     /**
@@ -203,25 +203,25 @@ class Evt
     /**
      * @var string
      */
-    #[ORM\Column(name: 'matos_evt', type: 'text', length: 65535, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'matos_evt', type: 'text', length: 65535, nullable: true)]
     private $matos;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'difficulte_evt', type: 'string', length: 50, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'difficulte_evt', type: 'string', length: 50, nullable: true)]
     private $difficulte;
 
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'itineraire', type: 'text', length: 65535, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'itineraire', type: 'text', length: 65535, nullable: true)]
     private $itineraire;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'description_evt', type: 'text', length: 65535, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'description_evt', type: 'text', length: 65535, nullable: false)]
     private $description;
 
     /**
@@ -251,7 +251,7 @@ class Evt
     /**
      * @var int
      */
-    #[ORM\Column(name: 'ngens_max_evt', type: 'integer', nullable: false, options: ['comment' => 'Nombre de gens pouvant y aller au total. Donnée '])]
+    #[ORM\Column(name: 'ngens_max_evt', type: 'integer', nullable: false, options: ['comment' => 'Nombre de gens pouvant y aller au total. Donnée "visuelle" uniquement, pas de calcul.'])]
     private $ngensMax;
 
     /**
@@ -271,7 +271,7 @@ class Evt
     /**
      * @var int
      */
-    #[ORM\Column(name: 'child_version_from_evt', type: 'integer', nullable: false, options: ['comment' => 'Versionning : chaque modification d-evt crée une entrée '])]
+    #[ORM\Column(name: 'child_version_from_evt', type: 'integer', nullable: false, options: ['comment' => 'Versionning : chaque modification d-evt crée une entrée "enfant" de l-originale. Ce champ prend l-ID de l-original'])]
     private $childVersionFrom = '0';
 
     /**

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -33,31 +33,31 @@ class Message
     /**
      * @var string
      */
-    #[ORM\Column(name: 'to_message', type: 'string', length: 100, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'to_message', type: 'string', length: 100, nullable: false)]
     private $to;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'from_message', type: 'string', length: 100, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'from_message', type: 'string', length: 100, nullable: false)]
     private $from;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'headers_message', type: 'string', length: 500, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'headers_message', type: 'string', length: 500, nullable: false)]
     private $headers;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'code_message', type: 'string', length: 30, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'code_message', type: 'string', length: 30, nullable: false)]
     private $code;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'cont_message', type: 'text', length: 65535, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'cont_message', type: 'text', length: 65535, nullable: false)]
     private $cont;
 
     /**

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -39,7 +39,7 @@ class Page
     /**
      * @var bool
      */
-    #[ORM\Column(name: 'superadmin_page', type: 'boolean', nullable: false, options: ['comment' => 'Page réservée au super-administrateur. '])]
+    #[ORM\Column(name: 'superadmin_page', type: 'boolean', nullable: false, options: ['comment' => 'Page réservée au super-administrateur. "Contenu" dans le niveau administrateur dans la hiérarchie des filtres sur le site : admin_page doit donc aussi etre activé'])]
     private $superadmin = '0';
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -42,7 +42,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @var string
      */
-    #[ORM\Column(name: 'mdp_user', type: 'string', length: 1024, nullable: true, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'mdp_user', type: 'string', length: 1024, nullable: true)]
     private $mdp;
 
     /**
@@ -60,19 +60,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @var string
      */
-    #[ORM\Column(name: 'firstname_user', type: 'string', length: 50, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'firstname_user', type: 'string', length: 50, nullable: false)]
     private $firstname;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'lastname_user', type: 'string', length: 50, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'lastname_user', type: 'string', length: 50, nullable: false)]
     private $lastname;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'nickname_user', type: 'string', length: 20, nullable: false, options: ['collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'nickname_user', type: 'string', length: 20, nullable: false)]
     private $nickname;
 
     /**
@@ -132,7 +132,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @var string
      */
-    #[ORM\Column(name: 'moreinfo_user', type: 'string', length: 500, nullable: true, options: ['comment' => 'FORMATIONS ?', 'collation' => 'utf8mb4_unicode_ci'])]
+    #[ORM\Column(name: 'moreinfo_user', type: 'string', length: 500, nullable: true, options: ['comment' => 'FORMATIONS ?',])]
     private $moreinfo;
 
     /**


### PR DESCRIPTION
Permet de "nettoyer" les migrations Doctrine.
Supprime le mapping (collation) de certains champs d'entités.
L'encodage par défaut est l'utf8mb4 (collation utf8mb4_unicode_ci).
La bdd doit être mise-à-jour en parallèle pour unifier les encodages de caractères.
Certains commentaires de tables ont été corrigés pour refléter ceux en bdd.