### PR TITLE
Move the email consume command to worker command on CC

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,5 +1,4 @@
 [
-  "* * * * * $ROOT/clevercloud/crons/consume-emails.sh",
   "3 7 * * * $ROOT/clevercloud/crons/sync-members.sh",
   "57 * * * * $ROOT/clevercloud/crons/save-images.sh",
   "54 5 * * * $ROOT/clevercloud/crons/send-reminders.sh"

--- a/clevercloud/crons/consume-emails.sh
+++ b/clevercloud/crons/consume-emails.sh
@@ -1,8 +1,0 @@
-#! /bin/bash -l
-
-# Important to keep this file
-# Clevercloud requires this to load environment
-# https://developers.clever-cloud.com/doc/administrate/cron/#access-environment-variables
-
-cd ${APP_HOME}
-bin/console messenger:consume mails --time-limit=55 --quiet --no-interaction


### PR DESCRIPTION
Cette PR déplace la commande pour le consume des emails vers une variable d'environnement sur Clevercloud.
Clevercloud gère ses workers avec systemd, ce qui est la façon de faire recommandée par Symfony.