### PR TITLE
Fix typescript error with logical and assignment in expense form

### DIFF
--- a/assets/vue/ExpenseReport/ExpenseReportForm.vue
+++ b/assets/vue/ExpenseReport/ExpenseReportForm.vue
@@ -217,10 +217,10 @@
                         const expenseType = this.formStructure[expenseReportFormGroup].expenseTypes.find((expenseType: any) => {
                             return expenseType.slug === selected;
                         });
-                        valid &= this.validateExpenseType(expenseType);
+                        valid &&= this.validateExpenseType(expenseType);
                     } else {
                         for (const expenseType of this.formStructure[expenseReportFormGroup].expenseTypes) {
-                            valid &= this.validateExpenseType(expenseType);
+                            valid &&= this.validateExpenseType(expenseType);
                         }
                     }
                 }


### PR DESCRIPTION
Remplace l'opérateur &= par &&= dans ExpenseReportForm.vue
=> [Logical AND assignment (&&=) - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment)