### PR TITLE
Fix normalized attachment url for expenses

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,7 +18,7 @@ parameters:
   legacy_env_MAX_ARTICLES_ACCUEIL: "%env(int:MAX_ARTICLES_ACCUEIL)%"
   legacy_env_MAX_IMAGE_SIZE: "%env(int:MAX_IMAGE_SIZE)%"
   legacy_env_DISPLAY_BANNER: "%env(bool:DISPLAY_BANNER)%"
-  legacy_ftp_path: "%kernel.project_dir%/public/ftp/"
+  legacy_ftp_path: "%public_dir%/ftp/"
   legacy_project_dir: "%kernel.project_dir%"
   #configuration extraite de: legacy/config/config.php
   legacy_env_SENTRY_DSN: "%env(string:SENTRY_DSN)%"
@@ -29,6 +29,7 @@ parameters:
   legacy_env_DB_NAME: "%env(string:DB_NAME)%"
   router.request_context.scheme: "%env(string:ROUTER_REQUEST_CONTEXT_SCHEME)%"
   asset.request_context.secure: "%env(bool:ASSET_REQUEST_CONTEXT_SECURE)%"
+  public_dir: "%kernel.project_dir%/public"
 
 services:
   # default configuration for services in *this* file
@@ -190,3 +191,7 @@ services:
   legacy_content_inline:
     public: true
     alias: App\Legacy\ContentInline
+
+  App\Utils\FileUploader:
+    arguments:
+      $publicDir: '%public_dir%'

--- a/src/Controller/Api/ExpenseAttachmentController.php
+++ b/src/Controller/Api/ExpenseAttachmentController.php
@@ -36,10 +36,6 @@ class ExpenseAttachmentController extends AbstractController
 
         $body = $request->getPayload()->all();
 
-        // if (empty($body['expenseReportId'])) {
-        //     throw new BadRequestHttpException('expenseReportId parameter is missing');
-        // }
-
         $expenseReport = $this->expenseReportRepository->findOneBy(['id' => $expenseReportId, 'user' => $user]);
         if (!$expenseReport) {
             throw $this->createNotFoundException('ExpenseReport not found');

--- a/src/Serializer/ExpenseAttachmentNormalizer.php
+++ b/src/Serializer/ExpenseAttachmentNormalizer.php
@@ -25,7 +25,7 @@ class ExpenseAttachmentNormalizer implements NormalizerInterface
         $context[self::ALREADY_CALLED] = true;
 
         // update the filePath with the url
-        $object->setFileUrl($this->fileUploader->getUploadUrl($object->getFilename(), 'expense-attachments'));
+        $object->setFileUrl($this->fileUploader->getUserUploadUrl($object->getUser(), $object->getFilename(), 'expense-attachments'));
 
         return $this->normalizer->normalize($object, $format, $context);
     }


### PR DESCRIPTION
Cette PR corrige le problème d'URL pour les attachments.
L'URL était précédemment construite en utilisant l'utilisateur courant
au lieu de l'utilisateur ayant uploadé le fichier
