### PR TITLE
Transform Partner entity into APIResource (PoC)

### DIFF
--- a/src/Entity/Partenaire.php
+++ b/src/Entity/Partenaire.php
@@ -2,7 +2,11 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\GetCollection;
 use App\Repository\PartenaireRepository;
+use App\State\PartnerStateProcessor;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -12,6 +16,20 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'caf_partenaires')]
 #[ORM\Entity(repositoryClass: PartenaireRepository::class)]
+#[ApiResource(
+    processor: PartnerStateProcessor::class,
+    operations: [
+        new GetCollection(
+            uriTemplate: '/partners',
+            security: "is_granted('ROLE_ADMIN')"
+        ),
+        new Delete(
+            uriTemplate: '/partners/{id}',
+            requirements: ['id' => '\d+'],
+            security: "is_granted('ROLE_ADMIN')"
+        )
+    ]
+)]
 class Partenaire
 {
     /**

--- a/src/State/PartnerStateProcessor.php
+++ b/src/State/PartnerStateProcessor.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class PartnerStateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
+        private ProcessorInterface $removeProcessor,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            $this->removeProcessor->process($data, $operation, $uriVariables, $context);
+        }
+    }
+}


### PR DESCRIPTION
Cette PR propose un PoC avec API Platform sur une ressource simple.
Le but est de valider la pertinence / rapidité d'une réécriture d'une partie de l'application avec une logique API centric.

Dépend de #612 pour fonctionner

Pour tester en local : 

DELETE : `http DELETE localhost:8000/api/partners/1 "Authorization: Bearer eyJ0eXAiOiJKV1...."`
GET : `http localhost:8000/api/partners/ "Authorization: Bearer eyJ0eXAiOiJKV1...."`