### PR TITLE
Update code to allow multi-tenancy

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 SITENAME="Club Alpin Français de Lyon-Villeurbanne"
+CAF_ID="lyon"
 
 ANALYTICS_ACCOUNT=
 GOOGLE_SITE_VERIFICATION=
@@ -45,6 +46,8 @@ MAX_SORTIES_VALIDATION=10
 MAX_ARTICLES_ADHERENT=10
 MAX_ARTICLES_ACCUEIL=16
 MAX_IMAGE_SIZE=1000
+ALERT_SORTIE_PREFIX="[CAF-Lyon-Sortie]"
+ALERT_ARTICLE_PREFIX="[CAF-Lyon-Article]"
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -9,6 +9,9 @@ twig:
         google_site_verification: "%env(GOOGLE_SITE_VERIFICATION)%"
         display_banner:  "%env(bool:DISPLAY_BANNER)%"
         whatsapp_commu_link: "%env(WHATSAPP_COMMU_LINK)%"
+        caf_id: "%env(CAF_ID)%"
+        default_alert_article_prefix: "%env(ALERT_ARTICLE_PREFIX)%"
+        default_alert_sortie_prefix: "%env(ALERT_SORTIE_PREFIX)%"
 
 when@test:
     twig:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,7 +20,7 @@ parameters:
   legacy_env_DISPLAY_BANNER: "%env(bool:DISPLAY_BANNER)%"
   legacy_ftp_path: "%public_dir%/ftp/"
   legacy_project_dir: "%kernel.project_dir%"
-  #configuration extraite de: legacy/config/config.php
+  legacy_env_SITENAME: "%env(string:SITENAME)%"
   legacy_env_SENTRY_DSN: "%env(string:SENTRY_DSN)%"
   legacy_env_DB_HOST: "%env(string:DB_HOST)%"
   legacy_env_DB_PORT: "%env(int:DB_PORT)%"
@@ -114,6 +114,11 @@ services:
 
   Symfony\Component\String\Slugger\SluggerInterface:
     class: Symfony\Component\String\Slugger\AsciiSlugger
+
+  App\Messenger\MessageHandler\UserNotificationHandler:
+    arguments:
+      $defaultAlertArticlePrefix: "%env(ALERT_ARTICLE_PREFIX)%"
+      $defaultAlertSortiePrefix: "%env(ALERT_SORTIE_PREFIX)%"
 
   # services used in legacy
   legacy_router:

--- a/legacy/config/params.php
+++ b/legacy/config/params.php
@@ -3,12 +3,6 @@
 date_default_timezone_set('Europe/Paris');
 setlocale(\LC_ALL, 'fr_FR');
 
-// NOM DU SITE ( apparaît notamment dans les e-mailings )
-$p_sitename = 'CAF Lyon Villeurbanne';
-
-// destinataire principal
-$p_contactdusite = 'sitemestre@clubalpinlyon.fr';
-
 // -------------------
 // PARAMS STATIQUES
 

--- a/legacy/config/staging/params.php
+++ b/legacy/config/staging/params.php
@@ -3,12 +3,6 @@
 date_default_timezone_set('Europe/Paris');
 setlocale(\LC_ALL, 'fr_FR');
 
-// NOM DU SITE ( apparaît notamment dans les e-mailings )
-$p_sitename = 'CAF Lyon Villeurbanne';
-
-// destinataire principal
-$p_contactdusite = 'sitemestre@clubalpinlyon.fr';
-
 // -------------------
 // PARAMS STATIQUES
 

--- a/legacy/config/www.clubalpinlyon.fr/params.php
+++ b/legacy/config/www.clubalpinlyon.fr/params.php
@@ -3,12 +3,6 @@
 date_default_timezone_set('Europe/Paris');
 setlocale(\LC_ALL, 'fr_FR');
 
-// NOM DU SITE ( apparaît notamment dans les e-mailings )
-$p_sitename = 'CAF Lyon Villeurbanne';
-
-// destinataire principal
-$p_contactdusite = 'sitemestre@clubalpinlyon.fr';
-
 // -------------------
 // PARAMS STATIQUES
 

