### PR TITLE
Fix error in transportation calculation

### DIFF
--- a/assets/ts/expense-report-service.ts
+++ b/assets/ts/expense-report-service.ts
@@ -20,11 +20,8 @@ const expenseReportService = {
             if (transportationMode.slug === 'vehicule_personnel') {
                 const distance : number = parseFloat(transportationMode.fields.find((field: any) => field.slug === 'distance').value) || 0.0;
                 const toll : number = parseFloat(transportationMode.fields.find((field: any) => field.slug === 'peage').value) || 0.0;
-                const passengers : number = parseInt(transportationMode.fields.find((field: any) => field.slug === 'nombre_voyageurs').value) || 0;
-                // distance * taux kilométrique
-                total += passengers !== 0 ? distance * expenseReportConfig.tauxKilometriqueVoiture / passengers : 0.0;
-                // péage / nombre voyageurs
-                total += passengers !== 0 ? toll / expenseReportConfig.divisionPeage : 0.0;
+                total += distance * expenseReportConfig.tauxKilometriqueVoiture;
+                total += toll / expenseReportConfig.divisionPeage;
             }
 
             // minibus location


### PR DESCRIPTION
Cette PR corrige l'erreur remontée par Christel sur les calculs des transports.
Ce point a été vérifié dans l'excel des notes de frais. Les indemnités kilométriques n'ont pas à être divisées par le nombre de passagers.