### PR TITLE
Avoid using same instance for unit tests, add var-dumper test trait

### DIFF
--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -9,7 +9,7 @@ class AdminControllerTest extends WebTestCase
 {
     public function testLogin()
     {
-        static::$client->request('GET', '/admin/');
+        $this->client->request('GET', '/admin/');
         $this->assertResponseStatusCodeSame(302);
         $this->assertResponseRedirects('http://localhost/login');
 
@@ -18,10 +18,10 @@ class AdminControllerTest extends WebTestCase
 
         $this->assertEquals($this->getSession()->has(SecurityConstants::SESSION_USER_ROLE_KEY), null);
 
-        static::$client->request('GET', '/admin/');
+        $this->client->request('GET', '/admin/');
         $this->assertResponseStatusCodeSame(200);
 
-        static::$client->submitForm('admin_connect', [
+        $this->client->submitForm('admin_connect', [
             'username' => 'caflyon',
             'password' => 'prout',
         ]);
@@ -29,7 +29,7 @@ class AdminControllerTest extends WebTestCase
 
         $this->assertEquals($this->getSession()->has(SecurityConstants::SESSION_USER_ROLE_KEY), null);
 
-        static::$client->submitForm('admin_connect', [
+        $this->client->submitForm('admin_connect', [
             'username' => 'caflyon',
             'password' => 'admin',
         ]);

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -16,10 +16,10 @@ class LoginControllerTest extends WebTestCase
         $em = $this->getContainer()->get('doctrine')->getManager();
         $em->flush();
 
-        static::$client->request('GET', '/login');
+        $this->client->request('GET', '/login');
         $this->assertResponseStatusCodeSame(200);
 
-        static::$client->submitForm('connect-button', [
+        $this->client->submitForm('connect-button', [
             '_username' => $user->getEmail(),
             '_password' => 'youpla',
         ]);
@@ -36,10 +36,10 @@ class LoginControllerTest extends WebTestCase
         $em = $this->getContainer()->get('doctrine')->getManager();
         $em->flush();
 
-        static::$client->request('GET', '/login');
+        $this->client->request('GET', '/login');
         $this->assertResponseStatusCodeSame(200);
 
-        static::$client->submitForm('connect-button', [
+        $this->client->submitForm('connect-button', [
             '_username' => $user->getEmail(),
             '_password' => 'invalid',
         ]);
@@ -52,7 +52,7 @@ class LoginControllerTest extends WebTestCase
         $user = $this->signup(mt_rand() . 'test@clubalpinlyon.fr');
         $this->signin($user);
 
-        static::$client->request('GET', '/login');
+        $this->client->request('GET', '/login');
         $this->assertResponseStatusCodeSame(302);
     }
 
@@ -61,7 +61,7 @@ class LoginControllerTest extends WebTestCase
         $user = $this->signup(mt_rand() . 'test@clubalpinlyon.fr');
         $this->signin($user);
 
-        static::$client->request('GET', '/password-lost');
+        $this->client->request('GET', '/password-lost');
         $this->assertResponseStatusCodeSame(302);
     }
 
@@ -69,10 +69,10 @@ class LoginControllerTest extends WebTestCase
     {
         $user = $this->signup(mt_rand() . 'test@clubalpinlyon.fr');
 
-        static::$client->request('GET', '/password-lost');
+        $this->client->request('GET', '/password-lost');
         $this->assertResponseStatusCodeSame(200);
 
-        $crawler = static::$client->submitForm('reset_password[submit]', [
+        $crawler = $this->client->submitForm('reset_password[submit]', [
             'reset_password[email]' => $user->getEmail(),
         ]);
 
@@ -91,15 +91,15 @@ class LoginControllerTest extends WebTestCase
     {
         $user = $this->signup(mt_rand() . 'test@clubalpinlyon.fr');
 
-        static::$client->request('GET', '/password');
+        $this->client->request('GET', '/password');
         $this->assertResponseStatusCodeSame(302);
 
         $this->signin($user);
 
-        static::$client->request('GET', '/password');
+        $this->client->request('GET', '/password');
         $this->assertResponseStatusCodeSame(200);
 
-        static::$client->submitForm('set_password[submit]', [
+        $this->client->submitForm('set_password[submit]', [
             'set_password[password][first]' => '!NewPassw0rd',
             'set_password[password][second]' => '!NewPassw0rd',
         ]);
@@ -123,15 +123,15 @@ class LoginControllerTest extends WebTestCase
         $user->setMdp($hasherFactory->getPasswordHasher('login_form')->hash('!currentPassw0rd'));
         $this->getContainer()->get('doctrine')->getManager()->flush();
 
-        static::$client->request('GET', '/change-password');
+        $this->client->request('GET', '/change-password');
         $this->assertResponseStatusCodeSame(302);
 
         $this->signin($user);
 
-        static::$client->request('GET', '/change-password');
+        $this->client->request('GET', '/change-password');
         $this->assertResponseStatusCodeSame(200);
 
-        static::$client->submitForm('change_password[submit]', [
+        $this->client->submitForm('change_password[submit]', [
             'change_password[current_password]' => '!currentPassw0rd',
             'change_password[password][first]' => '!NewPassw0rd',
             'change_password[password][second]' => '!NewPassw0rd',

--- a/tests/Controller/MonitoringControllerTest.php
+++ b/tests/Controller/MonitoringControllerTest.php
@@ -8,11 +8,11 @@ class MonitoringControllerTest extends WebTestCase
 {
     public function testItsWorkingAsExpected()
     {
-        static::$client->request('GET', '/monitoring/200');
+        $this->client->request('GET', '/monitoring/200');
         $this->assertResponseStatusCodeSame(200);
-        static::$client->request('GET', '/monitoring/500');
+        $this->client->request('GET', '/monitoring/500');
         $this->assertResponseStatusCodeSame(500);
-        static::$client->request('GET', '/monitoring/404');
+        $this->client->request('GET', '/monitoring/404');
         $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -18,7 +18,7 @@ class SortieControllerTest extends WebTestCase
         $event = $this->createEvent($user);
         $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
         $this->getContainer()->get('doctrine')->getManager()->flush();
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(200);
     }
 
@@ -38,7 +38,7 @@ class SortieControllerTest extends WebTestCase
         $event2->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
 
         $this->getContainer()->get('doctrine')->getManager()->flush();
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(200);
     }
 
@@ -48,7 +48,7 @@ class SortieControllerTest extends WebTestCase
         $this->signin($user);
 
         $event = $this->createEvent($user);
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(200);
     }
 
@@ -59,7 +59,7 @@ class SortieControllerTest extends WebTestCase
         $this->signin($user);
 
         $event = $this->createEvent($userOwner);
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(403);
     }
 
@@ -72,7 +72,7 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(200);
     }
 
@@ -85,7 +85,7 @@ class SortieControllerTest extends WebTestCase
         $event = $this->createEvent($userOwner);
         $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
         $this->getContainer()->get('doctrine')->getManager()->flush();
-        static::$client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
+        $this->client->request('GET', sprintf('/sortie/%s-%s.html', $event->getCode(), $event->getId()));
         $this->assertResponseStatusCodeSame(200);
     }
 
@@ -98,8 +98,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_validate'),
+        $this->client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_validate'),
         ]);
         $this->assertResponseStatusCodeSame(302);
 
@@ -122,8 +122,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'invalid_csrf'),
+        $this->client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'invalid_csrf'),
         ]);
         $this->assertResponseStatusCodeSame(400);
     }
@@ -136,8 +136,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($notCommissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_validate'),
+        $this->client->request('POST', sprintf('/sortie/%d/validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_validate'),
         ]);
         $this->assertResponseStatusCodeSame(403);
     }
@@ -151,8 +151,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_refus'),
+        $this->client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_refus'),
             'msg' => 'rien ne va plus',
         ]);
         $this->assertResponseStatusCodeSame(302);
@@ -176,8 +176,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'invalid_csrf'),
+        $this->client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'invalid_csrf'),
             'msg' => 'rien ne va plus',
         ]);
         $this->assertResponseStatusCodeSame(400);
