### PR TITLE
[WIP] Fix PHPUnit exit code in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,5 +47,10 @@ jobs:
         run: |
           make database-init-test
       - name: Run the unit tests
+        # For an obscure reason, the exit code is 0 even if there are errors.
+        # So we need to grep the output to check if there are errors.
         run: |
-          make tests
+          make tests 2>&1 | tee test_output.txt
+          if grep -E "ERRORS!|There was [0-9]+ failures" test_output.txt; then
+            exit 1
+          fi


### PR DESCRIPTION
PHPUnit returns an exit code of 0 even if there are errors.
As a workaround we grep the output to detect words indicating
there are errors and exit ourselves.

This run seems to be fine https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/actions/runs/11768183158/job/32777724762 even if there are errors. (Check the Run unit test step)