### PR TITLE
Fix issue occurring when merging members with one email not set

### DIFF
--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -43,11 +43,10 @@ class MemberMerger
                 throw new \Exception('Unable to find an user with this cafnum ' . $newCafNum);
             }
 
-            $email = $newCafUser->getEmail();
             $cafnum = $newCafUser->getCafnum();
 
             $newCafUser->setCafnum('obs_' . $cafnum);
-            $newCafUser->setEmail('obs_' . $email);
+            $newCafUser->setEmail('obs_' . time());
             $newCafUser->setIsDeleted(true);
 
             $this->entityManager->flush();
@@ -63,7 +62,7 @@ class MemberMerger
             $oldCafUser->setCafnumParent($newCafUser->getCafnumParent());
             $oldCafUser->setDoitRenouveler($newCafUser->getDoitRenouveler());
             $oldCafUser->setAlerteRenouveler($newCafUser->getAlerteRenouveler());
-            $oldCafUser->setEmail($email);
+
             $this->entityManager->flush();
 
             $this->entityManager->commit();


### PR DESCRIPTION
CF ce résumé qui explique le pourquoi de la PR : 

> De ce que je comprends, le cas dont il est question se produit lorsque tu as tenté de fusionner deux comptes.
> J’avais réécrit la logique de fusion suite à nos discussions de façon à avoir de façon instantanée les nouvelles informations sur le compte qu’on souhaitait garder.
> 
> Le cas de bug que tu rencontres se produit car je n’ai pas pris en compte qu’un utilisateur pouvait ne pas activer son nouveau compte et donc ne pas saisir d’adresse email valide. Or ma logique considérait que l’email saisi pour un nouveau compte serait plus “récent” / “légitime” que l’email de l’ancien compte.
> Dans le cas où le nouveau compte n’a pas d’email, on n’arrive pas à fusionner complètement les comptes.

La correction apportée consiste à ne plus toucher aux emails et considérer que l'email déjà défini sur l'ancien compte est le bon. Au pire, l'utilisateur fera un changement d'email lui-même mais il est peu probable que cela se produise.