@@ -191,8 +191,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($commissionAdmin);
 
-        static::$client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_refus'),
+        $this->client->request('POST', sprintf('/sortie/%d/refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_refus'),
             'msg' => 'rien ne va plus',
         ]);
         $this->assertResponseStatusCodeSame(403);
@@ -208,8 +208,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($president);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_legal_validate'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_legal_validate'),
         ]);
         $this->assertResponseStatusCodeSame(302);
 
@@ -232,8 +232,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($president);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'invalid_csrf'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'invalid_csrf'),
         ]);
         $this->assertResponseStatusCodeSame(400);
     }
@@ -247,8 +247,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($notPresident);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_legal_validate'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-validate', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_legal_validate'),
         ]);
         $this->assertResponseStatusCodeSame(403);
     }
@@ -263,8 +263,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($president);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_legal_refus'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_legal_refus'),
         ]);
         $this->assertResponseStatusCodeSame(302);
 
@@ -287,8 +287,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($president);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'invalid_csrf'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'invalid_csrf'),
         ]);
         $this->assertResponseStatusCodeSame(400);
     }
@@ -302,8 +302,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($notPresident);
 
-        static::$client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_legal_refus'),
+        $this->client->request('POST', sprintf('/sortie/%d/legal-refus', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_legal_refus'),
         ]);
         $this->assertResponseStatusCodeSame(403);
     }
