### PR TITLE
Fix error occurring on Clever Cloud during PDF export

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\String\Slugger\SluggerInterface;
 use Twig\Environment;
 
 class SortieController extends AbstractController
@@ -440,7 +441,7 @@ class SortieController extends AbstractController
     }
 
     #[Route(name: 'sortie_pdf', path: '/sortie/{id}/printPDF', requirements: ['id' => '\d+'] )]
-    public function generatePdf(PdfGenerator $pdfGenerator, Evt $event): Response
+    public function generatePdf(PdfGenerator $pdfGenerator, SluggerInterface $slugger, Evt $event): Response
     {
 
         $legacyDir = __DIR__ . '/../../legacy/';
@@ -452,6 +453,6 @@ class SortieController extends AbstractController
         require $this->getParameter('kernel.project_dir') . '/legacy/' . $path;
         $html = ob_get_clean();
 
-        return $pdfGenerator->generatePdf($html, $event->getTitre() . '.pdf');
+        return $pdfGenerator->generatePdf($html, $slugger->slug($event->getTitre()) . '.pdf');
     }
 }

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -163,12 +163,13 @@
             <img src="/img/base/print.png" alt="PRINT" title="" style="height:20px" />
             Imprimer la fiche de sortie
         </a>
+        <a href="{{ path('sortie_pdf', { id: event.id }) }}" title="Imprimer la fiche de sortie en PDF" class="nice2">
+            <img src="/img/base/print.png" alt="PRINT" title="" style="height:20px" />
+            Imprimer la fiche de sortie en PDF
+        </a>
         {% endif %}
 
-        <a href="{{ path('sortie_pdf', { id: event.id }) }}" title="Imprimer la fiche en PDF" class="nice2">
-            <img src="/img/base/print.png" alt="PRINT" title="" style="height:20px" />
-            Imprimer la fiche en PDF
-        </a>
+ 
 
         {% if is_granted('SORTIE_DUPLICATE', event) %}
          <form action="{{ path('sortie_duplicate', { id: event.id }) }}" method="post" class="loading">


### PR DESCRIPTION
Clever Cloud's gateway doesn't handle correctly utf-8 characters in filename. The fix is to slugify the event title.