### PR TITLE
Enhance FFCAM synchronization to automatically merge same members

### DIFF
--- a/legacy/scripts/operations/operations.user_edit.php
+++ b/legacy/scripts/operations/operations.user_edit.php
@@ -29,7 +29,7 @@ if (0 != strlen($userTab['cafnum_user_new']) && ((!is_numeric($userTab['cafnum_u
 
 if (!isset($errTab) || 0 === count($errTab)) {
     if ($userTab['cafnum_user_new'] > 0) {
-        LegacyContainer::get('legacy_member_merger')->mergeMembers($userTab['cafnum_user'], $userTab['cafnum_user_new']);
+        LegacyContainer::get('legacy_member_merger')->mergeExistingMembers($userTab['cafnum_user'], $userTab['cafnum_user_new']);
         $userTab['cafnum_user'] = $userTab['cafnum_user_new'];
     }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -146,4 +146,25 @@ SQL;
             \Sentry\captureException($exc);
         }
     }
+
+    public function findDuplicateUser(string $lastname, string $firstname, string $birthday, string $excludeCafnum): ?User
+    {
+        return $this->createQueryBuilder('u')
+            ->where('u.lastname = :lastname')
+            ->andWhere('u.firstname = :firstname')
+            ->andWhere('u.birthday = :birthday')
+            ->andWhere('u.cafnum != :excludeCafnum')
+            ->andWhere('u.doitRenouveler = true')
+            ->andWhere('u.isDeleted = false')
+            ->orderBy('u.tsInsert', 'DESC')
+            ->setMaxResults(1)
+            ->setParameters([
+                'lastname' => $lastname,
+                'firstname' => $firstname,
+                'birthday' => $birthday,
+                'excludeCafnum' => $excludeCafnum,
+            ])
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -7,25 +7,39 @@ use App\Service\FfcamSynchronizer;
 use App\Tests\TestHelpers\FfcamTestHelper;
 use App\Tests\WebTestCase;
 use Doctrine\ORM\EntityManagerInterface;
+use Faker\Factory;
 use SlopeIt\ClockMock\ClockMock;
 
 class FfcamSynchronizerTest extends WebTestCase
 {
+    private $faker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->faker = Factory::create('fr_FR');
+    }
+
     public function testSynchronizeCreatesNewUsers(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
         $identifiant2 = rand(100000000000, 999999999999);
 
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+        $lastname2 = $this->faker->lastName();
+        $firstname2 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
             ],
             [
                 'cafnum' => $identifiant2,
-                'lastname' => 'MARTIN',
-                'firstname' => 'PIERRE',
+                'lastname' => $lastname2,
+                'firstname' => $firstname2,
             ],
         ]);
 
@@ -38,24 +52,29 @@ class FfcamSynchronizerTest extends WebTestCase
 
         $user1 = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($identifiant1);
         $this->assertNotNull($user1->getId());
-        $this->assertEquals('Jean', $user1->getFirstname());
-        $this->assertEquals('Dupont', $user1->getLastname());
+        $this->assertEquals(mb_strtolower($firstname1), mb_strtolower($user1->getFirstname()));
+        $this->assertEquals(mb_strtolower($lastname1), mb_strtolower($user1->getLastname()));
         $this->assertEquals('0687000001', $user1->getTel());
         $this->assertEquals('Lyon', $user1->getVille());
 
         $user2 = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($identifiant2);
         $this->assertNotNull($user2->getId());
-        $this->assertEquals('Pierre', $user2->getFirstname());
+        $this->assertEquals(mb_strtolower($firstname2), mb_strtolower($user2->getFirstname()));
+        $this->assertEquals(mb_strtolower($lastname2), mb_strtolower($user2->getLastname()));
     }
 
     public function testSynchronizeUpdatesExistingUsers(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
+
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
             ],
         ]);
 
@@ -63,7 +82,7 @@ class FfcamSynchronizerTest extends WebTestCase
         $existingUser = $this->signup();
         $existingUser
             ->setCafnum($identifiant1)
-            ->setFirstname('Jeanne')
+            ->setFirstname($firstname1)
             ->setEmail($email)
             ->setPassword('hashedpassword');
 
@@ -76,8 +95,8 @@ class FfcamSynchronizerTest extends WebTestCase
 
         $em->refresh($existingUser);
 
-        $this->assertEquals('Jean', $existingUser->getFirstname());
-        $this->assertEquals('Dupont', $existingUser->getLastname());
+        $this->assertEquals(mb_strtolower($firstname1), mb_strtolower($existingUser->getFirstname()));
+        $this->assertEquals(mb_strtolower($lastname1), mb_strtolower($existingUser->getLastname()));
         $this->assertEquals('0687000001', $existingUser->getTel());
         $this->assertEquals($email, $existingUser->getEmail());
         $this->assertEquals('hashedpassword', $existingUser->getPassword());