@@ -319,8 +319,8 @@ class SortieControllerTest extends WebTestCase
         $this->signin($userOwner);
         $this->addAttribute($userOwner, UserAttr::ENCADRANT, 'commission:' . $event->getCommission()->getCode());
 
-        static::$client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_uncancel'),
+        $this->client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_uncancel'),
         ]);
         $this->assertResponseStatusCodeSame(302);
 
@@ -343,8 +343,8 @@ class SortieControllerTest extends WebTestCase
         $this->signin($userOwner);
         $this->addAttribute($userOwner, UserAttr::ENCADRANT, 'commission:' . $event->getCommission()->getCode());
 
-        static::$client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'invalid_csrf'),
+        $this->client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'invalid_csrf'),
         ]);
         $this->assertResponseStatusCodeSame(400);
     }
@@ -361,8 +361,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($anotherUser);
 
-        static::$client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'sortie_uncancel'),
+        $this->client->request('POST', sprintf('/sortie/%d/uncancel', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'sortie_uncancel'),
         ]);
         $this->assertResponseStatusCodeSame(403);
     }
@@ -375,8 +375,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($userOwner);
 
-        static::$client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'contact_participants'),
+        $this->client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'contact_participants'),
             'status_sendmail' => '*',
             'objet' => 'un objet de culte',
             'message' => 'tirelipimpon',
@@ -402,8 +402,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($userOwner);
 
-        static::$client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'contact_participants'),
+        $this->client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'contact_participants'),
             'status_sendmail' => EventParticipation::STATUS_REFUSE,
             'objet' => 'un objet de culte',
             'message' => 'tirelipimpon',
@@ -422,8 +422,8 @@ class SortieControllerTest extends WebTestCase
 
         $this->signin($userOwner);
 
