### PR TITLE
Add XDebug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
-.vscode
 .php-cs-fixer.cache
 .DS_Store
 public/ftp/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["xdebug.php-debug"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "detail": "Waits for requests to debug.",
+      "type": "php",
+      "request": "launch",
+      "pathMappings": {
+        "/var/www/": "${workspaceFolder}"
+      }
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,41 @@
 version: "3"
 
 services:
-    cafsite:
-        build:
-            context: ./docker
-            args:
-                - UID=${UID:-1000}
-                - GID=${GID:-1000}
-        container_name: www_caflyon
-        ports:
-            - "8000:80"
-        volumes:
-            - ./docker/vhosts:/etc/apache2/sites-enabled
-            - ./:/var/www
+  cafsite:
+    build:
+      context: ./docker
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+    container_name: www_caflyon
+    ports:
+      - "8000:80"
+    volumes:
+      - ./docker/vhosts:/etc/apache2/sites-enabled
+      - ./docker/utils/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./:/var/www
 
-    cafdb:
-        image: mysql:5.7
-        container_name: db_caflyon
-        environment:
-            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-            MYSQL_DATABASE: ${DB_NAME}
-        restart: always
-        volumes:
-            - ./db:/var/lib/mysql
+  cafdb:
+    image: mysql:5.7
+    container_name: db_caflyon
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+    restart: always
+    volumes:
+      - ./db:/var/lib/mysql
 
-    phpmyadmin:
-        image: phpmyadmin
-        container_name: phpmyadmin_caflyon
-        ports:
-            - 8080:80
-        environment:
-            PMA_HOST: ${DB_HOST}
-            UPLOAD_LIMIT: ${UPLOAD_LIMIT}
+  phpmyadmin:
+    image: phpmyadmin
+    container_name: phpmyadmin_caflyon
+    ports:
+      - 8080:80
+    environment:
+      PMA_HOST: ${DB_HOST}
+      UPLOAD_LIMIT: ${UPLOAD_LIMIT}
 
-    mailcatcher:
-        image: schickling/mailcatcher
-        container_name: mail_caflyon
-        ports:
-            - 1081:1080
+  mailcatcher:
+    image: schickling/mailcatcher
+    container_name: mail_caflyon
+    ports:
+      - 1081:1080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,9 +48,10 @@ RUN docker-php-ext-install -j$(nproc) mysqli pdo_mysql && \
     docker-php-ext-install -j$(nproc) intl && \
     docker-php-ext-configure gd --with-jpeg && \
     docker-php-ext-install -j$(nproc) gd
-    
+
 RUN pecl install apcu && docker-php-ext-enable apcu
 RUN pecl install imagick && docker-php-ext-enable imagick
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 COPY ./utils/docker-999-php.ini $PHP_INI_DIR/conf.d/999-php.ini
 

--- a/docker/utils/xdebug.ini
+++ b/docker/utils/xdebug.ini
@@ -1,0 +1,6 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes


### PR DESCRIPTION
This PR adds XDebug to the PHP container and propose a working configuration for VsCode.

The docker-compose file was formatted by prettier.
The new line is :

```
volumes:
      ....
      - ./docker/utils/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
      ....
```