--- a/legacy/includes/evt/feuille_de_sortie.php
+++ b/legacy/includes/evt/feuille_de_sortie.php
@@ -52,7 +52,7 @@ $nAccepteesCalc = count($evt['joins']['encadrant']) + count($evt['joins']['stagi
 presidence();
 
 $logo = LegacyContainer::get('legacy_content_inline')->getLogo();
-
+$p_sitename = LegacyContainer::getParameter('legacy_env_SITENAME');
 ?>
 
 <table style="border:0; padding:0; margin:0;">

--- a/legacy/includes/generic/header.php
+++ b/legacy/includes/generic/header.php
@@ -6,6 +6,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 global $ogImage;
 $jwt = LegacyContainer::get(JwtExtension::class)->generateJwtToken();
+$p_sitename = LegacyContainer::getParameter('legacy_env_SITENAME');
 ?>
 	<!-- vars php passées au js -->
     <script type="text/javascript">

--- a/legacy/index.php
+++ b/legacy/index.php
@@ -27,7 +27,7 @@ $versCettePage = $p1 . ($p2 ? '/' . $p2 : '') . ($p3 ? '/' . $p3 : '') . ($p4 ? 
     </title>
     <base href="<?php echo LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL); ?>" />
     <meta name="description" content="<?php echo html_utf8($meta_description); ?>">
-    <meta name="author" content="Club Alpin Français de Lyon-Villeurbanne">
+    <meta name="author" content="<?php echo LegacyContainer::getParameter('legacy_env_SITENAME'); ?>">
     <meta name="viewport" content="width=1200">
     <?php
     if (LegacyContainer::getParameter('legacy_env_GOOGLE_SITE_VERIFICATION')) {

--- a/legacy/pages/accueil.php
+++ b/legacy/pages/accueil.php
@@ -3,6 +3,7 @@
 use App\Legacy\LegacyContainer;
 
 $MAX_ARTICLES_ACCUEIL = LegacyContainer::getParameter('legacy_env_MAX_ARTICLES_ACCUEIL');
+$p_sitename = LegacyContainer::getParameter('legacy_env_SITENAME');
 
 $sliderTab = [];
 $articlesTab = [];

--- a/legacy/pages/article.php
+++ b/legacy/pages/article.php
@@ -7,6 +7,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 $article = false;
 $errPage = false; // message d'erreur spécifique à la page courante si besoin
 $id_article = (int) substr(strrchr($p2, '-'), 1);
+$p_sitename = LegacyContainer::getParameter('legacy_env_SITENAME');
 
 // sélection complète, non conditionnelle par rapport au status
 $req = "SELECT *

--- a/migrations/Version20241209144056.php
+++ b/migrations/Version20241209144056.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241209144056 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE caf_user CHANGE alert_sortie_prefix alert_sortie_prefix VARCHAR(255) NULL, CHANGE alert_article_prefix alert_article_prefix VARCHAR(255) NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_user CHANGE alert_sortie_prefix alert_sortie_prefix VARCHAR(255) DEFAULT \'[CAF-Lyon-Sortie]\' NOT NULL, CHANGE alert_article_prefix alert_article_prefix VARCHAR(255) DEFAULT \'[CAF-Lyon-Article]\' NOT NULL');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -215,11 +215,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
     #[ORM\Column(type: 'json', nullable: true, options: ['default' => EmailAlerts::DEFAULT_ALERTS_JSON])]
     private ?array $alerts = EmailAlerts::DEFAULT_ALERTS;
 
-    #[ORM\Column(type: 'string', nullable: false, options: ['default' => '[CAF-Lyon-Sortie]'])]
-    private string $alertSortiePrefix = '[CAF-Lyon-Sortie]';
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $alertSortiePrefix = null;
 
-    #[ORM\Column(type: 'string', nullable: false, options: ['default' => '[CAF-Lyon-Article]'])]
-    private string $alertArticlePrefix = '[CAF-Lyon-Article]';
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $alertArticlePrefix = null;
 
     public function __construct(?int $id = null)
     {
@@ -744,7 +744,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
         return $this;
     }
 
-    public function getAlertSortiePrefix(): string
+    public function getAlertSortiePrefix(): ?string
     {
         return $this->alertSortiePrefix;
     }
@@ -754,7 +754,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
         $this->alertSortiePrefix = $alertSortiePrefix;
     }
 
-    public function getAlertArticlePrefix(): string
+    public function getAlertArticlePrefix(): ?string
     {
         return $this->alertArticlePrefix;
     }

--- a/src/Messenger/MessageHandler/UserNotificationHandler.php
+++ b/src/Messenger/MessageHandler/UserNotificationHandler.php
@@ -23,6 +23,8 @@ class UserNotificationHandler
         private readonly UserNotificationRepository $userNotificationRepository,
         private readonly EntityManagerInterface $em,
         private readonly Mailer $mailer,
+        private readonly string $defaultAlertArticlePrefix,
+        private readonly string $defaultAlertSortiePrefix,
     ) {
     }
 
@@ -58,8 +60,8 @@ class UserNotificationHandler
         };
 
         $prefix = match ($message->alertType) {
-            AlertType::Article => $user->getAlertArticlePrefix(),
-            AlertType::Sortie => $user->getAlertSortiePrefix(),
+            AlertType::Article => $user->getAlertArticlePrefix() ?? $this->defaultAlertArticlePrefix,
+            AlertType::Sortie => $user->getAlertSortiePrefix() ?? $this->defaultAlertSortiePrefix,
         };
 
         $this->mailer->send($user, $template, ['entity' => $entity, 'prefix' => $prefix]);