@@ -86,11 +105,14 @@ class FfcamSynchronizerTest extends WebTestCase
     public function testSynchronizeSetsLicenceExpiredFlagOnly(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
                 'adhesionDate' => '0000-00-00',
             ],
         ]);
@@ -122,11 +144,14 @@ class FfcamSynchronizerTest extends WebTestCase
     public function testSynchronizeSetsExpiredAndRenewalFlag(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
                 'adhesionDate' => '0000-00-00',
             ],
         ]);
@@ -158,11 +183,14 @@ class FfcamSynchronizerTest extends WebTestCase
     public function testSynchronizeBlocksExpiredAccounts(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
                 'adhesionDate' => '0000-00-00',
             ],
         ]);
@@ -189,11 +217,14 @@ class FfcamSynchronizerTest extends WebTestCase
     public function testSynchronizeUnblocksExpiredAccounts(): void
     {
         $identifiant1 = rand(100000000000, 999999999999);
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
         $filePath = FfcamTestHelper::generateFile([
             [
                 'cafnum' => $identifiant1,
-                'lastname' => 'DUPONT',
-                'firstname' => 'JEAN',
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
                 'adhesionDate' => '2024-11-15',
             ],
         ]);
@@ -216,8 +247,146 @@ class FfcamSynchronizerTest extends WebTestCase
         $em->refresh($expiredUser);
 
         $this->assertFalse($expiredUser->getDoitRenouveler());
-        $this->assertFalse($expiredUser->getDoitRenouveler());
+        $this->assertFalse($expiredUser->getAlerteRenouveler());
 
         ClockMock::reset();
+    }
+
+    public function testSynchronizeDetectsAndMergesDuplicateUsers(): void
+    {
+        $identifiant1 = rand(100000000000, 999999999999);
+        $identifiant2 = rand(100000000000, 999999999999);
+
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+        $email1 = $this->faker->email();
+
+        $existingUser = $this->signup();
+        $existingUser
+            ->setCafnum($identifiant1)
+            ->setFirstname($firstname1)
+            ->setLastname($lastname1)
+            ->setBirthday('631152000') // 1990-01-01
+            ->setDoitRenouveler(true)
+            ->setEmail($email1)
+            ->setPassword('hashedpassword');
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($existingUser);
+        $em->flush();
+
+        $filePath = FfcamTestHelper::generateFile([
+            [
+                'cafnum' => $identifiant2,
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
+                'birthday' => '1990-01-01', // 1990-01-01
+            ],
+        ]);
+
+        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
+        $synchronizer->synchronize($filePath);
+
+        $em->refresh($existingUser);
+        $this->assertEquals($identifiant2, $existingUser->getCafnum());
+        $this->assertEquals($email1, $existingUser->getEmail());
+        $this->assertEquals('hashedpassword', $existingUser->getPassword());
+
+        $duplicateUser = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($identifiant1);
+        $this->assertNull($duplicateUser);
+    }
+
+    public function testSynchronizeDoesNotMergeNonExpiredUsers(): void
+    {
+        $identifiant1 = rand(100000000000, 999999999999);
+        $identifiant2 = rand(100000000000, 999999999999);
+
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
+        $existingUser = $this->signup();
+        $existingUser
+            ->setCafnum($identifiant1)
+            ->setFirstname($firstname1)
+            ->setLastname($lastname1)
+            ->setBirthday('631152000') // 1990-01-01
+            ->setDoitRenouveler(false)
+            ->setAlerteRenouveler(false);
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($existingUser);
+        $em->flush();
+
+        $filePath = FfcamTestHelper::generateFile([
+            [
+                'cafnum' => $identifiant2,
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
+                'birthday' => '1990-01-01', // 1990-01-01
+            ],
+        ]);
+
+        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
+        $synchronizer->synchronize($filePath);
+
+        $user1 = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($identifiant1);
+        $user2 = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($identifiant2);
+
+        $this->assertNotNull($user1);
+        $this->assertNotNull($user2);
+        $this->assertNotEquals($user1->getId(), $user2->getId());
+    }
+
+    public function testSynchronizeSelectsMostRecentDuplicate(): void
+    {
+        $identifiant1 = rand(100000000000, 999999999999);
+        $identifiant2 = rand(100000000000, 999999999999);
+        $identifiant3 = rand(100000000000, 999999999999);
+
+        $lastname1 = $this->faker->lastName();
+        $firstname1 = $this->faker->firstName();
+
+        $existingUser1 = $this->signup();
+        $existingUser1
+            ->setCafnum($identifiant1)
+            ->setFirstname($firstname1)
+            ->setLastname($lastname1)
+            ->setBirthday('631152000') // 1990-01-01
+            ->setTsInsert(time() - 3600)
+            ->setDoitRenouveler(true);
+
+        $existingUser2 = $this->signup();
+        $existingUser2
+            ->setCafnum($identifiant2)
+            ->setFirstname($firstname1)
+            ->setLastname($lastname1)
+            ->setBirthday('631152000') // 1990-01-01
+            ->setTsInsert(time())
+            ->setDoitRenouveler(true);
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($existingUser1);
+        $em->persist($existingUser2);
+        $em->flush();
+
+        $filePath = FfcamTestHelper::generateFile([
+            [
+                'cafnum' => $identifiant3,
+                'lastname' => $lastname1,
+                'firstname' => $firstname1,
+                'birthday' => '1990-01-01',
+            ],
+        ]);
+
+        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
+        $synchronizer->synchronize($filePath);
+
+        // Vérifie que c'est bien l'utilisateur le plus récent qui a été mis à jour
+        $em->refresh($existingUser2);
+        $this->assertEquals($identifiant3, $existingUser2->getCafnum());
+
+        // Vérifie que l'ancien utilisateur n'a pas été modifié
+        $em->refresh($existingUser1);
+        $this->assertEquals($identifiant1, $existingUser1->getCafnum());
     }
 }

