### PR TITLE
Update security rule for patch expense report

### DIFF
--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -44,7 +44,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Patch(
             uriTemplate: '/expense-reports/{id}',
-            security: 'object.getUser() == user',
+            security: 'object.getUser() == user or is_granted("validate_expense_report")',
             // normalizationContext: ['groups' => ['report:read', 'attachment:read', 'user:read', 'event:read']]
         ),
     ],


### PR DESCRIPTION
Cette PR corrige le problème d'Access Denied lorsqu'on modifie le statut d'une note de frais côté comptabilité