### PR TITLE
Add a service to swap two users in database

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,0 +1,6 @@
+services:
+  _defaults:
+    autowire: true
+  
+  App\Utils\UserIdSwapper:
+    public: true

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -204,10 +204,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JsonSer
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: ExpenseReport::class, orphanRemoval: false)]
     private Collection $expenseReports;
 
-    public function __construct()
+    public function __construct(int $id = null)
     {
         $this->attrs = new ArrayCollection();
         $this->created = time();
+        if ($id) {
+            $this->id = $id;
+        }
     }
 
     public function jsonSerialize(): mixed

--- a/src/Utils/UserIdSwapper.php
+++ b/src/Utils/UserIdSwapper.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Utils;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use App\Entity\User;
+
+class UserIdSwapper
+{
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function swapIds(int $id1, int $id2): void
+    {
+        $conn = $this->entityManager->getConnection();
+        $conn->beginTransaction(); // Commence la transaction
+
+        try {
+            // Générer un ID temporaire aléatoire
+            $tempId = $this->generateRandomBigint();
+
+            // Mettre à jour l'ID1 avec l'ID temporaire
+            $this->updateId($id1, $tempId);
+
+            // Mettre à jour l'ID2 avec ID1
+            $this->updateId($id2, $id1);
+
+            // Mettre à jour l'ID temporaire avec ID2
+            $this->updateId($tempId, $id2);
+
+            $conn->commit(); // Valide la transaction
+        } catch (Exception $e) {
+            $conn->rollBack(); // Annule la transaction en cas d'échec
+            throw $e; // Rethrow exception
+        }
+    }
+
+    private function generateRandomBigint(): int
+    {
+        // Les valeurs limites pour un BIGINT
+        $min = PHP_INT_MIN;
+        $max = -1; 
+
+        return random_int($min, $max);
+    }
+
+    private function updateId(int $currentId, int $newId): void
+    {
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb->update(User::class, 'e')
+            ->set('e.id', ':newId')
+            ->where('e.id = :currentId')
+            ->setParameter('newId', $newId)
+            ->setParameter('currentId', $currentId);
+
+        $qb->getQuery()->execute();
+    }
+}

--- a/tests/Utils/UserIdSwapperTest.php
+++ b/tests/Utils/UserIdSwapperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\Utils;
+
+use App\Entity\User;
+use App\Utils\UserIdSwapper;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserIdSwapperTest extends KernelTestCase
+{
+    private $entityManager;
+    private $userIdSwapper;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->userIdSwapper = static::getContainer()->get(UserIdSwapper::class);
+    }
+
+    public function testSwapIds(): void
+    {
+        $firstname1 = 'Gaston';
+        $firstname2 = 'Betty';
+
+        $userId1 = $this->createEntity($firstname1, 'Lagaffe', 10000);
+        $userId2 = $this->createEntity($firstname2, 'Boop', 20000);
+
+        $this->userIdSwapper->swapIds($userId1->getId(), $userId2->getId());
+
+        $updatedUserId1 = $this->entityManager->getRepository(User::class)->find($userId2->getId());
+        $updatedUserId2 = $this->entityManager->getRepository(User::class)->find($userId1->getId());
+
+        $this->assertSame($firstname1, $updatedUserId2->getFirstname());
+        $this->assertSame($firstname2, $updatedUserId1->getFirstname());
+    }
+
+    private function createEntity(string $firstname, string $lastname, int $id): User
+    {
+        $entity = new User($id);
+        $entity->setFirstname($firstname);
+        $entity->setLastname($lastname);
+        $entity->setNickname('nickname');
+        $entity->setCafnumParent('');
+        $entity->setTel('');
+        $entity->setTel2('');
+        $entity->setAdresse('');
+        $entity->setCp('');
+        $entity->setVille('');
+        $entity->setPays('');
+        $entity->setCiv('');
+        $entity->setMoreinfo('');
+        $entity->setCookietoken('');
+        $entity->setNomadeParent(0);
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        return $entity;
+    }
+}


### PR DESCRIPTION
Cette PR ajoute un service pour swapper des ids d'utilisateurs afin de faciliter la migration lorsqu'une licence a expiré