### PR TITLE
Empêche la génération des notes de frais sur la page des sorties pour…

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -11,6 +11,7 @@ use App\Repository\ExpenseGroupRepository;
 use App\Repository\ExpenseReportRepository;
 use App\Repository\ExpenseTypeExpenseFieldTypeRepository;
 use App\Repository\UserRepository;
+use App\Security\ExpenseAuthorization;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportEnum;
 use App\Utils\Serialize\ExpenseFieldTypeSerializer;
@@ -45,6 +46,7 @@ class SortieController extends AbstractController
         ExpenseReportRepository $expenseReportRepository,
         ExpenseReportSerializer $expenseReportSerializer,
         Environment $twig,
+        ExpenseAuthorization $expenseAuthorization,
         $baseUrl = '/',
     ) {
         if (!$this->isGranted('SORTIE_VIEW', $event)) {
@@ -55,111 +57,114 @@ class SortieController extends AbstractController
 
         // generate a new empty expense report form structure
         $expenseReportFormGroups = [];
-        $expenseGroups = $expenseGroupRepository->findAll();
+        $currentExpenseReport = null;
 
-        // each expense group has a list of expense types
-        // each expense type has a list of fields
-        foreach ($expenseGroups as $expenseGroup) {
-            $expenseReportFormGroups[$expenseGroup->getSlug()] = [
-                'name' => $expenseGroup->getName(),
-                'slug' => $expenseGroup->getSlug(),
-                'type' => $expenseGroup->getType(),
-                'expenseTypes' => [],
-                'selectedType' => 0,
-            ];
+        if ($expenseAuthorization->isAuthorized()) {
+            $expenseGroups = $expenseGroupRepository->findAll();
 
-            foreach ($expenseGroup->getExpenseTypes() as $expenseType) {
-                $fields = array_map(function ($expenseFieldTypeRelation) {
-                    return $expenseFieldTypeRelation->getExpenseFieldType();
-                }, $expenseType->getExpenseFieldTypeRelations()->toArray());
-
-                // add the needsJustification property to the field itself
-                // (needsJustification comes from the join table)
-                foreach ($fields as $field) {
-                    $relation = $expenseTypeFieldTypeRepository->findOneBy([
-                        'expenseType' => $expenseType,
-                        'expenseFieldType' => $field,
-                    ]);
-                    $field->setFlags([
-                        'needsJustification' => $relation->getNeedsJustification(),
-                        'displayOrder' => $relation->getDisplayOrder(),
-                        'isMandatory' => $relation->isMandatory(),
-                        'isUsedForTotal' => $relation->isUsedForTotal(),
-                    ]);
-                }
-
-                // add the type to the group
-                $expenseReportFormGroups[$expenseGroup->getSlug()]['expenseTypes'][] = [
-                    'expenseTypeId' => $expenseType->getId(),
-                    'name' => $expenseType->getName(),
-                    'slug' => $expenseType->getSlug(),
-                    'fields' => array_map(function ($expenseFieldType) {
-                        return ExpenseFieldTypeSerializer::serialize($expenseFieldType);
-                    }, $fields),
+            // each expense group has a list of expense types
+            // each expense type has a list of fields
+            foreach ($expenseGroups as $expenseGroup) {
+                $expenseReportFormGroups[$expenseGroup->getSlug()] = [
+                    'name' => $expenseGroup->getName(),
+                    'slug' => $expenseGroup->getSlug(),
+                    'type' => $expenseGroup->getType(),
+                    'expenseTypes' => [],
+                    'selectedType' => 0,
                 ];
-            }
-        }
-        $currentExpenseReport = $event && $user ? $expenseReportRepository->getExpenseReportByEventAndUser($event->getId(), $user->getId()) : null;
 
-        // prefill the form with the current expense report data
-        if ($currentExpenseReport
-            && \in_array($currentExpenseReport->getStatus(),
-                [ExpenseReportEnum::STATUS_DRAFT, ExpenseReportEnum::STATUS_REJECTED], true
-            )
-        ) {
-            // serialize the current expense report
-            $currentExpenseReport = $expenseReportSerializer->serialize($currentExpenseReport);
+                foreach ($expenseGroup->getExpenseTypes() as $expenseType) {
+                    $fields = array_map(function ($expenseFieldTypeRelation) {
+                        return $expenseFieldTypeRelation->getExpenseFieldType();
+                    }, $expenseType->getExpenseFieldTypeRelations()->toArray());
 
-            $expenseReportFormGroups['refundRequired'] = $currentExpenseReport['refundRequired'] ? 1 : 0;
-            // for each expense group
-            foreach ($currentExpenseReport['expenseGroups'] as $groupSlug => $expenseGroup) {
-                // set the selected expense type
-                if (!empty($expenseGroup['selectedType'])) {
-                    $expenseReportFormGroups[$groupSlug]['selectedType'] = $expenseGroup['selectedType'];
-                }
-
-                $index = 0;
-                // for each expense type
-                foreach ($expenseGroup as $expense) {
-                    // ignore values that are not expenses
-                    if (!\is_array($expense)) {
-                        continue;
-                    }
-
-                    // for each field
-                    $newFields = [];
-                    foreach ($expense['fields'] as $field) {
-                        // set the value from the current expense report if existing
-                        $newField = $field->jsonSerialize();
-                        // add the field type flags to this field
+                    // add the needsJustification property to the field itself
+                    // (needsJustification comes from the join table)
+                    foreach ($fields as $field) {
                         $relation = $expenseTypeFieldTypeRepository->findOneBy([
-                            'expenseType' => $expense['expenseType']->getId(),
-                            'expenseFieldType' => $field->getFieldType()->getId(),
+                            'expenseType' => $expenseType,
+                            'expenseFieldType' => $field,
                         ]);
-                        $newField['fieldTypeId'] = $field->getFieldType()->getId();
-                        $newField['flags']['needsJustification'] = $relation->getNeedsJustification();
-                        $newField['flags']['isMandatory'] = $relation->isMandatory();
-                        $newField['flags']['isUsedForTotal'] = $relation->isUsedForTotal();
-                        $newField['flags']['displayOrder'] = $relation->getDisplayOrder();
-                        $newField['name'] = $field->getFieldType()->getName();
-                        $newField['slug'] = $field->getFieldType()->getSlug();
-                        $newFields[] = $newField;
+                        $field->setFlags([
+                            'needsJustification' => $relation->getNeedsJustification(),
+                            'displayOrder' => $relation->getDisplayOrder(),
+                            'isMandatory' => $relation->isMandatory(),
+                            'isUsedForTotal' => $relation->isUsedForTotal(),
+                        ]);
                     }
 
-                    if ('unique' === $expense['expenseType']->getExpenseGroup()->getType()) {
-                        $targetExpenseTypeIndex = array_search($expense['expenseType']->getId(), array_column($expenseReportFormGroups[$groupSlug]['expenseTypes'], 'expenseTypeId'), true);
-                        $expenseReportFormGroups[$groupSlug]['expenseTypes'][$targetExpenseTypeIndex]['fields'] = $newFields;
-                    } else {
-                        if (0 === $index) {
-                            $expenseReportFormGroups[$groupSlug]['expenseTypes'][0]['fields'] = $newFields;
-                            ++$index;
-                        } else {
-                            // Duplicate the preceding expenseType
-                            $expenseReportFormGroups[$groupSlug]['expenseTypes'][$index] = $expenseReportFormGroups[$groupSlug]['expenseTypes'][0];
-                            // Override preceding expenseType fields
-                            $expenseReportFormGroups[$groupSlug]['expenseTypes'][$index++]['fields'] = $newFields;
+                    // add the type to the group
+                    $expenseReportFormGroups[$expenseGroup->getSlug()]['expenseTypes'][] = [
+                        'expenseTypeId' => $expenseType->getId(),
+                        'name' => $expenseType->getName(),
+                        'slug' => $expenseType->getSlug(),
+                        'fields' => array_map(function ($expenseFieldType) {
+                            return ExpenseFieldTypeSerializer::serialize($expenseFieldType);
+                        }, $fields),
+                    ];
+                }
+            }
+            $currentExpenseReport = $event && $user ? $expenseReportRepository->getExpenseReportByEventAndUser($event->getId(), $user->getId()) : null;
+
+            // prefill the form with the current expense report data
+            if ($currentExpenseReport
+                && \in_array($currentExpenseReport->getStatus(),
+                    [ExpenseReportEnum::STATUS_DRAFT, ExpenseReportEnum::STATUS_REJECTED], true
+                )
+            ) {
+                // serialize the current expense report
+                $currentExpenseReport = $expenseReportSerializer->serialize($currentExpenseReport);
+
+                $expenseReportFormGroups['refundRequired'] = $currentExpenseReport['refundRequired'] ? 1 : 0;
+                // for each expense group
+                foreach ($currentExpenseReport['expenseGroups'] as $groupSlug => $expenseGroup) {
+                    // set the selected expense type
+                    if (!empty($expenseGroup['selectedType'])) {
+                        $expenseReportFormGroups[$groupSlug]['selectedType'] = $expenseGroup['selectedType'];
+                    }
+
+                    $index = 0;
+                    // for each expense type
+                    foreach ($expenseGroup as $expense) {
+                        // ignore values that are not expenses
+                        if (!\is_array($expense)) {
+                            continue;
                         }
 
+                        // for each field
+                        $newFields = [];
+                        foreach ($expense['fields'] as $field) {
+                            // set the value from the current expense report if existing
+                            $newField = $field->jsonSerialize();
+                            // add the field type flags to this field
+                            $relation = $expenseTypeFieldTypeRepository->findOneBy([
+                                'expenseType' => $expense['expenseType']->getId(),
+                                'expenseFieldType' => $field->getFieldType()->getId(),
+                            ]);
+                            $newField['fieldTypeId'] = $field->getFieldType()->getId();
+                            $newField['flags']['needsJustification'] = $relation->getNeedsJustification();
+                            $newField['flags']['isMandatory'] = $relation->isMandatory();
+                            $newField['flags']['isUsedForTotal'] = $relation->isUsedForTotal();
+                            $newField['flags']['displayOrder'] = $relation->getDisplayOrder();
+                            $newField['name'] = $field->getFieldType()->getName();
+                            $newField['slug'] = $field->getFieldType()->getSlug();
+                            $newFields[] = $newField;
+                        }
+
+                        if ('unique' === $expense['expenseType']->getExpenseGroup()->getType()) {
+                            $targetExpenseTypeIndex = array_search($expense['expenseType']->getId(), array_column($expenseReportFormGroups[$groupSlug]['expenseTypes'], 'expenseTypeId'), true);
+                            $expenseReportFormGroups[$groupSlug]['expenseTypes'][$targetExpenseTypeIndex]['fields'] = $newFields;
+                        } else {
+                            if (0 === $index) {
+                                $expenseReportFormGroups[$groupSlug]['expenseTypes'][0]['fields'] = $newFields;
+                                ++$index;
+                            } else {
+                                // Duplicate the preceding expenseType
+                                $expenseReportFormGroups[$groupSlug]['expenseTypes'][$index] = $expenseReportFormGroups[$groupSlug]['expenseTypes'][0];
+                                // Override preceding expenseType fields
+                                $expenseReportFormGroups[$groupSlug]['expenseTypes'][$index++]['fields'] = $newFields;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… les utilisateurs non concernés.

Vu lors d'une PR précédente, le code de génération des notes de frais est exécuté par le controller pour chaque utilisateur. Le fix consiste à utiliser le service ExpenseAuthorization déjà existant pour vérifier directement dans le controller la capacité de l'utilisateur a accéder aux notes de frais.