### PR TITLE
Fix typo in query to find enabled partners

### DIFF
--- a/src/Repository/PartenaireRepository.php
+++ b/src/Repository/PartenaireRepository.php
@@ -25,7 +25,7 @@ class PartenaireRepository extends ServiceEntityRepository implements PasswordUp
     {
         return $this->createQueryBuilder('p')
             ->select('p')
-            ->where('p.enable = 1')
+            ->where('p.enabled = 1')
             ->andWhere('p.name IS NOT NULL')
             ->andWhere('p.name != \'\'')
             ->andWhere('p.image IS NOT NULL')


### PR DESCRIPTION
Erreur au chargement du site en local:
```
Error: Class App\Entity\Partenaire has no field or association named enable
```

La PR [#712](https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/pull/712/files#diff-3dba4b288f356d8bbd2a7e7be5debf344fe87b12f6e969a9e0581692a9631504R57) a renommé l'attribut `enable` de la classe `Partenaire` en `enabled`, ce qui casse la query faite dans `findEnabled()`.
