### PR TITLE
Fix client side validation on event creation page

### DIFF
--- a/legacy/includes/evt/creer.php
+++ b/legacy/includes/evt/creer.php
@@ -372,7 +372,7 @@ inclure('infos-matos', 'mini');
         <button class="biglink" href="javascript:void(0)" title="Enregistrer">
             <span class="bleucaf">&gt;</span>
             ENREGISTRER ET DEMANDER LA PUBLICATION
-        </a>
+        </button>
     </div>
 </form>
 


### PR DESCRIPTION
To avoid introducing more legacy JS code, we rely on HTML validation on most of fields.
The tradeoff is to accept not validating the TinyMCE description field and the checkboxes. 

Related to https://app.clickup.com/t/86bwcaxh2