### PR TITLE
NDF: Ajout division par le nombre de passagers

### DIFF
--- a/assets/ts/expense-report-service.ts
+++ b/assets/ts/expense-report-service.ts
@@ -22,7 +22,7 @@ const expenseReportService = {
                 const toll : number = parseFloat(transportationMode.fields.find((field: any) => field.slug === 'peage').value) || 0.0;
                 const passengers : number = parseInt(transportationMode.fields.find((field: any) => field.slug === 'nombre_voyageurs').value) || 0;
                 // distance * taux kilométrique
-                total += passengers !== 0 ? distance * expenseReportConfig.tauxKilometriqueVoiture : 0.0;
+                total += passengers !== 0 ? distance * expenseReportConfig.tauxKilometriqueVoiture / passengers : 0.0;
                 // péage / nombre voyageurs
                 total += passengers !== 0 ? toll / passengers : 0.0;
             }


### PR DESCRIPTION
Le cout de location n'était pas divisé par le nombre de passager