### PR TITLE
Remove session lifetime index renaming

### DIFF
--- a/migrations/Version20240307092240.php
+++ b/migrations/Version20240307092240.php
@@ -22,9 +22,8 @@ final class Version20240307092240 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE INDEX id_user ON caf_user (id_user)');
 
-        if (!in_array($_ENV['APP_ENV'], ['dev', 'test'])) {
+        if (!\in_array($_ENV['APP_ENV'], ['dev', 'test'], true)) {
             $this->addSql('ALTER TABLE sessions CHANGE sess_data sess_data LONGBLOB NOT NULL');
-            $this->addSql('ALTER TABLE sessions RENAME INDEX expiry TO sess_lifetime_idx');
         }
     }
 
@@ -32,11 +31,9 @@ final class Version20240307092240 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('DROP INDEX id_user ON caf_user');
-        
-        if (!in_array($_ENV['APP_ENV'], ['dev', 'test'])) {
-            $this->addSql('ALTER TABLE sessions CHANGE sess_data sess_data BLOB NOT NULL');
-            $this->addSql('ALTER TABLE sessions RENAME INDEX sess_lifetime_idx TO EXPIRY');
-        }
 
+        if (!\in_array($_ENV['APP_ENV'], ['dev', 'test'], true)) {
+            $this->addSql('ALTER TABLE sessions CHANGE sess_data sess_data BLOB NOT NULL');
+        }
     }
 }


### PR DESCRIPTION
This index sess_lifetime_idx is created by the PDOSessionHandler here https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php#L228

In older data dump, this expiry column doesn't exist at all so renaming the column fails