### PR TITLE
NDF: Fix rechargement au clic sur button remplacement

### DIFF
--- a/assets/expense-report-form/src/components/ExpenseFieldV2.vue
+++ b/assets/expense-report-form/src/components/ExpenseFieldV2.vue
@@ -21,6 +21,7 @@
         <button 
           @click="openFileInput"
           class="tw-text-gray-600 hover:tw-text-gray-800"
+          type="button"
         >
           Remplacer
         </button>


### PR DESCRIPTION
Sans le type, le clic sur le bouton fait que la page se recharge (et on perd tout ce qu'on a déjà saisi)