### PR TITLE
Rename EvtJoin into meaningful EventParticipation

### DIFF
--- a/resources/fixtures/dev/DevData.php
+++ b/resources/fixtures/dev/DevData.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Entity\Evt;
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use App\Entity\User;
 use App\Repository\CommissionRepository;
 use App\Utils\NicknameGenerator;
@@ -43,16 +43,16 @@ class DevData implements FixtureInterface, ContainerAwareInterface
         }
 
         $roles = [
-            EvtJoin::ROLE_ENCADRANT,
-            EvtJoin::ROLE_BENEVOLE,
-            EvtJoin::ROLE_COENCADRANT,
-            EvtJoin::ROLE_MANUEL,
-            EvtJoin::ROLE_BENEVOLE,
+            EventParticipation::ROLE_ENCADRANT,
+            EventParticipation::ROLE_BENEVOLE,
+            EventParticipation::ROLE_COENCADRANT,
+            EventParticipation::ROLE_MANUEL,
+            EventParticipation::ROLE_BENEVOLE,
         ];
         $status = [
-            EvtJoin::STATUS_VALIDE,
-            EvtJoin::STATUS_NON_CONFIRME,
-            EvtJoin::STATUS_REFUSE,
+            EventParticipation::STATUS_VALIDE,
+            EventParticipation::STATUS_NON_CONFIRME,
+            EventParticipation::STATUS_REFUSE,
         ];
 
         foreach ($set->getObjects() as $object) {
@@ -74,21 +74,21 @@ class DevData implements FixtureInterface, ContainerAwareInterface
                 $limit = mt_rand(4, 8);
 
                 foreach ($users as $user) {
-                    $participant = new EvtJoin($object, $user, $roles[array_rand($roles)], $status[array_rand($status)]);
-                    if (in_array($participant->getRole(), [EvtJoin::ROLE_ENCADRANT, EvtJoin::ROLE_BENEVOLE, EvtJoin::ROLE_COENCADRANT], true)) {
-                        $participant->setStatus(EvtJoin::STATUS_VALIDE);
+                    $participation = new EventParticipation($object, $user, $roles[array_rand($roles)], $status[array_rand($status)]);
+                    if (in_array($participation->getRole(), [EventParticipation::ROLE_ENCADRANT, EventParticipation::ROLE_BENEVOLE, EventParticipation::ROLE_COENCADRANT], true)) {
+                        $participation->setStatus(EventParticipation::STATUS_VALIDE);
                     }
-                    $manager->persist($participant);
+                    $manager->persist($participation);
                     if (++$i > $limit) {
                         break;
                     }
                 }
 
-                if ($owner = $object->getParticipant($object->getUser())) {
-                    $owner->setRole(EvtJoin::ROLE_ENCADRANT);
+                if ($owner = $object->getParticipation($object->getUser())) {
+                    $owner->setRole(EventParticipation::ROLE_ENCADRANT);
                 } else {
-                    $participant = new EvtJoin($object, $object->getUser(), EvtJoin::ROLE_ENCADRANT, EvtJoin::STATUS_VALIDE);
-                    $manager->persist($participant);
+                    $participation = new EventParticipation($object, $object->getUser(), EventParticipation::ROLE_ENCADRANT, EventParticipation::STATUS_VALIDE);
+                    $manager->persist($participation);
                 }
             }
         }

--- a/src/Bridge/Twig/TwigExtension.php
+++ b/src/Bridge/Twig/TwigExtension.php
@@ -3,7 +3,7 @@
 namespace App\Bridge\Twig;
 
 use App\Entity\Evt;
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use App\Entity\User;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\String\Slugger\SluggerInterface;
@@ -37,8 +37,8 @@ class TwigExtension extends AbstractExtension implements ServiceSubscriberInterf
             new TwigFilter('is_legal_validable', [$this, 'isLegalValidable']),
             new TwigFilter('paiement_title', [$this, 'getPaiementTitle']),
             new TwigFilter('intldate', [$this, 'formatDate']),
-            new TwigFilter('participant_status_name', [$this, 'getParticipantStatusName']),
-            new TwigFilter('participant_role_name', [$this, 'getParticipantRoleName']),
+            new TwigFilter('participation_status_name', [$this, 'getParticipationStatusName']),
+            new TwigFilter('participation_role_name', [$this, 'getParticipationRoleName']),
             new TwigFilter('temoin_event', [$this, 'getTemoinPlacesSortie']),
             new TwigFilter('temoin_event_title', [$this, 'getTemoinPlacesSortieTitle']),
         ];
@@ -58,7 +58,7 @@ class TwigExtension extends AbstractExtension implements ServiceSubscriberInterf
         if (!$event->joinHasStarted()) {
             return '';
         }
