### PR TITLE
Replace one raw SQL in legacy to PoC Doctrine integration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -157,3 +157,7 @@ services:
   legacy_content_html:
     public: true
     alias: App\Legacy\ContentHtml
+
+  legacy_user_repository:
+    public: true
+    alias: App\Repository\UserRepository

--- a/legacy/pages/adherents-consulter.php
+++ b/legacy/pages/adherents-consulter.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Legacy\LegacyContainer;
+use App\Repository\UserRepository;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 if (!admin() && !allowed('user_edit_notme')) {
@@ -66,9 +67,8 @@ if (!admin() && !allowed('user_edit_notme')) {
 
         // FILIATION CHEF DE FAMILLE ?
         if ('' != $userTab['cafnum_parent_user']) {
-            $req = "SELECT id_user, firstname_user, lastname_user, cafnum_user FROM caf_user WHERE cafnum_user = '".LegacyContainer::get('legacy_mysqli_handler')->escapeString($userTab['cafnum_parent_user'])."' LIMIT 1";
-            $result = LegacyContainer::get('legacy_mysqli_handler')->query($req);
-            $userTab['cafnum_parent_user'] = $result->fetch_assoc();
+            $req = LegacyContainer::get('legacy_user_repository')->findOneByLicenseNumber($userTab['cafnum_parent_user'], 'HYDRATE_LEGACY');
+            $userTab['cafnum_parent_user'] = $req;
         }
 
         // FILIATION ENFANTS ?

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -20,6 +21,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
+        $this->getEntityManager()->getConfiguration()->addCustomHydrationMode('HYDRATE_LEGACY', 'App\Utils\LegacyHydrator');
     }
 
     /**
@@ -46,6 +48,15 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->getOneOrNullResult();
     }
 
+    public function findOneByLicenseNumber(string $licenseNumber, string $hydratorMode = null) {
+        return $this->createQueryBuilder('u')
+            ->where('u.cafnum = :licenseNumber')
+            ->setParameter('licenseNumber', $licenseNumber)
+            ->getQuery()
+            ->getOneOrNullResult($hydratorMode)
+        ;
+    }
+
     public function getFiliations(User $user)
     {
         if (!$user->getCafnum()) {
@@ -58,5 +69,5 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->getQuery()
             ->getResult()
         ;
-    }
+    }    
 }

--- a/src/Utils/LegacyHydrator.php
+++ b/src/Utils/LegacyHydrator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Utils;
+
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+
+class LegacyHydrator extends AbstractHydrator
+{
+    protected function hydrateAllData()
+    {
+        $result =  $this->_stmt->fetchAllAssociative();
+
+        // Remove suffixes put by Doctrine on field names
+        foreach ($result as $row) {
+            $hydratedRow = [];
+            foreach ($row as $key => $value) {
+                $newKey = preg_replace('/_\d+$/', '', $key); // Supprime le suffixe numérique
+                $hydratedRow[$newKey] = $value;
+            }
+            $hydratedResult[] = $hydratedRow;
+        }
+        
+        return $hydratedResult;
+    }
+
+}


### PR DESCRIPTION
Cette PR introduit un custom hydrator pour pouvoir utiliser les repository Doctrine dans le code legacy.
Cela permettra de cleaner tout le raw SQL qui traine partout dans le code.

Idéalement il faudrait ajouter le custom hydrator à l'entity manager de façon globale. On pourra le faire plus tard lors de la généralisation à d'autres repositories