### PR TITLE
Fix "complet" label

### DIFF
--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -78,7 +78,7 @@
 
             <div id="evt-list">
                 {% for event in list_events(get_commission(current_commission)) %}
-                    {% set nInscritsTotal = event.participations([constant('App\\Entity\\EventParticipation::ROLE_INSCRIT'), constant('App\\Entity\\EventParticipation::ROLE_BENEVOLE'), constant('App\\Entity\\EventParticipation::ROLE_MANUEL'), constant('App\\Entity\\EventParticipation::ROLE_COENCADRANT'), constant('App\\Entity\\EventParticipation::ROLE_STAGIAIRE'), constant('App\\Entity\\EventParticipation::ROLE_ENCADRANT')]) | length %}
+                    {% set nInscritsTotal = event.participations() | length %}
                     {% set nPlacesRestantesTotal = max(0, event.ngensMax - nInscritsTotal) %}
                     <a href="/sortie/{{ event.code }}-{{ event.id }}.html?commission={{ event.commission.code }}" title="Voir la sortie">
                         <span style="color:#fff">{{ event.tsp | intldate('ccc d/MM') | capitalize }} </span> |


### PR DESCRIPTION
Matching behavior of red button in Events list : event is full if all spots are taken, not if all _online_ spots are taken (see Slack).

For this booking : <img src="https://github.com/user-attachments/assets/4745799f-5430-4628-bf99-64365fbe1572" width="400">

Before / After :

<img src="https://github.com/user-attachments/assets/bbfb9abe-e6d4-4874-be0a-d15edc83e0dc" width="400">

<img src="https://github.com/user-attachments/assets/0dc74e4d-3213-49b0-b7e1-f0258943330c" width="400">