-        static::$client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
-            'csrf_token' => $this->generateCsrfToken(static::$client, 'contact_participants'),
+        $this->client->request('POST', sprintf('/sortie/%d/contact-participants', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'contact_participants'),
             'status_sendmail' => EventParticipation::STATUS_VALIDE,
             'objet' => 'un objet de culte',
             'message' => 'Prout PROUT',

--- a/tests/VarDumper.php
+++ b/tests/VarDumper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Component\VarDumper\Cloner\Cursor;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+class VarDumper extends CliDumper
+{
+    public function enterHash(Cursor $cursor, $type, $class, $hasChild): void
+    {
+        if (Cursor::HASH_INDEXED === $type || Cursor::HASH_ASSOC === $type) {
+            $class = 0;
+        }
+        parent::enterHash($cursor, $type, $class, $hasChild);
+    }
+
+    protected function dumpKey(Cursor $cursor): void
+    {
+        if (Cursor::HASH_INDEXED !== $cursor->hashType) {
+            parent::dumpKey($cursor);
+        } elseif (null !== $cursor->hashKey && $cursor->hardRefTo) {
+            $this->line .= $this->style('ref', '&' . ($cursor->hardRefCount ? $cursor->hardRefTo : ''), ['count' => $cursor->hardRefCount]) . ' ';
+        }
+    }
+}

--- a/tests/VarDumperTestTrait.php
+++ b/tests/VarDumperTestTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+trait VarDumperTestTrait
+{
+    protected $client;
+
+    public function assertDumpEquals($dump, $data, $message = '')
+    {
+        $this->assertSame(rtrim(\is_string($dump) ? $dump : $this->getVarDumperDump($dump)), $this->getVarDumperDump($data), $message);
+    }
+
+    public function assertResponseDumpEquals($dump, $message = '')
+    {
+        if (!$this->client) {
+            throw new \Exception(sprintf('The "%s" method can be used in WebTestCase context', __METHOD__));
+        }
+        $this->assertDumpEquals($dump, json_decode($this->client->getResponse()->getContent(), true), $message);
+    }
+
+    public function assertDumpMatchesFormat($dump, $data, $message = '')
+    {
+        $this->assertStringMatchesFormat(rtrim($dump), $this->getVarDumperDump($data), $message);
+    }
+
+    public function assertResponseDumpMatchesFormat($dump, $message = '')
+    {
+        if (!$this->client) {
+            throw new \Exception(sprintf('The "%s" method can be used in WebTestCase context', __METHOD__));
+        }
+        $this->assertDumpMatchesFormat($dump, json_decode($this->client->getResponse()->getContent(), true), $message);
+    }
+
+    private function getVarDumperDump($data)
+    {
+        $h = fopen('php://memory', 'r+b');
+        $cloner = new VarCloner();
+        $cloner->setMaxItems(-1);
+        $dumper = new VarDumper($h);
+        $dumper->setColors(false);
+        $dumper->dump($cloner->cloneVar($data)->withRefHandles(false));
+        $data = stream_get_contents($h, -1, 0);
+        fclose($h);
+
+        return rtrim($data);
+    }
+}

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -7,7 +7,6 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Repository\UsertypeRepository;
 use App\UserRights;
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -18,12 +17,12 @@ abstract class WebTestCase extends BaseWebTestCase
 {
     use SessionHelper;
 
-    protected static ?KernelBrowser $client;
+    protected $client;
 
     protected function setUp(): void
     {
         parent::setUp();
-        static::$client = static::createClient();
+        $this->client = static::createClient();
     }
 
     protected function signup(?string $email = null)
@@ -85,7 +84,7 @@ abstract class WebTestCase extends BaseWebTestCase
         // the client must register the session cookie
         // taken from TestSessionListener
         $params = session_get_cookie_params();
-        static::$client->getCookieJar()->set(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
+        $this->client->getCookieJar()->set(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
 
         return $user;
     }
@@ -97,7 +96,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $session->save();
 
         $this->getContainer()->get('security.token_storage')->setToken(null);
-        static::$client->getCookieJar()->clear();
+        $this->client->getCookieJar()->clear();
     }
 
     protected function createCommission(string $name = 'Alpinisme'): Commission
@@ -121,6 +120,6 @@ abstract class WebTestCase extends BaseWebTestCase
 
     protected function getSession(): Session
     {
-        return $this->createSession(static::$client);
+        return $this->createSession($this->client);
     }
 }


### PR DESCRIPTION
Je propose de ne pas utiliser de static pour le client browserkit pour eviter les effets de bord d'un test a l'autre, et de repartir pour chaque test avec un client tout frais

j'ajoute aussi le var dumper test trait qui facilite la comparaison de dump de variables, efficace et pratique dans les tests, que j'utilise dans #728