### PR TITLE
Sort public participation listing

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -899,7 +899,7 @@
                 {% if nInscritsTotal > 0 and not is_granted('MODIFICATION_SORTIE', event) %}
                     <table class="big-lines-table" style="width:570px; margin-left:20px;">
 
-                        {% for inscrit in event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_VALIDE')) %}
+                        {% for inscrit in event.participations(null, constant('App\\Entity\\EventParticipation::STATUS_VALIDE')) | sort((a, b) => a.user.firstname <=> b.user.firstname) %}
                             <td>
                             <td>
                                 {% if allowed('user_read_private', event.commission.code) %}


### PR DESCRIPTION
Le tri actuel de la liste publique des adherents a une sortie est le tri par date d'inscription
Ce changement permet une liste plus facile à lire

![image](https://github.com/user-attachments/assets/7ebeac4a-bdb2-44bd-869e-5ad5624a9fe5)
