### PR TITLE
Send notification on new article or new event

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -4,7 +4,21 @@ framework:
         failure_transport: failed
 
         transports:
+            alertes:
+                options:
+                    auto_setup: false
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=alertes'
+                retry_strategy:
+                    max_retries: 3
+                    # milliseconds delay
+                    delay: 10000
+                    # causes the delay to be higher before each retry
+                    # e.g. 1 second delay, 2 seconds, 4 seconds
+                    multiplier: 2
+                    max_delay: 0
             mails:
+                options:
+                    auto_setup: false
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 retry_strategy:
                     max_retries: 3
@@ -18,6 +32,9 @@ framework:
             failed: 'doctrine://default?queue_name=failed'
 
         routing:
+            'App\Messenger\Message\ArticlePublie': alertes
+            'App\Messenger\Message\SortiePubliee': alertes
+            'App\Messenger\Message\UserNotification': alertes
             'Symfony\Component\Mailer\Messenger\SendEmailMessage': mails
 
         buses:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -129,6 +129,10 @@ services:
     public: true
     alias: Symfony\Component\Security\Csrf\CsrfTokenManagerInterface
 
+  legacy_message_bus:
+    public: true
+    alias: Symfony\Component\Messenger\MessageBusInterface
+
   legacy_twig:
     public: true
     alias: Twig\Environment

--- a/legacy/scripts/operations/operations.article_validate.php
+++ b/legacy/scripts/operations/operations.article_validate.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Legacy\LegacyContainer;
+use App\Messenger\Message\ArticlePublie;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 $id_article = (int) $_POST['id_article'];
@@ -19,6 +20,9 @@ $authorDatas = null;
 // save
 if (!isset($errTab) || 0 === count($errTab)) {
     $req = "UPDATE caf_article SET status_article='$status_article', status_who_article=" . getUser()->getId() . " WHERE caf_article.id_article =$id_article";
+
+    LegacyContainer::get('legacy_message_bus')->dispatch(new ArticlePublie($id_article));
+
     if (!LegacyContainer::get('legacy_mysqli_handler')->query($req)) {
         $errTab[] = 'Erreur SQL';
     }

--- a/migrations/Version20241025100018.php
+++ b/migrations/Version20241025100018.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241025100018 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE caf_user_notification (id INT AUTO_INCREMENT NOT NULL, user_id BIGINT NOT NULL, type VARCHAR(10) NOT NULL, entity_id VARCHAR(64) NOT NULL, signature VARCHAR(200) NOT NULL, UNIQUE INDEX UNIQ_71260650AE880141 (signature), INDEX IDX_71260650A76ED395 (user_id), INDEX user_notif_signature (signature), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE caf_user_notification ADD CONSTRAINT FK_71260650A76ED395 FOREIGN KEY (user_id) REFERENCES caf_user (id_user) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE caf_user ADD alerts JSON DEFAULT NULL, ADD alert_sortie_prefix VARCHAR(255) DEFAULT \'[CAF-Lyon-Sortie]\' NOT NULL, ADD alert_article_prefix VARCHAR(255) DEFAULT \'[CAF-Lyon-Article]\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_user_notification DROP FOREIGN KEY FK_71260650A76ED395');
+        $this->addSql('DROP TABLE caf_user_notification');
+        $this->addSql('ALTER TABLE caf_user DROP alerts, DROP alert_sortie_prefix, DROP alert_article_prefix');
+    }
+}

--- a/src/Bridge/Twig/TwigExtension.php
+++ b/src/Bridge/Twig/TwigExtension.php
@@ -2,6 +2,7 @@
 
 namespace App\Bridge\Twig;
 
+use App\Entity\AlertType;
 use App\Entity\EventParticipation;
 use App\Entity\Evt;
 use App\Entity\User;
@@ -10,6 +11,7 @@ use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class TwigExtension extends AbstractExtension implements ServiceSubscriberInterface
 {
@@ -26,6 +28,14 @@ class TwigExtension extends AbstractExtension implements ServiceSubscriberInterf
     {
         return [
             SluggerInterface::class,
+        ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('user_has_articles_alerts', [$this, 'getUserHasArticlesAlerts']),
+            new TwigFunction('user_has_sorties_alerts', [$this, 'getUserHasSortiesAlerts']),
         ];
     }
 
@@ -168,5 +178,15 @@ class TwigExtension extends AbstractExtension implements ServiceSubscriberInterf
         $size_compl = \strlen($compl);
 
         return substr($title, 0, 64 - $size_compl) . $compl;
+    }
+
+    public function getUserHasArticlesAlerts(User $user, string $commissionCode)
+    {
+        return $user->hasAlertEnabledOn(AlertType::Article, $commissionCode);
+    }
+
+    public function getUserHasSortiesAlerts(User $user, string $commissionCode)
+    {
+        return $user->hasAlertEnabledOn(AlertType::Sortie, $commissionCode);
     }
 }