-        if ($event->getJoinMax() <= \count($event->getParticipants())) {
+        if ($event->getJoinMax() <= \count($event->getParticipations())) {
             return 'off';
         }
 
@@ -79,47 +79,47 @@ class TwigExtension extends AbstractExtension implements ServiceSubscriberInterf
         if (!$event->joinHasStarted()) {
             return sprintf('Les inscriptions pour cette sortie commenceront le %s', date('d/m/y', $event->getJoinStart()));
         }
-        if ($event->getJoinMax() <= \count($event->getParticipants())) {
+        if ($event->getJoinMax() <= \count($event->getParticipations())) {
             return sprintf('Les %d places libres ont été réservées', $event->getJoinMax());
         }
 
-        return sprintf('%d places restantes', $event->getJoinMax() - \count($event->getParticipants()));
+        return sprintf('%d places restantes', $event->getJoinMax() - \count($event->getParticipations()));
     }
 
-    public function getParticipantStatusName(?EvtJoin $participant): string
+    public function getParticipationStatusName(?EventParticipation $participation): string
     {
-        if (!$participant) {
+        if (!$participation) {
             return '';
         }
 
-        switch ($participant->getStatus()) {
-            case EvtJoin::STATUS_NON_CONFIRME:
+        switch ($participation->getStatus()) {
+            case EventParticipation::STATUS_NON_CONFIRME:
                 return 'Non confirmé';
-            case EvtJoin::STATUS_VALIDE:
+            case EventParticipation::STATUS_VALIDE:
                 return 'Validé';
-            case EvtJoin::STATUS_REFUSE:
+            case EventParticipation::STATUS_REFUSE:
                 return 'Refusé';
-            case EvtJoin::STATUS_ABSENT:
+            case EventParticipation::STATUS_ABSENT:
                 return 'Absent';
         }
 
         return '';
     }
 
-    public function getParticipantRoleName(?EvtJoin $participant): string
+    public function getParticipationRoleName(?EventParticipation $participation): string
     {
-        if (!$participant) {
+        if (!$participation) {
             return '';
         }
 
-        switch ($participant->getRole()) {
-            case EvtJoin::ROLE_BENEVOLE:
+        switch ($participation->getRole()) {
+            case EventParticipation::ROLE_BENEVOLE:
                 return 'Bénévole';
-            case EvtJoin::ROLE_STAGIAIRE:
+            case EventParticipation::ROLE_STAGIAIRE:
                 return 'Stagiaire';
-            case EvtJoin::ROLE_COENCADRANT:
+            case EventParticipation::ROLE_COENCADRANT:
                 return 'Co-encadrant(e)';
-            case EvtJoin::ROLE_ENCADRANT:
+            case EventParticipation::ROLE_ENCADRANT:
                 return 'Encadrant(e)';
             default:
                 return 'Participant(e)';

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -3,9 +3,9 @@
 namespace App\Controller;
 
 use App\Entity\Evt;
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use App\Mailer\Mailer;
-use App\Repository\EvtJoinRepository;
+use App\Repository\EventParticipationRepository;
 use App\Repository\EvtRepository;
 use App\Repository\ExpenseGroupRepository;
 use App\Repository\ExpenseReportRepository;
@@ -40,7 +40,7 @@ class SortieController extends AbstractController
     public function sortie(
         Evt $event, 
         UserRepository $repository,
-        EvtJoinRepository $participantRepository,
+        EventParticipationRepository $participationRepository,
         ExpenseGroupRepository $expenseGroupRepository,
         ExpenseTypeExpenseFieldTypeRepository $expenseTypeFieldTypeRepository,
         ExpenseReportRepository $expenseReportRepository,
@@ -164,9 +164,9 @@ class SortieController extends AbstractController
 
         return [
             'event' => $event,
-            'participants' => $participantRepository->getSortedParticipants($event, null, null),
+            'participations' => $participationRepository->getSortedParticipations($event, null, null),
             'filiations' => $user ? $repository->getFiliations($user) : null,
-            'empietements' => $participantRepository->getEmpietements($event),
+            'empietements' => $participationRepository->getEmpietements($event),
             'expenseReportFormStructure' => $expenseReportFormGroups,
             'currentExpenseReport' => $currentExpenseReport,
         ];
@@ -192,18 +192,18 @@ class SortieController extends AbstractController
             'event_date' => date('d/m/Y', $event->getTsp()),
         ]);
 
-        foreach ($event->getParticipants() as $participant) {
-            if ($participant->getUser() === $event->getUser()) {
+        foreach ($event->getParticipations() as $participation) {
+            if ($participation->getUser() === $event->getUser()) {
                 // mail already sent
                 continue;
             }
 
-            $mailer->send($participant->getUser(), 'transactional/sortie-publiee-inscrit', [
+            $mailer->send($participation->getUser(), 'transactional/sortie-publiee-inscrit', [
                 'author_url' => $this->generateUrl('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL).'voir-profil/'.$event->getUser()->getId().'.html',
                 'author_nickname' => $event->getUser()->getNickname(),
                 'event_url' => $this->generateUrl('sortie', ['code' => $event->getCode(), 'id' => $event->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
                 'event_name' => $event->getTitre(),
-                'role' => $participant->getRole(),
+                'role' => $participation->getRole(),
             ], [], null, $event->getUser()->getEmail());
         }
 
@@ -229,9 +229,9 @@ class SortieController extends AbstractController
 
         $user = $this->getUser();
 
-        foreach ($request->request->all('id_evt_join', []) as $participantId) {
-            $status = $request->request->get('status_evt_join_'.$participantId);
-            $role = $request->request->get('role_evt_join_'.$participantId);
+        foreach ($request->request->all('id_evt_join', []) as $participationId) {
+            $status = $request->request->get('status_evt_join_'.$participationId);
+            $role = $request->request->get('role_evt_join_'.$participationId);
 
             if (null === $status) {
                 // FIX ME Log something
@@ -240,32 +240,32 @@ class SortieController extends AbstractController
 
             $status = (int) $status;
 
-            if (null === $participant = $event->getParticipantById($participantId)) {
+            if (null === $participation = $event->getParticipationById($participationId)) {
                 continue;
             }
 
             if ($status < 0) {
-                $em->remove($participant);
+                $em->remove($participation);
 
                 continue;
             }
 
-            if ($status === $participant->getStatus() && (null === $role || $role === $participant->getRole())) {
+            if ($status === $participation->getStatus() && (null === $role || $role === $participation->getRole())) {
                 continue;
             }
 
             // there can be no role passed in the request
             if ($role) {
-                $participant->setRole($role);
+                $participation->setRole($role);
             }
 
-            $participant
+            $participation
                 ->setStatus($status)
                 ->setLastchangeWhen(time())
                 ->setLastchangeWho($user)
             ;
 
-            if (!\in_array($status, [EvtJoin::STATUS_VALIDE, EvtJoin::STATUS_REFUSE], true)) {
+            if (!\in_array($status, [EventParticipation::STATUS_VALIDE, EventParticipation::STATUS_REFUSE], true)) {
                 continue;
             }
 
@@ -273,38 +273,38 @@ class SortieController extends AbstractController
                 continue;
             }
 
-            if ($participant->getUser()->getNomade()) {
+            if ($participation->getUser()->getNomade()) {
                 $statusName = '';
-                if (EvtJoin::STATUS_NON_CONFIRME === $status) {
+                if (EventParticipation::STATUS_NON_CONFIRME === $status) {
                     $statusName = 'En attente';
                 }
-                if (EvtJoin::STATUS_VALIDE === $status) {
+                if (EventParticipation::STATUS_VALIDE === $status) {
                     $statusName = 'Inscrit';
                 }
-                if (EvtJoin::STATUS_REFUSE === $status) {
+                if (EventParticipation::STATUS_REFUSE === $status) {
                     $statusName = 'Refusé';
                 }
 
                 $this->addFlash('warning', sprintf('%s %s est un adhérent nomade. Il n\'a pas d\'email et '.
-                    'doit être prévenu par téléphone de son nouveau statut : %s. Son téléphone: %s', $participant->getUser()->getFirstname(), $participant->getUser()->getLastname(), $statusName, $participant->getUser()->getTel()));
+                    'doit être prévenu par téléphone de son nouveau statut : %s. Son téléphone: %s', $participation->getUser()->getFirstname(), $participation->getUser()->getLastname(), $statusName, $participation->getUser()->getTel()));
 
                 continue;
             }
 
-            $toMail = null !== $participant->getAffiliantUserJoin() ? $participant->getAffiliantUserJoin() : $participant->getUser();
+            $toMail = null !== $participation->getAffiliantUserJoin() ? $participation->getAffiliantUserJoin() : $participation->getUser();
 
             if (!$toMail) {
                 continue;
             }
 
-            switch ($participant->getRole()) {
-                case EvtJoin::ROLE_ENCADRANT:
-                case EvtJoin::ROLE_COENCADRANT:
-                    $roleName = $participant->getRole().'(e)';
+            switch ($participation->getRole()) {
+                case EventParticipation::ROLE_ENCADRANT:
+                case EventParticipation::ROLE_COENCADRANT:
+                    $roleName = $participation->getRole().'(e)';
                     break;
-                case EvtJoin::ROLE_BENEVOLE:
-                case EvtJoin::ROLE_STAGIAIRE:
-                    $roleName = $participant->getRole();
+                case EventParticipation::ROLE_BENEVOLE:
+                case EventParticipation::ROLE_STAGIAIRE:
+                    $roleName = $participation->getRole();
                     break;
                 default:
                     $roleName = 'participant(e)';
@@ -317,10 +317,10 @@ class SortieController extends AbstractController
                 'event_name' => $event->getTitre(),
             ];
 
-            if (EvtJoin::STATUS_VALIDE === $status) {
+            if (EventParticipation::STATUS_VALIDE === $status) {
                 $mailer->send($toMail, 'transactional/sortie-participation-confirmee', $context);
             }
-            if (EvtJoin::STATUS_REFUSE === $status) {
+            if (EventParticipation::STATUS_REFUSE === $status) {
                 $mailer->send($toMail, 'transactional/sortie-participation-declinee', $context);
             }
         }
@@ -442,16 +442,16 @@ class SortieController extends AbstractController
         $status = $request->request->get('status_sendmail');
         $status = ctype_digit($status) ? (int) $status : $status;
 
-        if (!\in_array($status, ['*', EvtJoin::STATUS_VALIDE, EvtJoin::STATUS_ABSENT, EvtJoin::STATUS_NON_CONFIRME, EvtJoin::STATUS_REFUSE], true)) {
+        if (!\in_array($status, ['*', EventParticipation::STATUS_VALIDE, EventParticipation::STATUS_ABSENT, EventParticipation::STATUS_NON_CONFIRME, EventParticipation::STATUS_REFUSE], true)) {
             throw new BadRequestException(sprintf('Invalid status "%s".', $status));
         }
 
-        $participants = $event
-            ->getParticipants(null, '*' === $status ? null : $status)
-            ->map(fn (EvtJoin $participant) => $participant->getUser())
+        $participations = $event
+            ->getParticipations(null, '*' === $status ? null : $status)
+            ->map(fn (EventParticipation $participation) => $participation->getUser())
             ->toArray();
 
-        $mailer->send($participants, 'transactional/message-sortie', [
+        $mailer->send($participations, 'transactional/message-sortie', [
             'objet' => $request->request->get('objet'),
             'message_author' => sprintf('%s %s', $event->getUser()->getFirstname(), $event->getUser()->getLastname()),
             'url_sortie' => $this->generateUrl('sortie', ['code' => $event->getCode(), 'id' => $event->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
@@ -465,26 +465,26 @@ class SortieController extends AbstractController
     }
 
     #[Route(name: 'sortie_remove_participant', path: '/sortie/remove-participant/{id}', requirements: ['id' => '\d+'], methods: ['POST'], priority: '10')]
-    public function removeParticipant(Request $request, EvtJoin $participant, EntityManagerInterface $em, Mailer $mailer)
+    public function removeParticipant(Request $request, EventParticipation $participation, EntityManagerInterface $em, Mailer $mailer)
     {
-        $event = $participant->getEvt();
+        $event = $participation->getEvt();
 
         if (!$this->isCsrfTokenValid('remove_participant', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
         }
 
-        if (!$this->isGranted('PARTICIPANT_ANNULATION', $participant)) {
+        if (!$this->isGranted('PARTICIPANT_ANNULATION', $participation)) {
             throw new AccessDeniedHttpException('Vous n\'êtes pas autorisé à celà.');
         }
 
-        $em->remove($participant);
+        $em->remove($participation);
         $em->flush();
 
         $user = $this->getUser();
 
-        if ($participant->isStatusValide()) {
+        if ($participation->isStatusValide()) {
             $mailer->send($event->getUser(), 'transactional/sortie-desinscription', [
-                'username' => $participant->getUser()->getFirstname().' '.$participant->getUser()->getLastname(),
+                'username' => $participation->getUser()->getFirstname().' '.$participation->getUser()->getLastname(),
                 'event_url' => $this->generateUrl('sortie', ['code' => $event->getCode(), 'id' => $event->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
                 'event_name' => $event->getTitre(),
                 'user' => $user,
@@ -524,12 +524,12 @@ class SortieController extends AbstractController
         );
         $em->persist($newEvent);
 
-        foreach ($event->getParticipants() as $participant) {
-            if ($participant->getUser() === $newEvent->getUser()) {
+        foreach ($event->getParticipations() as $participation) {
+            if ($participation->getUser() === $newEvent->getUser()) {
                 continue;
             }
 
-            $join = $newEvent->addParticipant($participant->getUser(), $participant->getRole(), $participant->getStatus());
+            $join = $newEvent->addParticipation($participation->getUser(), $participation->getRole(), $participation->getStatus());
             $em->persist($join);
         }
 

--- a/src/Entity/EventParticipation.php
+++ b/src/Entity/EventParticipation.php
@@ -2,17 +2,17 @@
 
 namespace App\Entity;
 
-use App\Repository\EvtJoinRepository;
+use App\Repository\EventParticipationRepository;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * EvtJoin.
+ * EventParticipation.
  *
  *
  */
 #[ORM\Table(name: 'caf_evt_join')]
-#[ORM\Entity(repositoryClass: EvtJoinRepository::class)]
-class EvtJoin
+#[ORM\Entity(repositoryClass: EventParticipationRepository::class)]
+class EventParticipation
 {
     public const STATUS_NON_CONFIRME = 0;
     public const STATUS_VALIDE = 1;
@@ -44,7 +44,7 @@ class EvtJoin
     private $status = self::STATUS_NON_CONFIRME;
 
     
-    #[ORM\ManyToOne(targetEntity: 'Evt', inversedBy: 'joins', fetch: 'EAGER')]
+    #[ORM\ManyToOne(targetEntity: 'Evt', inversedBy: 'participations', fetch: 'EAGER')]
     #[ORM\JoinColumn(name: 'evt_evt_join', nullable: false, referencedColumnName: 'id_evt', onDelete: 'CASCADE')]
     private $evt;
 

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -243,10 +243,10 @@ class Evt
     private $joinMax;
 
     /**
-     * @var EvtJoin[]
+     * @var EventParticipation[]
      */
-    #[ORM\OneToMany(targetEntity: 'EvtJoin', mappedBy: 'evt', cascade: ['persist'])]
-    private $joins;
+    #[ORM\OneToMany(targetEntity: 'EventParticipation', mappedBy: 'evt', cascade: ['persist'])]
+    private $participations;
 
     /**
      * @var int
@@ -312,13 +312,13 @@ class Evt
         $this->joinMax = $maxInscriptions;
         $this->ngensMax = $maxParticipants;
         $this->commission = $commission;
-        $this->joins = new ArrayCollection();
+        $this->participations = new ArrayCollection();
         $this->articles = new ArrayCollection();
         $this->cycleChildren = new ArrayCollection();
         $this->tspCrea = time();
 
         // FIX ME fix encadrant
-        $this->joins->add(new EvtJoin($this, $user, EvtJoin::ROLE_ENCADRANT, EvtJoin::STATUS_VALIDE));
+        $this->participations->add(new EventParticipation($this, $user, EventParticipation::ROLE_ENCADRANT, EventParticipation::STATUS_VALIDE));
     }
 
     public function getId(): ?int
@@ -427,16 +427,16 @@ class Evt
         return $this;
     }
 
-    public function addParticipant(User $user, string $role = EvtJoin::ROLE_INSCRIT, int $status = EvtJoin::STATUS_NON_CONFIRME): EvtJoin
+    public function addParticipation(User $user, string $role = EventParticipation::ROLE_INSCRIT, int $status = EventParticipation::STATUS_NON_CONFIRME): EventParticipation
     {
-        $participant = new EvtJoin($this, $user, $role, $status);
-        $this->joins->add($participant);
+        $participation = new EventParticipation($this, $user, $role, $status);
+        $this->participations->add($participation);
 
-        return $participant;
+        return $participation;
     }
 
-    /** @return EvtJoin[] */
-    public function getParticipants($roles = null, $status = EvtJoin::STATUS_VALIDE): Collection
+    /** @return EventParticipation[] */
+    public function getParticipations($roles = null, $status = EventParticipation::STATUS_VALIDE): Collection
     {
         if (null !== $roles && !\is_array($roles)) {
             $roles = (array) $roles;
@@ -445,42 +445,42 @@ class Evt
             $status = (array) $status;
         }
 
-        return $this->joins->filter(function (EvtJoin $participant) use ($roles, $status) {
-            return (null === $roles || \in_array($participant->getRole(), $roles, true))
-                && (null === $status || \in_array($participant->getStatus(), $status, true));
+        return $this->participations->filter(function (EventParticipation $participation) use ($roles, $status) {
+            return (null === $roles || \in_array($participation->getRole(), $roles, true))
+                && (null === $status || \in_array($participation->getStatus(), $status, true));
         });
     }
 
-    public function getParticipant(?User $user): ?EvtJoin
+    public function getParticipation(?User $user): ?EventParticipation
     {
         if (!$user) {
             return null;
         }
 
-        foreach ($this->joins as $join) {
-            if ($join->getUser() === $user) {
-                return $join;
+        foreach ($this->participations as $participation) {
+            if ($participation->getUser() === $user) {
+                return $participation;
             }
         }
 
         return null;
     }
 
-    public function getParticipantById(int $id): ?EvtJoin
+    public function getParticipationById(int $id): ?EventParticipation
     {
-        foreach ($this->joins as $join) {
-            if ($join->getId() === $id) {
-                return $join;
+        foreach ($this->participations as $participation) {
+            if ($participation->getId() === $id) {
+                return $participation;
             }
         }
 
         return null;
     }
 
-    /** @return EvtJoin[] */
-    public function getEncadrants($types = [EvtJoin::ROLE_ENCADRANT, EvtJoin::ROLE_STAGIAIRE, EvtJoin::ROLE_COENCADRANT]): Collection
+    /** @return EventParticipation[] */
+    public function getEncadrants($types = [EventParticipation::ROLE_ENCADRANT, EventParticipation::ROLE_STAGIAIRE, EventParticipation::ROLE_COENCADRANT]): Collection
     {
-        return $this->getParticipants($types, [EvtJoin::STATUS_VALIDE]);
+        return $this->getParticipations($types, [EventParticipation::STATUS_VALIDE]);
     }
 
     public function getCommission(): Commission

--- a/src/Repository/EventParticipationRepository.php
+++ b/src/Repository/EventParticipationRepository.php
@@ -3,33 +3,33 @@
 namespace App\Repository;
 
 use App\Entity\Evt;
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
- * @method EvtJoin|null find($id, $lockMode = null, $lockVersion = null)
- * @method EvtJoin|null findOneBy(array $criteria, array $orderBy = null)
- * @method EvtJoin[]    findAll()
- * @method EvtJoin[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method EventParticipation|null find($id, $lockMode = null, $lockVersion = null)
+ * @method EventParticipation|null findOneBy(array $criteria, array $orderBy = null)
+ * @method EventParticipation[]    findAll()
+ * @method EventParticipation[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
-class EvtJoinRepository extends ServiceEntityRepository
+class EventParticipationRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
-        parent::__construct($registry, EvtJoin::class);
+        parent::__construct($registry, EventParticipation::class);
     }
 
-    /** @return EvtJoin[][] */
+    /** @return EventParticipation[][] */
     public function getEmpietements(Evt $event)
     {
         $qb = $this->createQueryBuilder('p')
             ->select('e, p')
             ->innerJoin('p.evt', 'e')
             ->where('p.status != :status_refuse')
-            ->setParameter('status_refuse', EvtJoin::STATUS_REFUSE)
+            ->setParameter('status_refuse', EventParticipation::STATUS_REFUSE)
             ->andWhere('p.status != :status_absent')
-            ->setParameter('status_absent', EvtJoin::STATUS_ABSENT)
+            ->setParameter('status_absent', EventParticipation::STATUS_ABSENT)
             ->andWhere('e.id != :id')
             ->setParameter('id', $event->getId())
             ->andWhere('e.status != :event_status')
@@ -40,22 +40,22 @@ class EvtJoinRepository extends ServiceEntityRepository
             ->orderBy('e.tsp', 'asc')
         ;
 
-        /** @var EvtJoin[] $results */
+        /** @var EventParticipation[] $results */
         $results = $qb
             ->getQuery()
             ->getResult();
 
         $ret = [];
 
-        foreach ($results as $participant) {
-            $ret[$participant->getUser()->getId()][] = $participant;
+        foreach ($results as $participation) {
+            $ret[$participation->getUser()->getId()][] = $participation;
         }
 
         return $ret;
     }
 
     /**
-     * Retourne la liste des participants triée par rôles.
+     * Retourne la liste des participations triée par rôles.
      *
      * @param Evt $event
      *   La sortie.
@@ -65,7 +65,7 @@ class EvtJoinRepository extends ServiceEntityRepository
      *   Les status à filtrer.
      * @return mixed
      */
-    public function getSortedParticipants(Evt $event, $roles = null, $status = EvtJoin::STATUS_VALIDE): mixed
+    public function getSortedParticipations(Evt $event, $roles = null, $status = EventParticipation::STATUS_VALIDE): mixed
     {
         $qb = $this->createQueryBuilder('ej')
             ->select('ej as liste')

--- a/src/Security/Voter/DuplicateSortieVoter.php
+++ b/src/Security/Voter/DuplicateSortieVoter.php
@@ -38,8 +38,8 @@ class DuplicateSortieVoter extends Voter
             return false;
         }
 
-        foreach ($subject->getParticipants() as $evtJoin) {
-            if ($evtJoin->getUser() === $user) {
+        foreach ($subject->getParticipations() as $eventParticipation) {
+            if ($eventParticipation->getUser() === $user) {
                 return true;
             }
         }

--- a/src/Security/Voter/FicheSortieVoter.php
+++ b/src/Security/Voter/FicheSortieVoter.php
@@ -42,8 +42,8 @@ class FicheSortieVoter extends Voter
             return true;
         }
 
-        foreach ($subject->getEncadrants() as $evtJoin) {
-            if ($evtJoin->getUser() === $user) {
+        foreach ($subject->getEncadrants() as $eventParticipation) {
+            if ($eventParticipation->getUser() === $user) {
                 return true;
             }
         }

--- a/src/Security/Voter/ParticipantAnnulationVoter.php
+++ b/src/Security/Voter/ParticipantAnnulationVoter.php
@@ -2,7 +2,7 @@
 
 namespace App\Security\Voter;
 
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use App\Entity\User;
 use App\UserRights;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -30,8 +30,8 @@ class ParticipantAnnulationVoter extends Voter
             return false;
         }
 
-        if (!$subject instanceof EvtJoin) {
-            throw new \InvalidArgumentException('The voter requires a participant subject');
+        if (!$subject instanceof EventParticipation) {
+            throw new \InvalidArgumentException('The voter requires a participation subject');
         }
 
         if ($subject->getUser() !== $user) {

--- a/src/Security/Voter/SortieContactVoter.php
+++ b/src/Security/Voter/SortieContactVoter.php
@@ -42,8 +42,8 @@ class SortieContactVoter extends Voter
             return true;
         }
 
-        foreach ($subject->getEncadrants() as $evtJoin) {
-            if ($evtJoin->getUser() === $user) {
+        foreach ($subject->getEncadrants() as $eventParticipation) {
+            if ($eventParticipation->getUser() === $user) {
                 return true;
             }
         }

--- a/src/Security/Voter/SortieInscriptionsModificationVoter.php
+++ b/src/Security/Voter/SortieInscriptionsModificationVoter.php
@@ -51,8 +51,8 @@ class SortieInscriptionsModificationVoter extends Voter
         if ($user->hasAttribute(UserAttr::SALARIE)) {
             return true;
         }
-        foreach ($subject->getEncadrants() as $evtJoin) {
-            if ($evtJoin->getUser() === $user) {
+        foreach ($subject->getEncadrants() as $eventParticipation) {
+            if ($eventParticipation->getUser() === $user) {
                 return true;
             }
         }

--- a/src/Security/Voter/UserJoinSortieVoter.php
+++ b/src/Security/Voter/UserJoinSortieVoter.php
@@ -38,6 +38,6 @@ class UserJoinSortieVoter extends Voter
             return false;
         }
 
-        return null === $subject->getParticipant($user) || \count($this->userRepo->getFiliations($user)) > 0;
+        return null === $subject->getParticipation($user) || \count($this->userRepo->getFiliations($user)) > 0;
     }
 }

--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -66,7 +66,7 @@
 
             <div id="evt-list">
                 {% for event in list_events(get_commission(current_commission)) %}
-                    {% set nPlacesRestantesOnline = max(0, event.joinMax - event.participants([constant('App\\Entity\\EvtJoin::ROLE_INSCRIT'), constant('App\\Entity\\EvtJoin::ROLE_BENEVOLE')]) | length) %}
+                    {% set nPlacesRestantesOnline = max(0, event.joinMax - event.participations([constant('App\\Entity\\EventParticipation::ROLE_INSCRIT'), constant('App\\Entity\\EventParticipation::ROLE_BENEVOLE')]) | length) %}
                     <a href="/sortie/{{ event.code }}-{{ event.id }}.html?commission={{ event.commission.code }}" title="Voir la sortie">
                         <span style="color:#fff">{{ event.tsp | intldate('ccc d/MM') | capitalize }} </span> |
                         {% if event.cancelled %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -178,12 +178,12 @@
         <br />
         <br />
 
-        {% set my_status = event.participant(app.user) %}
+        {% set my_status = event.participation(app.user) %}
 
         {% if not event.cycleParent %}
         {# les messages et options liées aux inscriptions ne s'appliquent pas sur les suites de cycles #}
 
-            {% if my_status and my_status.status == constant('App\\Entity\\EvtJoin::STATUS_NON_CONFIRME') %}
+            {% if my_status and my_status.status == constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME') %}
                 {% if not event.finished %}
                     {% if allowed('evt_unjoin') %}
                     <p class="alerte">
@@ -202,7 +202,7 @@
                 {% endif %}
             {% endif %}
 
-            {% if my_status and my_status.status == constant('App\\Entity\\EvtJoin::STATUS_REFUSE') %}
+            {% if my_status and my_status.status == constant('App\\Entity\\EventParticipation::STATUS_REFUSE') %}
                 <p class="erreur">
                     <img src="/img/inscrit-cross.png" alt="" title="" style="float:left" />
                     <br />
@@ -212,7 +212,7 @@
                 <br />
             {% endif %}
 
-            {% if my_status and my_status.status == constant('App\\Entity\\EvtJoin::STATUS_VALIDE') %}
+            {% if my_status and my_status.status == constant('App\\Entity\\EventParticipation::STATUS_VALIDE') %}
                 {% if my_status.role == 'encadrant' or my_status.role == 'stagiaire' or my_status.role == 'coencadrant' or my_status.role == 'benevole' %}
                     {% if not event.finished %}
                         {% if allowed('evt_unjoin') %}
@@ -244,7 +244,7 @@
                             </div>
                         </div>
                         {% endif %}
-                        {% if my_status and my_status.status != constant('App\\Entity\\EvtJoin::STATUS_NON_CONFIRME') %}
+                        {% if my_status and my_status.status != constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME') %}
                             {% if is_granted('PARTICIPANT_ANNULATION', my_status) %}
                                 <div id="inscription-annuler" style="display: none;">
                                     {{ easy_include('formalites-inscription-suppression', 'formalites') }}
@@ -404,20 +404,20 @@
 {#                                // création du tableau "empiètement" pour chaque user#}
 {#                                $row['empietements'] = empietement_sortie($row['id_user'], $evt);#}
 
-                                {% for participant in participants %}
-                                    {% set participant = participant['liste'] %}
-                                    <tr class="status{{ participant.status }}" style="color:gray; font-size:10px;">
+                                {% for participation in participations %}
+                                    {% set participation = participation['liste'] %}
+                                    <tr class="status{{ participation.status }}" style="color:gray; font-size:10px;">
 
                                         <td>
-                                            {{ participant.user.lastname | upper }}, {{ participant.user.firstname | capitalize }}<br/>
-                                            <a href="/includer.php?p=includes/fiche-profil.php&amp;id_user={{ participant.user.id }}" class="fancyframe userlink">{{ participant.user.nickname }}</a>
+                                            {{ participation.user.lastname | upper }}, {{ participation.user.firstname | capitalize }}<br/>
+                                            <a href="/includer.php?p=includes/fiche-profil.php&amp;id_user={{ participation.user.id }}" class="fancyframe userlink">{{ participation.user.nickname }}</a>
 
-                                            {% if participant.user.doitRenouveler %}
+                                            {% if participation.user.doitRenouveler %}
                                                 <img src="/img/base/delete.png" title="licence expirée" style="margin-bottom:-4px;">
                                             {% endif %}
                                         </td>
 
-                                        <td class="mini joinlabels status{{ participant.status }}">
+                                        <td class="mini joinlabels status{{ participation.status }}">
 
                                         {% set disable_waiting = true %}
                                         {% set disable_accepted = true %}
@@ -437,14 +437,14 @@
                                             {% set disable_unsubscribe = false %}
                                         {% endif %}
 
-                                        {% if empietements[participant.user.id] is defined %}
+                                        {% if empietements[participation.user.id] is defined %}
                                             <div class="empietements">
                                                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Attention au timing :</b>
-                                                {% for empietement in empietements[participant.user.id] %}
-                                                    {% if empietement.status == constant('App\\Entity\\EvtJoin::STATUS_NON_CONFIRME') %}
+                                                {% for empietement in empietements[participation.user.id] %}
+                                                    {% if empietement.status == constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME') %}
                                                         <br />- Adhérent pré-inscrit sur
                                                         <br /><a href="{{ path('sortie', { code : empietement.event.code, id: empietement.event.id }) }}">{{ empietement.event.titre }}</a>
-                                                    {% elseif empietement.status == constant('App\\Entity\\EvtJoin::STATUS_VALIDE') %}
+                                                    {% elseif empietement.status == constant('App\\Entity\\EventParticipation::STATUS_VALIDE') %}
                                                         <br />- Adhérent <span style="color:red">confirmé</span> sur <br />
                                                         <br /><a href="{{ path('sortie', { code : empietement.event.code, id: empietement.event.id }) }}">{{ empietement.event.titre }}</a>
                                                     {% endif %}
@@ -452,60 +452,60 @@
                                             </div>
                                         {% endif %}
 
-                                        {% if participant.role != 'encadrant' %}
-                                            <span style="display:none">{{ participant.status }}</span>
-                                            <input type="hidden" name="id_evt_join[]" value="{{ participant.id }}" />
+                                        {% if participation.role != 'encadrant' %}
+                                            <span style="display:none">{{ participation.status }}</span>
+                                            <input type="hidden" name="id_evt_join[]" value="{{ participation.id }}" />
 
-                                            {% if participant.isStatusEnAttente %}
-                                                <label for="join_{{ participant.id }}_0">
+                                            {% if participation.isStatusEnAttente %}
+                                                <label for="join_{{ participation.id }}_0">
                                                     <input
                                                         checked="checked"
                                                         {{ disable_waiting ? 'disabled="disabled"' : '' }}
                                                         type="radio"
-                                                        name="status_evt_join_{{ participant.id }}"
-                                                        id="join_{{ participant.id }}_0"
+                                                        name="status_evt_join_{{ participation.id }}"
+                                                        id="join_{{ participation.id }}_0"
                                                         value="0"
                                                     />
                                                     En attente
                                                 </label>
                                             {% endif %}
 
-                                            {% if (event.finished and participant.isStatusValide) or not event.finished %}
-                                                <label for="join_{{ participant.id }}_1">
+                                            {% if (event.finished and participation.isStatusValide) or not event.finished %}
+                                                <label for="join_{{ participation.id }}_1">
                                                     <input
-                                                        {{ participant.isStatusValide ? 'checked="checked"' : '' }}
+                                                        {{ participation.isStatusValide ? 'checked="checked"' : '' }}
                                                         {{ disable_accepted ? 'disabled="disabled"' : '' }}
                                                         type="radio"
-                                                        name="status_evt_join_{{ participant.id }}"
-                                                        id="join_{{ participant.id }}_1"
+                                                        name="status_evt_join_{{ participation.id }}"
+                                                        id="join_{{ participation.id }}_1"
                                                         value="1"
                                                     />
                                                     Accepté
                                                 </label>
                                             {% endif %}
 
-                                            {% if event.finished and not participant.isStatusRefuse %}
-                                                <label for="join_{{ participant.id }}_3">
+                                            {% if event.finished and not participation.isStatusRefuse %}
+                                                <label for="join_{{ participation.id }}_3">
                                                     <input
-                                                        {{ participant.isStatusAbsent ? 'checked="checked"' : '' }}
+                                                        {{ participation.isStatusAbsent ? 'checked="checked"' : '' }}
                                                         {{ disable_absent ? 'disabled="disabled"' : '' }}
                                                         type="radio"
-                                                        name="status_evt_join_{{ participant.id }}"
-                                                        id="join_{{ participant.id }}_3"
+                                                        name="status_evt_join_{{ participation.id }}"
+                                                        id="join_{{ participation.id }}_3"
                                                         value="3"
                                                     />
                                                     Absent
                                                 </label>
                                             {% endif %}
 
-                                            {% if (event.finished and participant.isStatusRefuse) or not event.finished %}
-                                                <label for="join_{{ participant.id }}_2">
+                                            {% if (event.finished and participation.isStatusRefuse) or not event.finished %}
+                                                <label for="join_{{ participation.id }}_2">
                                                     <input
-                                                        {{ participant.isStatusRefuse ? 'checked="checked"' : '' }}
+                                                        {{ participation.isStatusRefuse ? 'checked="checked"' : '' }}
                                                         {{ disable_refused ? 'disabled="disabled"' : '' }}
                                                         type="radio"
-                                                        name="status_evt_join_{{ participant.id }}"
-                                                        id="join_{{ participant.id }}_2"
+                                                        name="status_evt_join_{{ participation.id }}"
+                                                        id="join_{{ participation.id }}_2"
                                                         value="2"
                                                     />
                                                     Refusé
@@ -513,12 +513,12 @@
                                             {% endif %}
 
                                             {% if not event.finished %}
-                                                <label for="join_{{ participant.id }}_-1">
+                                                <label for="join_{{ participation.id }}_-1">
                                                     <input
-                                                        name="status_evt_join_{{ participant.id }}"
+                                                        name="status_evt_join_{{ participation.id }}"
                                                         {{ disable_unsubscribe ? 'disabled="disabled"' : '' }}
                                                         type="radio"
-                                                        id="join_{{ participant.id }}_-1"
+                                                        id="join_{{ participation.id }}_-1"
                                                         value="-1"
                                                     />
                                                     Désinscrire
@@ -529,7 +529,7 @@
 
                                         </td>
                                         <td class="mini" >
-                                            {% if participant.user.nomade %}
+                                            {% if participation.user.nomade %}
                                                 <br />
                                                 <img
                                                     src="/img/base/bullet_error.png"
@@ -538,53 +538,53 @@
                                                     style="vertical-align:top"
                                                 />
                                                 <br />
-                                            {% elseif participant.isRoleManuel or participant.isRoleInscrit or participant.isRoleBenevole %}
-                                                {% if participant.isRoleManuel %}
-                                                    <label style="display:block; white-space:nowrap;" for="role_join_{{ participant.id }}_m">
+                                            {% elseif participation.isRoleManuel or participation.isRoleInscrit or participation.isRoleBenevole %}
+                                                {% if participation.isRoleManuel %}
+                                                    <label style="display:block; white-space:nowrap;" for="role_join_{{ participation.id }}_m">
                                                         <input
                                                             checked="checked"
-                                                            name="role_evt_join_{{ participant.id }}"
+                                                            name="role_evt_join_{{ participation.id }}"
                                                             type="radio"
-                                                            id="role_join_{{ participant.id }}_m"
+                                                            id="role_join_{{ participation.id }}_m"
                                                             value="manuel"
                                                         />
                                                         Manuel
                                                     </label>
                                                 {% endif %}
-                                                <label style="display:block; white-space:nowrap;" for="role_join_{{ participant.id }}_i">
+                                                <label style="display:block; white-space:nowrap;" for="role_join_{{ participation.id }}_i">
                                                     <input
-                                                        {% if participant.isRoleInscrit %}checked="checked"{% endif%}
-                                                        name="role_evt_join_{{ participant.id }}"
+                                                        {% if participation.isRoleInscrit %}checked="checked"{% endif%}
+                                                        name="role_evt_join_{{ participation.id }}"
                                                         type="radio"
-                                                        id="role_join_{{ participant.id }}_i"
+                                                        id="role_join_{{ participation.id }}_i"
                                                         value="inscrit"
                                                     />
                                                     Inscrit
                                                 </label>
-                                                <label style="display:block; white-space:nowrap;" for="role_join_{{ participant.id }}_b">
+                                                <label style="display:block; white-space:nowrap;" for="role_join_{{ participation.id }}_b">
                                                     <input
-                                                        {% if participant.isRoleBenevole %}checked="checked"{% endif%}
-                                                        name="role_evt_join_{{ participant.id }}"
+                                                        {% if participation.isRoleBenevole %}checked="checked"{% endif%}
+                                                        name="role_evt_join_{{ participation.id }}"
                                                         type="radio"
-                                                        id="role_join_{{ participant.id }}_b"
+                                                        id="role_join_{{ participation.id }}_b"
                                                         value="benevole"
                                                     />
                                                     Bénévole
                                                 </label>
                                             {% else %}
-                                                {{ participant | participant_role_name }}
+                                                {{ participation | participation_role_name }}
                                             {% endif %}
 
                                         </td>
                                         <td style="white-space:nowrap">
-                                            <span style="display:none">{{ participant.tsp }}</span>
-                                            {{ participant.tsp | date('d/m') }}<br />
-                                            {{ participant.tsp | date('à H:i') }}
+                                            <span style="display:none">{{ participation.tsp }}</span>
+                                            {{ participation.tsp | date('d/m') }}<br />
+                                            {{ participation.tsp | date('à H:i') }}
                                         </td>
                                         <td>
-                                            <a href="mailto:{{ participant.user.email }}">{{ participant.user.email | u.truncate(15, '...') }}</a><br />
-                                            {{ participant.user.tel|split('', 2)|join(' ') }}<br />
-                                            {{ participant.user.tel2|split('', 2)|join(' ') }}
+                                            <a href="mailto:{{ participation.user.email }}">{{ participation.user.email | u.truncate(15, '...') }}</a><br />
+                                            {{ participation.user.tel|split('', 2)|join(' ') }}<br />
+                                            {{ participation.user.tel2|split('', 2)|join(' ') }}
                                         </td>
                                     </tr>
                                 {% endfor %}
@@ -595,12 +595,12 @@
                         <p>Stats :</p>
                         <ul>
                             <li>
-                                <b id="nDemandes">{{ event.participants(null, null) | length }}</b> demande(s), dont
-                                <b id="nAcceptees">{{ event.participants(null, constant('App\\Entity\\EvtJoin::STATUS_VALIDE')) | length }}</b> acceptée(s), et
-                                <b id="nRefusees">{{ event.participants(null, constant('App\\Entity\\EvtJoin::STATUS_REFUSE')) | length }}</b> refusée(s).
+                                <b id="nDemandes">{{ event.participations(null, null) | length }}</b> demande(s), dont
+                                <b id="nAcceptees">{{ event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_VALIDE')) | length }}</b> acceptée(s), et
+                                <b id="nRefusees">{{ event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_REFUSE')) | length }}</b> refusée(s).
                             </li>
                             <li>
-                                <b id="nRefusees">{{ event.participants(null, constant('App\\Entity\\EvtJoin::STATUS_ABSENT')) | length }}</b> absent(s).
+                                <b id="nRefusees">{{ event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_ABSENT')) | length }}</b> absent(s).
                             </li>
                         </ul>
 
@@ -619,8 +619,8 @@
                                     ENREGISTRER LES STATUTS CI-DESSUS
                                 </button>
                             </div>
-                        {% elseif event.participant(app.user) %}
-                            <p class="mini">{{ event.participant(app.user) | participant_status_name }} : Vous ne pouvez pas modifier les inscriptions</p>
+                        {% elseif event.participation(app.user) %}
+                            <p class="mini">{{ event.participation(app.user) | participation_status_name }} : Vous ne pouvez pas modifier les inscriptions</p>
                         {% endif %}
                         <br />
                         <br />
@@ -871,10 +871,10 @@
 
         {% if not event.cycleParent %}
             {% if not event.cancelled %}
-                {% set nInscritsHorsEncadrement = event.participants([constant('App\\Entity\\EvtJoin::ROLE_INSCRIT'), constant('App\\Entity\\EvtJoin::ROLE_BENEVOLE'), constant('App\\Entity\\EvtJoin::ROLE_MANUEL')]) | length %}
-                {% set nInscritsTotal = nInscritsHorsEncadrement + event.participants([constant('App\\Entity\\EvtJoin::ROLE_COENCADRANT'), constant('App\\Entity\\EvtJoin::ROLE_STAGIAIRE'), constant('App\\Entity\\EvtJoin::ROLE_ENCADRANT')]) | length %}
-                {% set nPlacesRestantesOnline = max(0, event.joinMax - event.participants([constant('App\\Entity\\EvtJoin::ROLE_INSCRIT'), constant('App\\Entity\\EvtJoin::ROLE_BENEVOLE')]) | length) %}
-                {% set nEnAttente = event.participants(null, constant('App\\Entity\\EvtJoin::STATUS_NON_CONFIRME')) | length %}
+                {% set nInscritsHorsEncadrement = event.participations([constant('App\\Entity\\EventParticipation::ROLE_INSCRIT'), constant('App\\Entity\\EventParticipation::ROLE_BENEVOLE'), constant('App\\Entity\\EventParticipation::ROLE_MANUEL')]) | length %}
+                {% set nInscritsTotal = nInscritsHorsEncadrement + event.participations([constant('App\\Entity\\EventParticipation::ROLE_COENCADRANT'), constant('App\\Entity\\EventParticipation::ROLE_STAGIAIRE'), constant('App\\Entity\\EventParticipation::ROLE_ENCADRANT')]) | length %}
+                {% set nPlacesRestantesOnline = max(0, event.joinMax - event.participations([constant('App\\Entity\\EventParticipation::ROLE_INSCRIT'), constant('App\\Entity\\EventParticipation::ROLE_BENEVOLE')]) | length) %}
+                {% set nEnAttente = event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME')) | length %}
 
                 {% if nPlacesRestantesOnline > event.ngensMax - nInscritsTotal %}
                     {% set nPlacesRestantesOnline = max(0, event.ngensMax - nInscritsTotal) %}
@@ -905,7 +905,7 @@
                 {% if nInscritsHorsEncadrement > 0 and not is_granted('MODIFICATION_SORTIE', event) %}
                     <table class="big-lines-table" style="width:570px; margin-left:20px;">
 
-                        {% for inscrit in event.participants(null, constant('App\\Entity\\EvtJoin::STATUS_VALIDE')) %}
+                        {% for inscrit in event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_VALIDE')) %}
                             <td>
                             <td>
                                 {% if allowed('user_read_private', event.commission.code) %}
@@ -934,7 +934,7 @@
                             </tr>
                         {% endfor %}
 
-                        {% for inscrit in event.participants(null, constant('App\\Entity\\EvtJoin::ROLE_MANUEL')) %}
+                        {% for inscrit in event.participations(null, constant('App\\Entity\\EventParticipation::ROLE_MANUEL')) %}
 
                             <tr>
                                 <td>
@@ -968,7 +968,7 @@
                 {% endif %}
 
                 {# si utilisateur est inscrit, il a accès #}
-                {% if nPlacesRestantesOnline > 0 or event.participant(app.user) %}
+                {% if nPlacesRestantesOnline > 0 or event.participation(app.user) %}
 
                     {% if allowed('evt_join') %}
 

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests\Controller;
 
 use App\Entity\Evt;
-use App\Entity\EvtJoin;
+use App\Entity\EventParticipation;
 use App\Entity\User;
 use App\Entity\UserAttr;
 use App\Tests\WebTestCase;
@@ -450,7 +450,7 @@ class SortieControllerTest extends WebTestCase
 
         $this->client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
             'csrf_token' => $this->csrfToken('contact_participants'),
-            'status_sendmail' => EvtJoin::STATUS_REFUSE,
+            'status_sendmail' => EventParticipation::STATUS_REFUSE,
             'objet' => 'un objet de culte',
             'message' => 'tirelipimpon',
         ]);
@@ -472,7 +472,7 @@ class SortieControllerTest extends WebTestCase
 
         $this->client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
             'csrf_token' => $this->csrfToken('contact_participants'),
-            'status_sendmail' => EvtJoin::STATUS_VALIDE,
+            'status_sendmail' => EventParticipation::STATUS_VALIDE,
             'objet' => 'un objet de culte',
             'message' => 'Prout PROUT',
         ]);


### PR DESCRIPTION
Pour avoir des fixtures plus compréhensibles ensuite (et un code plus compréhensible aussi), cette PR renomme EvtJoin en EventParticipation et toutes les occurrences de participants / joins quand cela est pertinent.