### PR TITLE
Remove delay to unsubscribe participant to an event

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -518,18 +518,17 @@
                                                 </label>
                                             {% endif %}
 
-                                            {% if not event.finished %}
-                                                <label for="join_{{ participation.id }}_-1">
-                                                    <input
-                                                        name="status_evt_join_{{ participation.id }}"
-                                                        {{ disable_unsubscribe ? 'disabled="disabled"' : '' }}
-                                                        type="radio"
-                                                        id="join_{{ participation.id }}_-1"
-                                                        value="-1"
-                                                    />
-                                                    Désinscrire
-                                                </label>
-                                            {% endif %}
+                                            <label for="join_{{ participation.id }}_-1">
+                                                <input
+                                                    name="status_evt_join_{{ participation.id }}"
+                                                    {{ disable_unsubscribe ? 'disabled="disabled"' : '' }}
+                                                    type="radio"
+                                                    id="join_{{ participation.id }}_-1"
+                                                    value="-1"
+                                                />
+                                                Désinscrire
+                                            </label>
+
 
                                         {% endif %}
 


### PR DESCRIPTION
Cette PR supprime complètement le délai qui empêche de désinscrire un participant à une sortie passée.
Il semble préférable d'enlever cette contrainte et d'alerter par la suite le participant du statut appliqué par l'encadrant