### PR TITLE
Empêcher la désinscription à une sortie si la sortie est dans moins de 4 jours

### DIFF
--- a/assets/scss/common/_tooltip.scss
+++ b/assets/scss/common/_tooltip.scss
@@ -1,0 +1,26 @@
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  content: attr(data-tooltip);
+  left: 0;
+  top: calc(100% + 10px);
+  border-radius: 3px;
+  box-shadow: 0 0 5px 2px rgba(100, 100, 100, 0.6);
+  background-color: white;
+  z-index: 10;
+  padding: 8px;
+  width: 300px;
+  transform: translateY(-20px);
+  transition: all 150ms cubic-bezier(.25, .8, .25, 1);
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+  transition-duration: 300ms;
+}

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -4,5 +4,6 @@
 @import './common/layout';
 @import './common/titles';
 @import './common/utils';
+@import './common/tooltip';
 
 @import './components/expense-report-form';

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -20,6 +20,7 @@ class Evt implements \JsonSerializable
     public const STATUS_LEGAL_UNSEEN = 0;
     public const STATUS_LEGAL_VALIDE = 1;
     public const STATUS_LEGAL_REFUSE = 2;
+    public const UNSUBSCRIBE_LIMIT_PERIOD = 4;
 
     /**
      * @var int
@@ -894,5 +895,16 @@ class Evt implements \JsonSerializable
         $this->childVersionTosubmit = $childVersionTosubmit;
 
         return $this;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function canBeUnsubscribedFrom(): bool
+    {
+        $startDate = (new \DateTime())->setTimestamp($this->getTsp())->setTime(0, 0);
+        $startDate->modify(sprintf('- %d day', self::UNSUBSCRIBE_LIMIT_PERIOD));
+        $today = (new \DateTime())->setTime(0, 0);
+        return $startDate > $today;
     }
 }

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -319,7 +319,13 @@
                                 <img src="/img/inscrit-check.png" alt="" title=""/>
                                 <div class="text-container">Vous êtes inscrit comme participant à cette sortie.
                                     <div class="button-container">
-                                        <input type="button" class="nice" value="Annuler mon inscription" onclick="$('#inscription-annuler').slideToggle(200)" />
+                                        {% if event.canBeUnsubscribedFrom %}
+                                            <input type="button" class="nice" value="Annuler mon inscription" onclick="$('#inscription-annuler').slideToggle(200)" />
+                                        {% else %}
+                                            <span data-tooltip="Il n'est plus possible de se désinscrire, merci de contacter l'encadrant.e.">
+                                                <input type="button" class="nice" value="Annuler mon inscription" disabled />
+                                            </span>
+                                        {% endif %}
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Désactive le bouton "annuler mon inscription" et ajoute un tooltip explicatif si la sortie est dans moins de 4 jours.

Ajoute aussi dans la génération de la page de sortie un contrôle d'autorisation de l'utilisateur pour éviter de générer les notes de frais sans réelle utilité.

Permet de clôturer le ticket [Empêcher la désinscription à une sortie si la sortie est dans moins de 4 jours](https://app.clickup.com/t/86bzeup3t)

Ci-joint une capture d'écran du résultat du bouton désactivé accompagné du tooltip :
![Capture d’écran du 2024-07-04 11-11-26](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/assets/38693470/3b1c134c-25f1-4201-b5c4-da3677f4a5f8)
