### PR TITLE
Increase unsubscription delay

### DIFF
--- a/legacy/includes/evt/gestion_inscriptions.php
+++ b/legacy/includes/evt/gestion_inscriptions.php
@@ -250,7 +250,7 @@ if ('1' != $evt['cancelled_evt']) {
                                                 </label>';
                     }
 
-                    if (time() < $evt['tsp_end_evt']) {
+                    if (time() < ($evt['tsp_end_evt'] + 7 * 24 * 60 * 60)) {
                         echo '<label for="join_' . (int) $row['id_evt_join'] . '_-1">
                                                 <input name="status_evt_join_' . (int) $row['id_evt_join'] . '" ' . ($disable_1 ? 'disabled="disabled"' : '') . ' type="radio" id="join_' . (int) $row['id_evt_join'] . '_-1" value="-1" />
                                                 Désinscrire


### PR DESCRIPTION
Cette PR augmente le temps durant lequel le bouton pour désinscrire reste présent dans la liste des inscrits côté encadrant.
Le temps est augmenté à une semaine.