--- a/src/Controller/ProfilController.php
+++ b/src/Controller/ProfilController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\AlertType;
+use App\Messenger\Message\ArticlePublie;
+use App\Repository\CommissionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Twig\Attribute\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(path: '/profil', methods: ['GET'])]
+class ProfilController extends AbstractController
+{
+    #[Route(path: '/alertes', name: 'profil_alertes')]
+    #[IsGranted('ROLE_USER')]
+    #[Template('profil/alertes.html.twig')]
+    public function alertes()
+    {
+        return [
+        ];
+    }
+
+    #[Route(path: '/alertes', name: 'profil_alertes_update', methods: ['POST'])]
+    #[IsGranted('ROLE_USER')]
+    public function alertesUpdate(Request $request, CommissionRepository $commissionRepository, EntityManagerInterface $em)
+    {
+        if (!$this->isCsrfTokenValid('profil_alertes_update', $request->request->get('csrf_token'))) {
+            $this->addFlash('error', 'Jeton de validation invalide.');
+
+            return $this->redirect($this->generateUrl('profil_alertes'));
+        }
+
+        $user = $this->getUser();
+        $params = $request->request->all();
+
+        foreach ($commissionRepository->findVisible() as $commission) {
+            $user->setAlertStatus(AlertType::Sortie, $commission->getCode(), ($params['sorties'][$commission->getCode()] ?? '0') === '1');
+            $user->setAlertStatus(AlertType::Article, $commission->getCode(), ($params['articles'][$commission->getCode()] ?? '0') === '1');
+        }
+
+        $user->setAlertStatus(AlertType::Article, ArticlePublie::ACTU_CLUB_RUBRIQUE, ($params['articles'][ArticlePublie::ACTU_CLUB_RUBRIQUE] ?? '0') === '1');
+        $user->setAlertSortiePrefix($params['sortie-prefix-input']);
+        $user->setAlertArticlePrefix($params['article-prefix-input']);
+
+        $em->flush();
+
+        $this->addFlash('success', 'Configuration des alertes mise à jour.');
+
+        return $this->redirect($this->generateUrl('profil_alertes'));
+    }
+}

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -6,6 +6,7 @@ use App\Entity\EventParticipation;
 use App\Entity\Evt;
 use App\Entity\User;
 use App\Mailer\Mailer;
+use App\Messenger\Message\SortiePubliee;
 use App\Repository\EventParticipationRepository;
 use App\Repository\UserRepository;
 use App\Twig\JavascriptGlobalsExtension;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
@@ -56,8 +58,13 @@ class SortieController extends AbstractController
     }
 
     #[Route(name: 'sortie_validate', path: '/sortie/{id}/validate', requirements: ['id' => '\d+'], methods: ['POST'], priority: '10')]
