### PR TITLE
Update expense form labels

### DIFF
--- a/assets/vue/ExpenseReport/ExpenseReportForm.vue
+++ b/assets/vue/ExpenseReport/ExpenseReportForm.vue
@@ -28,18 +28,28 @@
                     <legend>
                         {{ expenseReportFormGroup.name }}
                         <a 
-                            v-if="expenseReportFormGroup.type == 'multiple'"
+                            v-if="expenseReportFormGroup.type === 'multiple'"
                             class="add-more"
                             href="#"
                             @click.prevent="spawnExpenseGroup(expenseReportFormGroup)"
                         >
-                            <span class="emoji">
+                            <span
+                                v-if="expenseReportFormGroup.slug === 'hebergement'"
+                                class="emoji"
+                            >
+                                &#10133;
+                                Ajouter une nuitée
+                            </span>
+                            <span
+                                v-else
+                                class="emoji"
+                            >
                                 &#10133;
                                 Ajouter
                             </span>
                         </a>
                     </legend>
-                    <div class="field type-select" v-if="expenseReportFormGroup.type == 'unique'">
+                    <div class="field type-select" v-if="expenseReportFormGroup.type === 'unique'">
                         <label>Choisir le type</label>
                         <select v-model="expenseReportFormGroup.selectedType">
                             <option 
@@ -56,9 +66,11 @@
                         <div v-for="(expenseType, expenseTypeIndex) in expenseReportFormGroup.expenseTypes" :key="expenseType.id">
                             <div v-if="expenseReportFormGroup.type !== 'unique' || expenseReportFormGroup.selectedType === expenseType.slug">
                                 <h4>
-                                    {{ expenseType.name }} <span v-if="expenseReportFormGroup.type !== 'unique'">{{ parseInt(expenseTypeIndex as any) + 1 }}</span>
+                                  <span v-if="expenseReportFormGroup.type !== 'unique' && expenseType.slug === 'nuitee'">{{ parseInt(expenseTypeIndex as any) + 1 }}° </span>
+                                    {{ expenseType.name }}
+                                  <span v-if="expenseReportFormGroup.type !== 'unique'  && expenseType.slug !== 'nuitee'">{{ parseInt(expenseTypeIndex as any) + 1 }}</span>
                                     <a
-                                        v-if="expenseReportFormGroup.type == 'multiple' && expenseTypeIndex !== 0"
+                                        v-if="expenseReportFormGroup.type === 'multiple' && expenseTypeIndex !== 0"
                                         class="delete" 
 
                                         href="#"

--- a/migrations/Version20240610142444.php
+++ b/migrations/Version20240610142444.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240610142444 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // A place de "Nuitée (demi-pension) 1", il faut mettre "1ere nuitée"
+        $this->addSql(
+            "UPDATE `expense_type` SET `name` = 'nuitée' WHERE `slug` = 'nuitee';"
+        );
+        // a la place de "Prix du carburant", il faut mettre "dépense carburant"
+        $this->addSql(
+            "UPDATE `expense_field_type` SET `name` = 'Dépense carburant' WHERE `slug` = 'prix_carburant';"
+        );
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(
+            "UPDATE `expense_type` SET `name` = 'Nuitée (demi-pension)' WHERE `slug` = 'nuitee';"
+        );
+        $this->addSql(
+            "UPDATE `expense_field_type` SET `name` = 'Prix du carburant' WHERE `slug` = 'prix_carburant';"
+        );
+    }
+}


### PR DESCRIPTION
Met à jour les libellés des champs du formulaire de note de frais : 
- dans le groupe "hébergement", le libellé du bouton devient "ajouter une nuitée",
- le libellé "Nuitée (demi-pension) 1" devient "1ere nuitée" et ainsi de suite,
- dans le groupe "Transport", le libellé "Prix du carburant" devient "Dépense carburant"

Répond au ticket [Form note de frais: changer le texte](https://app.clickup.com/t/86bz2gyzw)