### PR TITLE
Fix highlighted articles disappearance on some conditions

### DIFF
--- a/legacy/scripts/operations/operations.article_validate.php
+++ b/legacy/scripts/operations/operations.article_validate.php
@@ -41,7 +41,7 @@ if (!isset($errTab) || 0 === count($errTab)) {
         $errTab[] = 'User or article not found';
     }
 
-    $sql = 'SELECT (COUNT(id_article) - 5) as total FROM caf_article WHERE status_article > 0 AND une_article > 0';
+    $sql = 'SELECT (COUNT(id_article) - 5) as total FROM caf_article WHERE status_article = 1 AND une_article = 1';
     $result = LegacyContainer::get('legacy_mysqli_handler')->query($sql);
 
     if ($result && $row = $result->fetch_assoc()) {


### PR DESCRIPTION
Due to a wrong check in database, if we had more than 5 articles denied
but with the highlight feature checked, adding a new highlighted article
resulted in a blank screen in the slider because we reached the limit of 5
highlighted articles.
