### PR TITLE
Fix order of articles in right column

### DIFF
--- a/legacy/includes/droite-actus.php
+++ b/legacy/includes/droite-actus.php
@@ -20,7 +20,7 @@ if ($current_commission) {
         AND  `une_article` =0 '
         // commission donnée : filtre (mais on inclut les actus club, commission=0)
         . ($current_commission ? ' AND (commission_article = ' . (int) $comTab[$current_commission]['id_commission'] . ' OR commission_article = 0) ' : '')
-        . 'ORDER BY  `tsp_article` DESC
+        . 'ORDER BY  `tsp_validate_article` DESC
         LIMIT 16';
 $handleSql = LegacyContainer::get('legacy_mysqli_handler')->query($req);
 


### PR DESCRIPTION
Match behavior of main article list ("Accueil" or "commission" pages) where articles are ordered by original publication date (`tsp_validate_article`) and not last modification date (`tsp_article`)

Right column before editing article :

<img src="https://github.com/user-attachments/assets/9a417fc0-ee3a-4e23-b9ea-a701a38c7807" width="400">

<br>
<br>

After editing article, without and with the fix :

<img src="https://github.com/user-attachments/assets/4b516b95-a880-4fb6-bf95-9ec5da045dd4" width="400">

<img src="https://github.com/user-attachments/assets/9953e466-f52b-429e-801b-e1d197d45612" width="400">

