### PR TITLE
Fix migrations failing locally

### DIFF
--- a/migrations/Version20211121133517.php
+++ b/migrations/Version20211121133517.php
@@ -26,7 +26,6 @@ final class Version20211121133517 extends AbstractMigration
         $this->addSql('ALTER TABLE caf_page ENGINE = InnoDB');
         $this->addSql('ALTER TABLE caf_usertype ENGINE = InnoDB');
         $this->addSql('ALTER TABLE caf_message ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE caf_ftp_allowedext ENGINE = InnoDB');
         $this->addSql('ALTER TABLE caf_token ENGINE = InnoDB');
         $this->addSql('ALTER TABLE caf_evt_join ENGINE = InnoDB');
         $this->addSql('ALTER TABLE caf_img ENGINE = InnoDB');
@@ -51,7 +50,6 @@ final class Version20211121133517 extends AbstractMigration
         $this->addSql('ALTER TABLE caf_page ENGINE = MyISAM');
         $this->addSql('ALTER TABLE caf_usertype ENGINE = MyISAM');
         $this->addSql('ALTER TABLE caf_message ENGINE = MyISAM');
-        $this->addSql('ALTER TABLE caf_ftp_allowedext ENGINE = MyISAM');
         $this->addSql('ALTER TABLE caf_token ENGINE = MyISAM');
         $this->addSql('ALTER TABLE caf_evt_join ENGINE = MyISAM');
         $this->addSql('ALTER TABLE caf_img ENGINE = MyISAM');

--- a/migrations/Version20240420182620.php
+++ b/migrations/Version20240420182620.php
@@ -20,12 +20,16 @@ final class Version20240420182620 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE caf_ftp_allowedext');
+        if (!in_array($_ENV['APP_ENV'], ['dev', 'test'])) {
+            $this->addSql('DROP TABLE caf_ftp_allowedext');
+        }
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE caf_ftp_allowedext (id_ftp_allowedext INT AUTO_INCREMENT NOT NULL, ext_ftp_allowedext VARCHAR(6) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`, PRIMARY KEY(id_ftp_allowedext)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        if (!in_array($_ENV['APP_ENV'], ['dev', 'test'])) {
+            $this->addSql('CREATE TABLE caf_ftp_allowedext (id_ftp_allowedext INT AUTO_INCREMENT NOT NULL, ext_ftp_allowedext VARCHAR(6) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`, PRIMARY KEY(id_ftp_allowedext)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        }
     }
 }


### PR DESCRIPTION
Cette PR corrige un échec lors de l'exécution des migrations.

La table caf_ftp_allowed_ext a été enlevée par une précédente PR ce qui engendre une erreur de migration localement.

On ne pouvait pas le voir facilement car il fallait exécuter complètement les migrations sur une base vierge pour s'en rendre compte.