--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -133,7 +133,7 @@
                         <div class="nav-user">
                             <p class="menutitle">Mes sorties</p>
 
-                                {% if app.user %}
+                                {% if app.user and caf_id == 'lyon' %}
                                     <a href="{{ path('minibus') }}" title="">
                                         <span class="star">
                                             <img src="/img/base/bullet_star.png" alt="" title="" />
@@ -197,7 +197,9 @@
 
                                 <a href="/profil/infos.html" title="">mes infos publiques</a><br />
                                 <a href="/profil/infos.html#private" title="">mes infos privées</a><br />
-                                <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
+                                {% if caf_id == 'lyon' %}
+                                    <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
+                                {% endif %}
                                 <a href="{{ path('profil_alertes') }}" title="">mes alertes</a>
                             </div>
 

--- a/templates/profil/alertes.html.twig
+++ b/templates/profil/alertes.html.twig
@@ -72,7 +72,7 @@
 								<label for="article-prefix-input">Prefixe du sujet des emails d'alerte de nouveaux articles</label>
 							</td>
 							<td style="text-align: right">
-								<input class="type1" id="article-prefix-input" type="text" value="{{ app.user.alertArticlePrefix }}" name="article-prefix-input" />
+								<input class="type1" id="article-prefix-input" type="text" value="{{ app.user.alertArticlePrefix ?? default_alert_article_prefix }}" name="article-prefix-input" />
 							</td>
 						</tr>
 						<tr style="height:30px;">
@@ -80,7 +80,7 @@
 								<label for="sortie-prefix-input">Prefixe du sujet des emails d'alerte de nouvelles sorties</label>
 							</td>
 							<td style="text-align: right">
-								<input class="type1" id="sortie-prefix-input" type="text" value="{{ app.user.alertSortiePrefix }}" name="sortie-prefix-input" />
+								<input class="type1" id="sortie-prefix-input" type="text" value="{{ app.user.alertSortiePrefix ?? default_alert_sortie_prefix }}" name="sortie-prefix-input" />
 							</td>
 						</tr>
 					</tbody>

--- a/tests/Messenger/MessageHandler/UserNotificationHandlerTest.php
+++ b/tests/Messenger/MessageHandler/UserNotificationHandlerTest.php
@@ -30,6 +30,9 @@ class UserNotificationHandlerTest extends WebTestCase
             self::getContainer()->get(UserNotificationRepository::class),
             self::getContainer()->get(EntityManagerInterface::class),
             self::getContainer()->get(Mailer::class),
+
+            '[CAF-Sortie]',
+            '[CAF-Article]',
         );
 
         $handler(new UserNotification(AlertType::Article, 25000000, $user->getId()));
