### PR TITLE
Re-enable diff option in php-cs in the CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: ./.github/actions/prepare
         
       - name: Run php-cs
-        run: make php-cs
+        run: make args=--diff php-cs
 
   phpstan:
     name: phpstan


### PR DESCRIPTION
The check was (inadvertently?) removed in commit e3b1e9f9be6c22613f4e67c95629d9c4e2ab43c5 (https://github.com/Club-Alpin-Lyon-Villeurbanne/caflyon/pull/781)