### PR TITLE
Fix phpstan in GitHub actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,9 @@ jobs:
           export UID_OVERRIDE="$UID"
           export GID_OVERRIDE="$GID"
           make init
+      - name: Setup PHPUnit
+        run: |
+          make phpunit-setup
       - name: Run phpstan
         run: |
           make phpstan

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ ifdef clear
 endif
 	$(PHP) bin/phpunit ${path} $(args)
 
+phpunit-setup: ## Setup phpunit
+	@$(PHP) bin/phpunit --version
+
 database-init-test: ## Init database for test
 
 	$(SYMFONY_CONSOLE) doctrine:database:drop --force --if-exists --env=test


### PR DESCRIPTION
PHPStan requires phpunit to be installed to check for the test suite deps