### PR TITLE
Renomme le titre d une rubrique

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -197,7 +197,7 @@
 
                                 <a href="/profil/infos.html" title="">mes infos publiques</a><br />
                                 <a href="/profil/infos.html#private" title="">mes infos privées</a><br />
-                                <a href="/pages/boite-outils-des-encadrants.html" title="">Boite à outils des encadrants</a><br />
+                                <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
                                 {#<a href="/profil/filiations.html" title="">filiations</a>#}
                             </div>
 


### PR DESCRIPTION
Je propose ce renommage 
 - minuscule au début
 - plus court
Pour la consistance avec les autres liens, et la lisibilité sur une seule ligne

Avant:
![image](https://github.com/user-attachments/assets/62040613-7c36-45bf-a7e3-1d95e379d10f)

Apres:
![image](https://github.com/user-attachments/assets/e1d86900-5e91-4696-9fef-3bed8444455e)
