### PR TITLE
Fix naming of uploaded files for expenses

### DIFF
--- a/src/Controller/ExpenseReportController.php
+++ b/src/Controller/ExpenseReportController.php
@@ -182,7 +182,7 @@ class ExpenseReportController extends AbstractController
         $extension = $file->getClientOriginalExtension();
         $filename = pathinfo($file->getClientOriginalName(), \PATHINFO_FILENAME);
         // rebuild filename with hashed timestamp and extension
-        $filename = $filename . '_' . substr(md5(time()), 0, 6) . '.' . $extension;
+        $filename = md5(time() . $filename) . '.' . $extension;
 
         try {
             $file->move(FileUploadHelper::getUserUploadPath($this->getUser(), 'expense-reports-justification'), $filename);


### PR DESCRIPTION
Cette PR corrige le problème d'upload lié aux accents dans les noms de fichier en générant un nom aléatoire pour chaque fichier uploadé.