### PR TITLE
Fix code and tests

### DIFF
--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Controller;
 
+use App\Security\SecurityConstants;
 use App\Tests\WebTestCase;
 
 class AdminControllerTest extends WebTestCase
@@ -15,7 +16,7 @@ class AdminControllerTest extends WebTestCase
         $user = $this->signup(mt_rand() . 'test@clubalpinlyon.fr');
         $this->signin($user);
 
-        $this->assertFalse($this->getSession()->has('admin_caf'));
+        $this->assertEquals($this->getSession()->has(SecurityConstants::SESSION_USER_ROLE_KEY), null);
 
         static::$client->request('GET', '/admin/');
         $this->assertResponseStatusCodeSame(200);
@@ -26,7 +27,7 @@ class AdminControllerTest extends WebTestCase
         ]);
         $this->assertResponseStatusCodeSame(200);
 
-        $this->assertFalse($this->getSession()->has('admin_caf'));
+        $this->assertEquals($this->getSession()->has(SecurityConstants::SESSION_USER_ROLE_KEY), null);
 
         static::$client->submitForm('admin_connect', [
             'username' => 'caflyon',
@@ -35,6 +36,6 @@ class AdminControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(302);
         $this->assertResponseRedirects('/');
 
-        $this->assertTrue($this->getSession()->get('admin_caf'));
+        $this->assertEquals($this->getSession()->get(SecurityConstants::SESSION_USER_ROLE_KEY), SecurityConstants::ROLE_ADMIN);
     }
 }

--- a/tests/Utils/MemberMergerTest.php
+++ b/tests/Utils/MemberMergerTest.php
@@ -29,7 +29,7 @@ class MemberMergerTest extends KernelTestCase
 
         $this->memberMerger->mergeMembers($oldLicense, $newLicense);
 
-        $userOldLicense = $this->entityManager->getRepository(User::class)->findOneByLicenseNumber('ligne_obsolete');
+        $userOldLicense = $this->entityManager->getRepository(User::class)->findOneByLicenseNumber("obs_{$newLicense}");
         $userNewLicense = $this->entityManager->getRepository(User::class)->findOneByLicenseNumber($newLicense);
 
         $this->assertSame($userNewLicense->getId(), $user1->getId());


### PR DESCRIPTION
Cette PR corrige trois problèmes : 
- Un accès à un tableau via des clefs qui peuvent ne pas exister
- Le test AdminController qui n'a pas été aligné avec les récentes modifs
- Le test MemberMerger qui n'a pas été non plus aligné avec un changement de naming pour les users obsolètes post-merge. Ce test reste fragile en local puisqu'en fusionnant et en changeant le cafnum_user, l'utilisateur servant pour le test n'existe plus ensuite et il faut reload la DB pour pouvoir le rejouer.