### PR TITLE
Add JWT Token in HTML Page content for async calls

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,11 @@ services:
   App\Twig\VueExtension:
     tags: ["twig.extension"]
 
+  App\Twig\JwtExtension:
+    public: true
+    tags:
+        - { name: 'twig.extension' }
+
   App\Twig\JavascriptGlobalsExtension:
     tags: ["twig.extension"]
 

--- a/legacy/includes/generic/header.php
+++ b/legacy/includes/generic/header.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Legacy\LegacyContainer;
+use App\Twig\JwtExtension;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 global $ogImage;
+$jwt = LegacyContainer::get(JwtExtension::class)->generateJwtToken();
 ?>
 	<!-- vars php passées au js -->
     <script type="text/javascript">
@@ -16,6 +18,9 @@ global $ogImage;
 
 	<!-- icon -->
 	<link rel="shortcut icon" href="/favicon.ico" />
+<script>
+	localStorage.setItem('jwt', "<?= $jwt ?>")
+</script>
 
 	<!-- css SCREEN ONLY  -->
 	<!-- media="screen" -->

--- a/src/EventListener/JWTAuthenticatedListener.php
+++ b/src/EventListener/JWTAuthenticatedListener.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Security\AdminDetector;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTAuthenticatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class JWTAuthenticatedListener implements EventSubscriberInterface
+{
+
+    /**
+     * @param JWTAuthenticatedEvent $event
+     *
+     * @return void
+     */
+    public function onJWTAuthenticated(JWTAuthenticatedEvent $event)
+    {
+        $token = $event->getToken();
+        $payload = $event->getPayload();
+
+        if ($payload['is_admin'] ?? false) {
+            $token->setAttribute('is_admin', $payload['is_admin']);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::JWT_AUTHENTICATED => 'onJWTAuthenticated',
+        ];
+    }
+}

--- a/src/EventListener/JWTCreatedListener.php
+++ b/src/EventListener/JWTCreatedListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Security\AdminDetector;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class JWTCreatedListener implements EventSubscriberInterface
+{
+    private $adminDetector;
+
+    public function __construct(AdminDetector $adminDetector)
+    {
+        $this->adminDetector = $adminDetector;
+    }
+
+    /**
+     * @param JWTCreatedEvent $event
+     *
+     * @return void
+     */
+    public function onJWTCreated(JWTCreatedEvent $event)
+    {
+        $payload = $event->getData();
+        $isAdmin = $this->adminDetector->isAdmin();
+        if ($isAdmin) {
+            $payload['is_admin'] = $isAdmin;
+        }
+
+        $event->setData($payload);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::JWT_CREATED => 'onJWTCreated',
+        ];
+    }
+}

--- a/src/Security/Voter/UserFlagsVoter.php
+++ b/src/Security/Voter/UserFlagsVoter.php
@@ -34,6 +34,10 @@ class UserFlagsVoter extends Voter
             return true;
         }
 
+        if ($token->hasAttribute('is_admin') && $token->getAttribute('is_admin')) {
+            return true;
+        }
+
         return $this->adminDetector->isAdmin();
     }
 }

--- a/src/Twig/JwtExtension.php
+++ b/src/Twig/JwtExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class JwtExtension extends AbstractExtension
+{
+    private $jwtManager;
+    private $security;
+
+    public function __construct(JWTTokenManagerInterface $jwtManager, Security $security)
+    {
+        $this->jwtManager = $jwtManager;
+        $this->security = $security;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('jwt_token', [$this, 'generateJwtToken']),
+        ];
+    }
+
+    public function generateJwtToken(): ?string
+    {
+        $user = $this->security->getUser();
+
+        if ($user) {
+            return $this->jwtManager->create($user);
+        }
+
+        return null;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -33,7 +33,9 @@
             <link rel="stylesheet" href="/css/print.css" type="text/css"  media="print" />
         {% endblock %}
 
-        
+        <script>
+            localStorage.setItem('jwt', "{{ jwt_token()|e('js') }}")
+        </script>
 
         {% block scripts %}
             <script type="text/javascript">


### PR DESCRIPTION
Cette PR injecte un token JWT dans les pages du site sur la base de l'utilisateur connecté.
Avec ce token, il sera possible d'appeler des endpoints API Platform de façon transparente pour l'utilisateur.
Le token est renouvelé à chaque actualisation de page. 

Ce token est injecté dans le template Twig de base et dans le header legacy pour être disponible partout.

Il a fallu s'appuyer sur l'AdminDetector et le cycle de vie du token JWT pour mimic le comportement qui promeut l'utilisateur en tant qu'admin à la connexion sur /admin.

En résumé : 

- L'utilisateur se connecte via le formulaire de connexion 
- Il est considéré comme ROLE_USER, un token contenant ce rôle est généré et injecté dans le localstorage de la page.
- Si l'utilisateur va ensuite sur /admin et se connecte, un attribut admin_caf=true est défini dans la session de l'utilisateur.
- Lorsqu'on tente d'accéder à une page accessible uniquement à ROLE_ADMIN, Symfony récupère cette session via l'ID de session stocké dans le cookie et peut vérifier admin_caf=true. 
- Lexik quant à lui fonctionne de façon stateless avec un JWT, il n'a pas connaissance de cette session. Il faut donc définir  l'information au moment de la génération du token JWT et la vérifier au moment de son décodage en utilisant les événements du cycle de vie du token. Ainsi, on pourra aussi accéder à des endpoints accessibles uniquement à ROLE_ADMIN