### PR TITLE
Fix expense form: added front validation + corrected multiple type expense errors display

### DIFF
--- a/assets/scss/components/_expense-report-form.scss
+++ b/assets/scss/components/_expense-report-form.scss
@@ -126,6 +126,7 @@
     .justification {
         .filename {
             font-style: italic;
+            word-wrap: break-word;
         }
     }
 

--- a/assets/vue/ExpenseReport/ExpenseField.vue
+++ b/assets/vue/ExpenseReport/ExpenseField.vue
@@ -96,6 +96,9 @@ export default defineComponent({
             .then(response => response.json())
             .then(data => {
                 this.field.justificationFileUrl = data.fileUrl;
+                if (this.field.errors) {
+                    this.field.errors = null;
+                }
             });
         },
         removeFile() {

--- a/src/Controller/ExpenseReportController.php
+++ b/src/Controller/ExpenseReportController.php
@@ -133,7 +133,8 @@ class ExpenseReportController extends AbstractController
                                 'Un justificatif est obligatoire pour ce champ !',
                                 $fieldType->getSlug(),
                                 $expenseType->getId(),
-                                $dataExpenseGroup['slug']
+                                $dataExpenseGroup['slug'],
+                                $dataField['id'],
                             );
                         } elseif (!empty($dataField['justificationFileUrl'])) {
                             $expenseField->setJustificationDocument($dataField['justificationFileUrl']);

--- a/src/Utils/Error/ExpenseReportFormError.php
+++ b/src/Utils/Error/ExpenseReportFormError.php
@@ -8,7 +8,8 @@ class ExpenseReportFormError implements \JsonSerializable
         private string $message,
         private ?string $fieldSlug = null,
         private ?int $expenseTypeId = null,
-        private ?string $expenseGroupSlug = null
+        private ?string $expenseGroupSlug = null,
+        private ?int $fieldId = null,
     ) {
     }
 
@@ -19,6 +20,7 @@ class ExpenseReportFormError implements \JsonSerializable
             'field' => $this->fieldSlug,
             'expenseTypeId' => $this->expenseTypeId,
             'expenseGroup' => $this->expenseGroupSlug,
+            'fieldId' => $this->fieldId,
         ];
     }
 }


### PR DESCRIPTION
Corrige l'affichage des erreurs du formulaire de notes de frais. 
Ajoute une validation côté front (évite la requête POSTAjax au backend en cas d'erreurs). 
Gère les erreurs en cas de dépenses de type multiple (ex: hébergement et autres dépenses), que ce soit les erreurs côté front ou côté back.
Permet de traiter le ticket [Form note de frais: lors d'un upload, le fichier n'est pas pris en compte](https://app.clickup.com/t/86bz2gyua)