-    public function sortieValidate(Request $request, Evt $event, EntityManagerInterface $em, Mailer $mailer)
-    {
+    public function sortieValidate(
+        Request $request,
+        Evt $event,
+        EntityManagerInterface $em,
+        Mailer $mailer,
+        MessageBusInterface $messageBus,
+    ) {
         if (!$this->isCsrfTokenValid('sortie_validate', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
         }
@@ -68,6 +75,8 @@ class SortieController extends AbstractController
 
         $event->setStatus(Evt::STATUS_LEGAL_VALIDE)->setStatusWho($this->getUser());
         $em->flush();
+
+        $messageBus->dispatch(new SortiePubliee($event->getId()));
 
         $mailer->send($event->getUser(), 'transactional/sortie-publiee', [
             'event_name' => $event->getTitre(),

--- a/src/Entity/AlertType.php
+++ b/src/Entity/AlertType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Entity;
+
+enum AlertType
+{
+    case Article;
+    case Sortie;
+}

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -241,6 +241,13 @@ class Article
         return $this->commission;
     }
 
+    public function setCommission(?Commission $commission)
+    {
+        $this->commission = $commission;
+
+        return $this;
+    }
+
     public function getEvt(): ?Evt
     {
         return $this->evt;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -211,6 +211,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
     #[ORM\Column(name: 'is_deleted', type: 'boolean', nullable: false, options: ['default' => 0])]
     private bool $isDeleted = false;
 
+    #[ORM\Column(type: 'json', nullable: true)]
+    private ?array $alerts = [];
+
+    #[ORM\Column(type: 'string', nullable: false, options: ['default' => '[CAF-Lyon-Sortie]'])]
+    private string $alertSortiePrefix = '[CAF-Lyon-Sortie]';
+
+    #[ORM\Column(type: 'string', nullable: false, options: ['default' => '[CAF-Lyon-Article]'])]
+    private string $alertArticlePrefix = '[CAF-Lyon-Article]';
+
     public function __construct(?int $id = null)
     {
         $this->attrs = new ArrayCollection();
@@ -710,5 +719,47 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
         $this->isDeleted = $isDeleted;
 
         return $this;
+    }
+
+    public function getAlerts(): ?array
+    {
+        return $this->alerts;
+    }
+
+    public function setAlerts(?array $alerts): void
+    {
+        $this->alerts = $alerts;
+    }
+
+    public function hasAlertEnabledOn(AlertType $type, string $commissionCode): bool
+    {
+        return $this->alerts[$commissionCode][$type->name] ?? false;
+    }
+
+    public function setAlertStatus(AlertType $type, string $commissionCode, bool $status): self
+    {
+        $this->alerts[$commissionCode][$type->name] = $status;
+
+        return $this;
+    }
+
+    public function getAlertSortiePrefix(): string
+    {
+        return $this->alertSortiePrefix;
+    }
+
+    public function setAlertSortiePrefix(string $alertSortiePrefix): void
+    {
+        $this->alertSortiePrefix = $alertSortiePrefix;
+    }
+
+    public function getAlertArticlePrefix(): string
+    {
+        return $this->alertArticlePrefix;
+    }
+
+    public function setAlertArticlePrefix(string $alertArticlePrefix): void
+    {
+        $this->alertArticlePrefix = $alertArticlePrefix;
     }
 }

--- a/src/Entity/UserNotification.php
+++ b/src/Entity/UserNotification.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UserNotificationRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'caf_user_notification')]
+#[ORM\Index(name: 'user_notif_signature', columns: ['signature'])]
+#[ORM\Entity(repositoryClass: UserNotificationRepository::class)]
+class UserNotification
+{
+    #[ORM\Column(type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    private int $id;
+
+    #[ORM\ManyToOne(targetEntity: 'User', fetch: 'EAGER')]
+    #[ORM\JoinColumn(referencedColumnName: 'id_user', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(type: 'string', length: 10, nullable: false)]
+    private string $type;
+
+    #[ORM\Column(type: 'string', length: 64, nullable: false)]
+    private string $entityId;
+
+    #[ORM\Column(type: 'string', length: 200, nullable: false, unique: true)]
+    private string $signature;
+
+    public function __construct(User $user, AlertType $type, string|int $entityId)
+    {
+        $this->user = $user;
+        $this->entityId = (string) $entityId;
+        $this->type = $type->name;
+        $this->signature = self::generateSignature($user, $type, $entityId);
+    }
+
+    public static function generateSignature(User $user, AlertType $type, string|int $entityId): string
+    {
+        return sprintf('%s-%s-%s', $user->getId(), $type->name, $entityId);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getEntityId(): string
+    {
+        return $this->entityId;
+    }
+
+    public function setEntityId(string $entityId): void
+    {
+        $this->entityId = $entityId;
+    }
+
+    public function getSignature(): string
+    {
+        return $this->signature;
+    }
+
+    public function setSignature(string $signature): void
+    {
+        $this->signature = $signature;
+    }
+}

--- a/src/Messenger/Message/ArticlePublie.php
+++ b/src/Messenger/Message/ArticlePublie.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Messenger\Message;
+
+class ArticlePublie
+{
+    public const ACTU_CLUB_RUBRIQUE = 'actuclub';
+
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}

--- a/src/Messenger/Message/SortiePubliee.php
+++ b/src/Messenger/Message/SortiePubliee.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Messenger\Message;
+
+class SortiePubliee
+{
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}

--- a/src/Messenger/Message/UserNotification.php
+++ b/src/Messenger/Message/UserNotification.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Messenger\Message;
+
+use App\Entity\AlertType;
+
+class UserNotification
+{
+    public function __construct(
+        public readonly AlertType $alertType,
+        public readonly string $id,
+        public readonly string $userId
+    ) {
+    }
+}

--- a/src/Messenger/MessageHandler/ArticlePublieHandler.php
+++ b/src/Messenger/MessageHandler/ArticlePublieHandler.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Entity\Article;
+use App\Messenger\Message\ArticlePublie;
+use App\Messenger\Message\UserNotification;
+use App\Repository\ArticleRepository;
+use App\Repository\UserRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+class ArticlePublieHandler
+{
+    public function __construct(
+        private readonly ArticleRepository $articleRepository,
+        private readonly UserRepository $userRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(ArticlePublie $message): void
+    {
+        $article = $this->articleRepository->find($message->id);
+
+        if (!$article) {
+            return;
+        }
+
+        if ($article->getCommission()) {
+            $commissionCode = $article->getCommission()->getCode();
+        } elseif ($article->getEvt()) {
+            $commissionCode = $article->getEvt()->getCommission()->getCode();
+        } else {
+            $commissionCode = ArticlePublie::ACTU_CLUB_RUBRIQUE;
+        }
+
+        foreach ($this->userRepository->findUsersIdWithAlert($commissionCode, AlertType::Article) as $userId) {
+            $this->notifyUser($article, $userId);
+        }
+    }
+
+    private function notifyUser(Article $article, int $userId)
+    {
+        $this->messageBus->dispatch(new UserNotification(AlertType::Article, $article->getId(), $userId));
+    }
+}

--- a/src/Messenger/MessageHandler/SortiePublieeHandler.php
+++ b/src/Messenger/MessageHandler/SortiePublieeHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Entity\Evt;
+use App\Messenger\Message\SortiePubliee;
+use App\Messenger\Message\UserNotification;
+use App\Repository\EvtRepository;
+use App\Repository\UserRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+class SortiePublieeHandler
+{
+    public function __construct(
+        private readonly EvtRepository $evtRepository,
+        private readonly UserRepository $userRepository,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(SortiePubliee $message): void
+    {
+        $evt = $this->evtRepository->find($message->id);
+
+        if (!$evt) {
+            return;
+        }
+
+        $commissionCode = $evt->getCommission()->getCode();
+
+        foreach ($this->userRepository->findUsersIdWithAlert($commissionCode, AlertType::Sortie) as $userId) {
+            $this->notifyUser($evt, $userId);
+        }
+    }
+
+    private function notifyUser(Evt $sortie, int $userId): void
+    {
+        $this->messageBus->dispatch(new UserNotification(AlertType::Sortie, $sortie->getId(), $userId));
+    }
+}

--- a/src/Messenger/MessageHandler/UserNotificationHandler.php
+++ b/src/Messenger/MessageHandler/UserNotificationHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Entity\UserNotification as UserNotificationEntity;
+use App\Mailer\Mailer;
+use App\Messenger\Message\UserNotification;
+use App\Repository\ArticleRepository;
+use App\Repository\EvtRepository;
+use App\Repository\UserNotificationRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class UserNotificationHandler
+{
+    public function __construct(
+        private readonly ArticleRepository $articleRepository,
+        private readonly EvtRepository $evtRepository,
+        private readonly UserRepository $userRepository,
+        private readonly UserNotificationRepository $userNotificationRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly Mailer $mailer,
+    ) {
+    }
+
+    public function __invoke(UserNotification $message): void
+    {
+        $entity = match ($message->alertType) {
+            AlertType::Article => $this->articleRepository->find($message->id),
+            AlertType::Sortie => $this->evtRepository->find($message->id),
+            default => null,
+        };
+
+        if (null === $entity) {
+            return;
+        }
+
+        $user = $this->userRepository->find($message->userId);
+
+        if (null === $user) {
+            return;
+        }
+
+        if ($this->userNotificationRepository->hasNotificationBeSent($user, $message->alertType, $message->id)) {
+            return;
+        }
+
+        $notification = new UserNotificationEntity($user, $message->alertType, $message->id);
+        $this->em->persist($notification);
+        $this->em->flush();
+
+        $template = match ($message->alertType) {
+            AlertType::Article => 'transactional/notification-new-article',
+            AlertType::Sortie => 'transactional/notification-new-sortie',
+        };
+
+        $prefix = match ($message->alertType) {
+            AlertType::Article => $user->getAlertArticlePrefix(),
+            AlertType::Sortie => $user->getAlertSortiePrefix(),
+        };
+
+        $this->mailer->send($user, $template, ['entity' => $entity, 'prefix' => $prefix]);
+    }
+}

--- a/src/Repository/UserNotificationRepository.php
+++ b/src/Repository/UserNotificationRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\AlertType;
+use App\Entity\User;
+use App\Entity\UserNotification;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method UserNotification|null find($id, $lockMode = null, $lockVersion = null)
+ * @method UserNotification|null findOneBy(array $criteria, array $orderBy = null)
+ * @method UserNotification[]    findAll()
+ * @method UserNotification[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserNotificationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserNotification::class);
+    }
+
+    public function hasNotificationBeSent(User $user, AlertType $type, string|int $entityId): bool
+    {
+        $sql = 'SELECT id
+            FROM caf_user_notification
+            WHERE signature = :signature';
+
+        return false !== $this->_em->getConnection()->fetchOne($sql, ['signature' => UserNotification::generateSignature($user, $type, $entityId)]);
+    }
+}

--- a/templates/email/transactional/layout.html.twig
+++ b/templates/email/transactional/layout.html.twig
@@ -9,7 +9,7 @@
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
                     <td bgcolor="#ffffff" style="background: #ffffff; border-radius: 2px; padding: 15px 20px;">
-                        <h1>{{ block('subject') }}</h1>
+                        <h1>{% block rappel_objet %}{{ block('subject') }}{% endblock %}</h1>
                         <p>
                             {% block hello %}Bonjour,{% endblock %}
                         </p>

--- a/templates/email/transactional/notification-new-article.html.twig
+++ b/templates/email/transactional/notification-new-article.html.twig
@@ -1,0 +1,24 @@
+{% extends format == 'html' ? 'email/transactional/layout.html.twig' : 'email/transactional/layout.txt.twig' %}
+
+{% block subject -%}
+    {{ prefix }}{% if entity.commission %}[{{ entity.commission.title }}]{% elseif entity.evt %}[Compte Rendu]{% endif %} {{ entity.titre }}
+{%- endblock %}
+
+{% block rappel_objet '' %}
+
+{% block inner_html %}
+    <p>
+        Un {% if entity.evt %}nouveau compte-rendu{% else %}nouvel article{% endif %} "{{ entity.titre }}" vient d'être publié sur le site du Club Alpin Français Lyon-Villeurbanne{% if entity.commission %} dans la commission {{ entity.commission.title }}{% endif %}.
+        <a href="{{ url_site }}/article/{{ entity.code }}-{{ entity.id }}.html">Lire l'article</a>.
+    </p>
+    <p>
+        Vous pouvez gérer vos alertes depuis <a href="{{ url('profil_alertes') }}">votre espace alertes</a>.
+    </p>
+{% endblock %}
+
+{% block inner_txt %}
+    Un {% if entity.evt %}nouveau compte-rendu{% else %}nouvel article{% endif %} "{{ entity.titre }}" vient d'être publié sur le site du Club Alpin Français Lyon-Villeurbanne{% if entity.commission %} dans la commission {{ entity.commission.title }}{% endif %}.
+    Lire l'article ({{ url_site }}/article/{{ entity.code }}-{{ entity.id }}.html)
+
+    Vous pouvez gérer vos alertes depuis votre espace alertes ({{ url('profil_alertes') }}).
+{% endblock %}

--- a/templates/email/transactional/notification-new-sortie.html.twig
+++ b/templates/email/transactional/notification-new-sortie.html.twig
@@ -1,0 +1,24 @@
+{% extends format == 'html' ? 'email/transactional/layout.html.twig' : 'email/transactional/layout.txt.twig' %}
+
+{% block subject -%}
+    {{ prefix }}[{{ entity.commission.title }}] {{ entity.titre }}
+{%- endblock %}
+
+{% block rappel_objet '' %}
+
+{% block inner_html %}
+    <p>
+        Une nouvelle sortie "{{ entity.titre }}" vient d'être publiée sur le site du Club Alpin Français Lyon-Villeurbanne dans la commission {{ entity.commission.title }}.
+        <a href="{{ url('sortie', {code: entity.code, id: entity.id}) }}">Voir la sortie</a>.
+    </p>
+    <p>
+        Vous pouvez gérer vos alertes depuis <a href="{{ url('profil_alertes') }}">votre espace alertes</a>.
+    </p>
+{% endblock %}
+
+{% block inner_txt %}
+    Une nouvelle sortie "{{ entity.titre }}" vient d'être publiée sur le site du Club Alpin Français Lyon-Villeurbanne dans la commission {{ entity.commission.title }}.
+    Voir la sortie ({{ url('sortie', {code: entity.code, id: entity.id}) }}).
+
+    Vous pouvez gérer vos alertes depuis votre espace alertes ({{ url('profil_alertes') }}).
+{% endblock %}

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -198,7 +198,7 @@
                                 <a href="/profil/infos.html" title="">mes infos publiques</a><br />
                                 <a href="/profil/infos.html#private" title="">mes infos privées</a><br />
                                 <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
-                                {#<a href="/profil/filiations.html" title="">filiations</a>#}
+{#                                <a href="{{ path('profil_alertes') }}" title="">mes alertes</a>#}
                             </div>
 
                             <div class="nav-user">

--- a/templates/profil/alertes.html.twig
+++ b/templates/profil/alertes.html.twig
@@ -1,0 +1,99 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Mes alertes{% endblock %}
+
+{% block body %}
+	<div id="left1">
+		<h1 class="page-h1">Mes alertes</h1>
+		<div class="main-type">
+			<p style="margin: 20px 0">
+				Chaque fois qu'un article ou une sortie est publiée sur le site du club, vous pouvez recevoir
+				une alerte par email.<br/><br/>
+				Configurez ici ce que vous souhaitez recevoir.
+			</p>
+
+
+			<form action="{{ path('profil_alertes_update') }}" method="post">
+				<table style="width: 100%;">
+					<thead>
+						<tr>
+							<th style="text-align: left;"></th>
+							<th style="text-align: center;width: 120px;"></th>
+							<th style="text-align: center;width: 120px;"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr style="height:30px;">
+							<td style="text-align: left;">
+								Être alerté lors de la publication d'articles d'actualités du club
+							</td>
+							<td style="text-align: center;">
+								<input value="1" name="articles[{{ constant('App\\Messenger\\Message\\ArticlePublie::ACTU_CLUB_RUBRIQUE') }}]" type="checkbox" {{ user_has_articles_alerts(app.user, constant('App\\Messenger\\Message\\ArticlePublie::ACTU_CLUB_RUBRIQUE')) ? 'checked="checked"' }}/>
+							</td>
+							<td></td>
+						</tr>
+					</tbody>
+				</table>
+				<table style="width: 100%;margin-top: 20px;">
+					<thead>
+					<tr style="height:30px;">
+						<th style="text-align: left;">Être alerté pour la commission</th>
+						<th style="text-align: center;width: 120px;">Articles</th>
+						<th style="text-align: center;width: 120px;">Sorties</th>
+					</tr>
+					</thead>
+					<tbody>
+						{% for commission in list_commissions()|sort((a, b) => a.code <=> b.code) %}
+							<tr style="height:30px;">
+								<td style="text-align: left;">
+									{{ commission.title }}
+								</td>
+								<td style="text-align: center;">
+									<input value="1" name="articles[{{ commission.code }}]" type="checkbox" {{ user_has_articles_alerts(app.user, commission.code) ? 'checked="checked"' }}/>
+								</td>
+								<td style="text-align: center;">
+									<input value="1" name="sorties[{{ commission.code }}]" type="checkbox" {{ user_has_sorties_alerts(app.user, commission.code) ? 'checked="checked"' }} />
+								</td>
+							</tr>
+						{% endfor %}
+					</tbody>
+				</table>
+
+
+				<table style="width: 100%;margin-top: 20px;">
+					<thead>
+						<tr style="height:30px;">
+							<th colspan="2" style="text-align: left;">Prefixe du sujet des emails d'alerte</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr style="height:30px;">
+							<td>
+								<label for="article-prefix-input">Prefixe du sujet des emails d'alerte de nouveaux articles</label>
+							</td>
+							<td style="text-align: right">
+								<input class="type1" id="article-prefix-input" type="text" value="{{ app.user.alertArticlePrefix }}" name="article-prefix-input" />
+							</td>
+						</tr>
+						<tr style="height:30px;">
+							<td>
+								<label for="sortie-prefix-input">Prefixe du sujet des emails d'alerte de nouvelles sorties</label>
+							</td>
+							<td style="text-align: right">
+								<input class="type1" id="sortie-prefix-input" type="text" value="{{ app.user.alertSortiePrefix }}" name="sortie-prefix-input" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p style="text-align: center;margin-top: 20px;">
+					<button type="submit" style="cursor: pointer; border: none;" class="biglink" title="Enregistrer">
+						<span class="bleucaf">&gt;</span>
+						ENREGISTRER MES ALERTES
+					</button>
+				</p>
+				<input type="hidden" name="csrf_token" value="{{ csrf_token('profil_alertes_update') }}" />
+			</form>
+		</div>
+	</div>
+{% endblock %}

--- a/tests/Messenger/MessageHandler/ArticlePublieHandlerTest.php
+++ b/tests/Messenger/MessageHandler/ArticlePublieHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Messenger\Message\ArticlePublie;
+use App\Messenger\MessageHandler\ArticlePublieHandler;
+use App\Repository\ArticleRepository;
+use App\Repository\UserRepository;
+use App\Tests\VarDumperTestTrait;
+use App\Tests\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class ArticlePublieHandlerTest extends WebTestCase
+{
+    use VarDumperTestTrait;
+
+    public function testNotFound()
+    {
+        $handler = new ArticlePublieHandler(
+            self::getContainer()->get(ArticleRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(MessageBusInterface::class),
+        );
+
+        // this id should not exist
+        $handler(new ArticlePublie(2500000));
+
+        $this->assertEmpty(self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages());
+    }
+
+    public function testItDispatchMessages()
+    {
+        $userOwner = $this->signup();
+        $otherUserSubscribed = $this->signup();
+        $otherUserNotSubscribed = $this->signup();
+
+        $article = $this->createArticle($userOwner);
+
+        $userOwner->setAlertStatus(AlertType::Article, $article->getCommission()->getCode(), true);
+        $otherUserSubscribed->setAlertStatus(AlertType::Article, $article->getCommission()->getCode(), true);
+        $otherUserNotSubscribed->setAlertStatus(AlertType::Article, $article->getCommission()->getCode(), false);
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $handler = new ArticlePublieHandler(
+            self::getContainer()->get(ArticleRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(MessageBusInterface::class),
+        );
+
+        $handler(new ArticlePublie($article->getId()));
+
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+
+        // it sends a UserNotification to both two subscribed users
+        $expected = <<<EOEXPECTED
+[
+  App\Messenger\Message\UserNotification {
+    +alertType: App\Entity\AlertType {#1
+      +name: "Article"
+    }
+    +id: "{$article->getId()}"
+    +userId: "{$userOwner->getId()}"
+  }
+  App\Messenger\Message\UserNotification {
+    +alertType: App\Entity\AlertType {#1}
+    +id: "{$article->getId()}"
+    +userId: "{$otherUserSubscribed->getId()}"
+  }
+]
+EOEXPECTED;
+
+        $this->assertDumpMatchesFormat($expected, array_map(static fn ($d) => $d['message'], $messages));
+    }
+}

--- a/tests/Messenger/MessageHandler/SortiePublieeHandlerTest.php
+++ b/tests/Messenger/MessageHandler/SortiePublieeHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Messenger\Message\SortiePubliee;
+use App\Messenger\MessageHandler\SortiePublieeHandler;
+use App\Repository\EvtRepository;
+use App\Repository\UserRepository;
+use App\Tests\VarDumperTestTrait;
+use App\Tests\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class SortiePublieeHandlerTest extends WebTestCase
+{
+    use VarDumperTestTrait;
+
+    public function testNotFound()
+    {
+        $handler = new SortiePublieeHandler(
+            self::getContainer()->get(EvtRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(MessageBusInterface::class),
+        );
+
+        // this id should not exist
+        $handler(new SortiePubliee(2500000));
+
+        $this->assertEmpty(self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages());
+    }
+
+    public function testItDispatchMessages()
+    {
+        $userOwner = $this->signup();
+        $otherUserSubscribed = $this->signup();
+        $otherUserNotSubscribed = $this->signup();
+
+        $evt = $this->createEvent($userOwner);
+
+        $userOwner->setAlertStatus(AlertType::Sortie, $evt->getCommission()->getCode(), true);
+        $otherUserSubscribed->setAlertStatus(AlertType::Sortie, $evt->getCommission()->getCode(), true);
+        $otherUserNotSubscribed->setAlertStatus(AlertType::Sortie, $evt->getCommission()->getCode(), false);
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $handler = new SortiePublieeHandler(
+            self::getContainer()->get(EvtRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(MessageBusInterface::class),
+        );
+
+        $handler(new SortiePubliee($evt->getId()));
+
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+
+        // it sends a UserNotification to both two subscribed users
+        $expected = <<<EOEXPECTED
+[
+  App\Messenger\Message\UserNotification {
+    +alertType: App\Entity\AlertType {#1
+      +name: "Sortie"
+    }
+    +id: "{$evt->getId()}"
+    +userId: "{$userOwner->getId()}"
+  }
+  App\Messenger\Message\UserNotification {
+    +alertType: App\Entity\AlertType {#1}
+    +id: "{$evt->getId()}"
+    +userId: "{$otherUserSubscribed->getId()}"
+  }
+]
+EOEXPECTED;
+
+        $this->assertDumpMatchesFormat($expected, array_map(static fn ($d) => $d['message'], $messages));
+    }
+}

--- a/tests/Messenger/MessageHandler/UserNotificationHandlerTest.php
+++ b/tests/Messenger/MessageHandler/UserNotificationHandlerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Tests\Messenger\MessageHandler;
+
+use App\Entity\AlertType;
+use App\Mailer\Mailer;
+use App\Messenger\Message\UserNotification;
+use App\Messenger\MessageHandler\UserNotificationHandler;
+use App\Repository\ArticleRepository;
+use App\Repository\EvtRepository;
+use App\Repository\UserNotificationRepository;
+use App\Repository\UserRepository;
+use App\Tests\VarDumperTestTrait;
+use App\Tests\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class UserNotificationHandlerTest extends WebTestCase
+{
+    use VarDumperTestTrait;
+
+    public function testNotFound()
+    {
+        $user = $this->signup();
+
+        $handler = new UserNotificationHandler(
+            self::getContainer()->get(ArticleRepository::class),
+            self::getContainer()->get(EvtRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(UserNotificationRepository::class),
+            self::getContainer()->get(EntityManagerInterface::class),
+            self::getContainer()->get(Mailer::class),
+        );
+
+        $handler(new UserNotification(AlertType::Article, 25000000, $user->getId()));
+        $handler(new UserNotification(AlertType::Sortie, 25000000, $user->getId()));
+
+        $emails = $this->getMailerMessages();
+        $this->assertEmpty($emails);
+
+        $article = $this->createArticle($user);
+        $evt = $this->createEvent($user);
+
+        $handler(new UserNotification(AlertType::Article, $article->getId(), 250100000));
+        $handler(new UserNotification(AlertType::Sortie, $evt->getId(), 250100000));
+
+        $emails = $this->getMailerMessages();
+        $this->assertEmpty($emails);
+    }
+
+    public function testItDispatchMessagesSortie()
+    {
+        $userOwner = $this->signup();
+        $otherUserSubscribed = $this->signup();
+
+        $evt = $this->createEvent($userOwner);
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $handler = new UserNotificationHandler(
+            self::getContainer()->get(ArticleRepository::class),
+            self::getContainer()->get(EvtRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(UserNotificationRepository::class),
+            self::getContainer()->get(EntityManagerInterface::class),
+            self::getContainer()->get(Mailer::class),
+        );
+
+        $handler(new UserNotification(AlertType::Sortie, $evt->getId(), $userOwner->getId()));
+
+        // message is sent using queue, for owner
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(1, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(1, $emails);
+
+        $this->assertEmailHeaderSame($emails[0], 'To', sprintf('%s <%s>', $userOwner->getNickname(), $userOwner->getEmail()));
+        $this->assertEmailSubjectContains($emails[0], $userOwner->getAlertSortiePrefix());
+        $this->assertEmailHtmlBodyContains($emails[0], 'Une nouvelle sortie');
+        $this->assertEmailHtmlBodyContains($emails[0], 'vient d\'être publiée sur le site');
+
+        // triggering the notification a second time for owner does not send a new mail
+        $handler(new UserNotification(AlertType::Sortie, $evt->getId(), $userOwner->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(1, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(1, $emails);
+
+        // message is sent using queue, for other user
+        $handler(new UserNotification(AlertType::Sortie, $evt->getId(), $otherUserSubscribed->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(2, $emails);
+
+        $this->assertEmailHeaderSame($emails[1], 'To', sprintf('%s <%s>', $otherUserSubscribed->getNickname(), $otherUserSubscribed->getEmail()));
+        $this->assertEmailSubjectContains($emails[1], $otherUserSubscribed->getAlertSortiePrefix());
+        $this->assertEmailHtmlBodyContains($emails[1], 'Une nouvelle sortie');
+        $this->assertEmailHtmlBodyContains($emails[1], 'vient d\'être publiée sur le site');
+
+        // triggering the notification a second time for owner does not send a new mail
+        $handler(new UserNotification(AlertType::Sortie, $evt->getId(), $otherUserSubscribed->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(2, $emails);
+    }
+
+    public function testItDispatchMessagesArticle()
+    {
+        $userOwner = $this->signup();
+        $otherUserSubscribed = $this->signup();
+
+        $article = $this->createArticle($userOwner);
+
+        self::getContainer()->get(EntityManagerInterface::class)->flush();
+
+        $handler = new UserNotificationHandler(
+            self::getContainer()->get(ArticleRepository::class),
+            self::getContainer()->get(EvtRepository::class),
+            self::getContainer()->get(UserRepository::class),
+            self::getContainer()->get(UserNotificationRepository::class),
+            self::getContainer()->get(EntityManagerInterface::class),
+            self::getContainer()->get(Mailer::class),
+        );
+
+        $handler(new UserNotification(AlertType::Article, $article->getId(), $userOwner->getId()));
+
+        // message is sent using queue, for owner
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(1, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(1, $emails);
+
+        $this->assertEmailHeaderSame($emails[0], 'To', sprintf('%s <%s>', $userOwner->getNickname(), $userOwner->getEmail()));
+        $this->assertEmailSubjectContains($emails[0], $userOwner->getAlertArticlePrefix());
+        $this->assertEmailHtmlBodyContains($emails[0], 'Un nouvel article');
+        $this->assertEmailHtmlBodyContains($emails[0], 'vient d\'être publié sur le site');
+
+        // triggering the notification a second time for owner does not send a new mail
+        $handler(new UserNotification(AlertType::Article, $article->getId(), $userOwner->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(1, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(1, $emails);
+
+        // message is sent using queue, for other user
+        $handler(new UserNotification(AlertType::Article, $article->getId(), $otherUserSubscribed->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(2, $emails);
+
+        $this->assertEmailHeaderSame($emails[1], 'To', sprintf('%s <%s>', $otherUserSubscribed->getNickname(), $otherUserSubscribed->getEmail()));
+        $this->assertEmailSubjectContains($emails[1], $otherUserSubscribed->getAlertArticlePrefix());
+        $this->assertEmailHtmlBodyContains($emails[1], 'Un nouvel article');
+        $this->assertEmailHtmlBodyContains($emails[1], 'vient d\'être publié sur le site');
+
+        // triggering the notification a second time for owner does not send a new mail
+        $handler(new UserNotification(AlertType::Article, $article->getId(), $otherUserSubscribed->getId()));
+        $messages = self::getContainer()->get(MessageBusInterface::class)->getDispatchedMessages();
+        $this->assertCount(2, $messages);
+        $emails = $this->getMailerMessages();
+        $this->assertCount(2, $emails);
+    }
+}

--- a/tests/WebTestCase.php
+++ b/tests/WebTestCase.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests;
 
+use App\Entity\Article;
 use App\Entity\Commission;
+use App\Entity\Evt;
 use App\Entity\User;
 use App\Repository\UserRepository;
 use App\Repository\UsertypeRepository;
@@ -49,6 +51,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $user->setMoreinfo('');
         $user->setCookietoken('');
         $user->setNomadeParent(0);
+        $user->setValid(true);
 
         $em->persist($user);
         $em->flush();
@@ -121,5 +124,39 @@ abstract class WebTestCase extends BaseWebTestCase
     protected function getSession(): Session
     {
         return $this->createSession($this->client);
+    }
+
+    protected function createEvent(User $user): Evt
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $commission = $this->createCommission();
+
+        $event = new Evt($user, $commission, 'Titre !', 'code', new \DateTime('+7 days'), new \DateTime('+8 days'), 'Hotel de ville', 12, 2, 'Une chtite sortie', time(), 12, 12);
+        $em->persist($event);
+        $em->flush();
+
+        return $event;
+    }
+
+    protected function createArticle(User $user): Article
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $commission = $this->createCommission();
+
+        $article = new Article();
+        $article->setUser($user);
+        $article->setTitre('titre');
+        $article->setCommission($commission);
+        $article->setTsp(time());
+        $article->setTspCrea(time());
+        $article->setTspLastedit(new \DateTime());
+        $article->setTopubly(1);
+        $article->setCode(bin2hex(random_bytes(5)));
+        $article->setCont('');
+
+        $em->persist($article);
+        $em->flush();
+
+        return $article;
     }
 }


### PR DESCRIPTION
This PR ads what's necessary to notify users when new articles or events are posted.
It uses a `/profil/alertes` page to configure this. By default, no alerts are sent

![image](https://github.com/user-attachments/assets/c5b30897-ea86-49e6-bc0a-cca235bf3ba8)

There is no menu yet to make this page visible to users, on purpose.
It allows us to test the feature before adding a menu item and unveil it to all users