### PR TITLE
Fix strict comparison failing in expense authorization

### DIFF
--- a/src/Security/ExpenseAuthorization.php
+++ b/src/Security/ExpenseAuthorization.php
@@ -28,7 +28,7 @@ class ExpenseAuthorization
         if (false !== $response) {
             $jsonResponse = json_decode($response, true);
 
-            $this->authorizedIds = array_map('trim', explode(',', array_values($jsonResponse['files'])[0]['content']));
+            $this->authorizedIds = array_map('intval', explode(',', array_values($jsonResponse['files'])[0]['content']));
         } else {
             $this->authorizedIds = [];
         }


### PR DESCRIPTION
Cette PR corrige le problème de note de frais qui ne s'affichait plus suite à un passage en comparaison stricte sur les in_array