### PR TITLE
Add year in user event listing

### DIFF
--- a/legacy/pages/profil-sorties.php
+++ b/legacy/pages/profil-sorties.php
@@ -227,7 +227,7 @@ if (user()) {
 
                     echo '<tr>'
                             . '<td class="agenda-gauche">'
-                                . (null !== $evt['tsp_evt'] ? jour(date('N', $evt['tsp_evt']), 'short') . ' ' . date('d', $evt['tsp_evt']) . ' ' . mois(date('m', $evt['tsp_evt'])) : '') .
+                                . (null !== $evt['tsp_evt'] ? jour(date('N', $evt['tsp_evt']), 'short') . ' ' . date('d', $evt['tsp_evt']) . ' ' . mois(date('m', $evt['tsp_evt'])) : '') . ' ' . date('Y', $evt['tsp_evt']) .
                                 // STATUT si j'en suis l'auteur :
                                 $status_evt
                             . '</td>'

--- a/public/css/style1.css
+++ b/public/css/style1.css
@@ -276,12 +276,12 @@ table#agenda tr td{border-top:1px solid #c9c9c7; vertical-align:top;}
 table#agenda tr.up td{color:black;}
 table#agenda tr.off td{color:#CCCCCC;}
 table#agenda tr.weekendday td{background-color:#dcf0fa;}
-table#agenda td.agenda-gauche{border-right:1px solid #c9c9c7; width:130px; padding:6px 0 6px 4px; font-size:12px;}
+table#agenda td.agenda-gauche{border-right:1px solid #c9c9c7; width:140px; padding:6px 0 6px 4px; font-size:12px;}
 table#agenda td hr{margin:0 0px 0 5px; padding:0; height:1px; border:none; background:url(../img/bg-dottedhr.png) top left;}
 .agenda-date{float:right; font-family:DIN; color:#B9BFC1; font-size:28px; position:relative; bottom:44px; font-weight:100}
 .agenda-stat{font-size:11px; padding:10px 0 0 133px; color:gray;}
 a.agenda-evt-debut{display:block; clear:both; padding:8px 10px 10px 0;}
-a.agenda-evt-debut .droite{float:right; width:435px;}
+a.agenda-evt-debut .droite{float:right; width:425px;}
 a.agenda-evt-debut .picto{display:block; float:left; border-right:1px solid #dde1e4;}
 a.agenda-evt-debut .picto .picto-light{display:none;}
 a.agenda-evt-debut .picto .picto-dark{opacity:0.3;}


### PR DESCRIPTION
This is quite annoying when scrolling back old events. It's impossible to know when it occured

Before
![image](https://github.com/user-attachments/assets/7faf48ae-b908-4e95-8c71-3606d8441649)

After
![image](https://github.com/user-attachments/assets/13893785-5eb6-4d1e-b290-b259e68773cb)