@@ -50,8 +53,12 @@ class UserNotificationHandlerTest extends WebTestCase
 
     public function testItDispatchMessagesSortie()
     {
+        $defaultAlertSortiePrefix = '[CAF-Sortie]';
+        $defaultAlertArticlePrefix = '[CAF-Article]';
+
         $userOwner = $this->signup();
         $otherUserSubscribed = $this->signup();
+        $otherUserSubscribed->setAlertSortiePrefix('Test');
 
         $evt = $this->createEvent($userOwner);
 
@@ -64,6 +71,8 @@ class UserNotificationHandlerTest extends WebTestCase
             self::getContainer()->get(UserNotificationRepository::class),
             self::getContainer()->get(EntityManagerInterface::class),
             self::getContainer()->get(Mailer::class),
+            $defaultAlertArticlePrefix,
+            $defaultAlertSortiePrefix,
         );
 
         $handler(new UserNotification(AlertType::Sortie, $evt->getId(), $userOwner->getId()));
@@ -75,7 +84,7 @@ class UserNotificationHandlerTest extends WebTestCase
         $this->assertCount(1, $emails);
 
         $this->assertEmailHeaderSame($emails[0], 'To', sprintf('%s <%s>', $userOwner->getNickname(), $userOwner->getEmail()));
-        $this->assertEmailSubjectContains($emails[0], $userOwner->getAlertSortiePrefix());
+        $this->assertEmailSubjectContains($emails[0], $defaultAlertSortiePrefix);
         $this->assertEmailHtmlBodyContains($emails[0], 'Une nouvelle sortie');
         $this->assertEmailHtmlBodyContains($emails[0], 'vient d\'être publiée sur le site');
 
@@ -108,6 +117,9 @@ class UserNotificationHandlerTest extends WebTestCase
 
     public function testItDispatchMessagesArticle()
     {
+        $defaultAlertSortiePrefix = '[CAF-Sortie]';
+        $defaultAlertArticlePrefix = '[CAF-Article]';
+
         $userOwner = $this->signup();
         $otherUserSubscribed = $this->signup();
 
@@ -122,6 +134,8 @@ class UserNotificationHandlerTest extends WebTestCase
             self::getContainer()->get(UserNotificationRepository::class),
             self::getContainer()->get(EntityManagerInterface::class),
             self::getContainer()->get(Mailer::class),
+            $defaultAlertArticlePrefix,
+            $defaultAlertSortiePrefix,
         );
 
         $handler(new UserNotification(AlertType::Article, $article->getId(), $userOwner->getId()));
@@ -133,7 +147,7 @@ class UserNotificationHandlerTest extends WebTestCase
         $this->assertCount(1, $emails);
 
         $this->assertEmailHeaderSame($emails[0], 'To', sprintf('%s <%s>', $userOwner->getNickname(), $userOwner->getEmail()));
-        $this->assertEmailSubjectContains($emails[0], $userOwner->getAlertArticlePrefix());
+        $this->assertEmailSubjectContains($emails[0], $defaultAlertArticlePrefix);
         $this->assertEmailHtmlBodyContains($emails[0], 'Un nouvel article');
         $this->assertEmailHtmlBodyContains($emails[0], 'vient d\'être publié sur le site');
 
@@ -152,7 +166,7 @@ class UserNotificationHandlerTest extends WebTestCase
         $this->assertCount(2, $emails);
 
         $this->assertEmailHeaderSame($emails[1], 'To', sprintf('%s <%s>', $otherUserSubscribed->getNickname(), $otherUserSubscribed->getEmail()));
-        $this->assertEmailSubjectContains($emails[1], $otherUserSubscribed->getAlertArticlePrefix());
+        $this->assertEmailSubjectContains($emails[1], $defaultAlertArticlePrefix);
         $this->assertEmailHtmlBodyContains($emails[1], 'Un nouvel article');
         $this->assertEmailHtmlBodyContains($emails[1], 'vient d\'être publié sur le site');
 


### PR DESCRIPTION
Cette PR retire les parties spécifiques du code pour qu'il puisse être utilisé par différents clubs dans une logique d'unification.

Les parties qu'il était pour l'instant compliqué de rendre génériques ont été conditionnées à une variable d'environnement CAF_ID en attendant de trouver une meilleure solution