### PR TITLE
Dockerfile: Remove unused fr_FR locale

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,8 +95,7 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
-RUN echo "fr_FR.UTF-8 UTF-8" >> /etc/locale. &&  locale-gen
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 ENV APACHE_DOC_ROOT=/var/www/html/public


### PR DESCRIPTION
Before this patch, the locale `fr_FR.UTF-8 UTF-8` was appended to a file named `/etc/locale.` instead of `/etc/locale.gen`. I am no expert, but I believe that this may have been a typo.

We have two choices:
* fixing the typo to actually generate the locale; or
* removing the line so that the container image keeps building en_US like it as always done.

Since nobody seems to have noticed the absence of the French locale, I propose here to simply remove the line.