### PR TITLE
Fix cron code too long error by using fixed-size hash

### DIFF
--- a/legacy/app/cron/cron_rappel.php
+++ b/legacy/app/cron/cron_rappel.php
@@ -36,7 +36,6 @@ function cron_email($datas)
 
     LegacyContainer::get('legacy_mailer')->send($datas['to'], $datas['template'], $datas['context']);
 
-    error_log($datas['code']);
     $req = "INSERT INTO caf_chron_operation(tsp_chron_operation, code_chron_operation, parent_chron_operation)
                                 VALUES ('" . time() . "',  '" . $datas['code'] . "',  '" . $datas['parent'] . "');";
 


### PR DESCRIPTION
Fixes an error caught in Clevercloud logs 

Data too long for column 'code_chron_operation' at row 1 