--- a/tests/TestHelpers/FfcamTestHelper.php
+++ b/tests/TestHelpers/FfcamTestHelper.php
@@ -4,7 +4,7 @@ namespace App\Tests\TestHelpers;
 
 class FfcamTestHelper
 {
-    private const TEMPLATE = '%s;6900;%s;99;A1;;1986-02-24;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;0687000001;;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
+    private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;0687000001;;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
 
     public static function generateFile(array $members): string
     {
@@ -17,14 +17,16 @@ class FfcamTestHelper
             $lastname = $member['lastname'] ?? 'DUPONT';
             $firstname = $member['firstname'] ?? 'JEAN';
             $adhesionDate = $member['adhesionDate'] ?? '0000-00-00';
+            $birthday = $member['birthday'] ?? '1990-01-01';
 
             $content .= sprintf(
                 self::TEMPLATE,
                 $cafnum,
                 $shortCafnum,
+                $birthday,
                 $adhesionDate,
                 $lastname,
-                $firstname
+                $firstname,
             ) . "\n";
         }
 

--- a/tests/Utils/MemberMergerTest.php
+++ b/tests/Utils/MemberMergerTest.php
@@ -8,7 +8,7 @@ use App\Utils\MemberMerger;
 
 class MemberMergerTest extends WebTestCase
 {
-    public function testMergeMembers(): void
+    public function testMergeExistingMembers(): void
     {
         $entityManager = static::getContainer()->get('doctrine')->getManager();
         $memberMerger = static::getContainer()->get(MemberMerger::class);
@@ -19,12 +19,38 @@ class MemberMergerTest extends WebTestCase
         $oldLicense = $user1->getCafnum();
         $newLicense = $user2->getCafnum();
 
-        $memberMerger->mergeMembers($oldLicense, $newLicense);
+        $memberMerger->mergeExistingMembers($oldLicense, $newLicense);
 
         $userOldLicense = $entityManager->getRepository(User::class)->findOneByLicenseNumber("obs_{$newLicense}");
         $userNewLicense = $entityManager->getRepository(User::class)->findOneByLicenseNumber($newLicense);
 
         $this->assertSame($userNewLicense->getId(), $user1->getId());
         $this->assertSame($userOldLicense->getId(), $user2->getId());
+    }
+
+    public function testMergeNewMember(): void
+    {
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+        $memberMerger = static::getContainer()->get(MemberMerger::class);
+
+        $user1 = $this->signup();
+        $user2 = new User();
+
+        $user2Cafnum = mt_rand(100000000000, 999999999999);
+        $user2->setEmail('test-' . bin2hex(random_bytes(12)) . '@clubalpinlyon.fr')
+            ->setCafnum($user2Cafnum)
+            ->setFirstname('prenom')
+            ->setLastname('nom')
+            ->setDoitRenouveler(false)
+            ->setAlerteRenouveler(false);
+
+        $oldLicense = $user1->getCafnum();
+
+        $memberMerger->mergeNewMember($oldLicense, $user2);
+
+        $userOldLicense = $entityManager->getRepository(User::class)->findOneByLicenseNumber("obs_{$user2Cafnum}");
+        $userNewLicense = $entityManager->getRepository(User::class)->findOneByLicenseNumber($user2Cafnum);
+
+        $this->assertSame($userNewLicense->getId(), $user1->getId());
     }
 }


### PR DESCRIPTION
This PR updates the FFCAM synchronization process to automatically merge same
users based on firstname, lastname, birthday, renew flag enabled and different
cafnum user.
