### PR TITLE
Update ffcam file loading to accept dynamic paths

### DIFF
--- a/.env
+++ b/.env
@@ -48,6 +48,7 @@ MAX_ARTICLES_ACCUEIL=16
 MAX_IMAGE_SIZE=1000
 ALERT_SORTIE_PREFIX="[CAF-Lyon-Sortie]"
 ALERT_ARTICLE_PREFIX="[CAF-Lyon-Article]"
+FFCAM_FILE_PATH=./ffcam/6900.txt
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev

--- a/clevercloud/crons/sync-members.sh
+++ b/clevercloud/crons/sync-members.sh
@@ -5,4 +5,4 @@
 # https://developers.clever-cloud.com/doc/administrate/cron/#access-environment-variables
 
 cd ${APP_HOME}
-bin/console fichier-adherent ./ffcam/6900.txt
+bin/console ffcam-file-sync

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -200,3 +200,7 @@ services:
   App\Utils\FileUploader:
     arguments:
       $publicDir: '%public_dir%'
+
+  App\Command\FfcamFileSync:
+    arguments:
+      $ffcamFilePath: "%env(FFCAM_FILE_PATH)%"

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,3 +1,8 @@
 services:
   _defaults:
     autowire: true
+    autoconfigure: true
+
+  App\Command\FfcamFileSync:
+    arguments:
+      $ffcamFilePath: "/tmp/test_ffcam.txt"

--- a/src/Command/FfcamFileSync.php
+++ b/src/Command/FfcamFileSync.php
@@ -5,40 +5,35 @@ namespace App\Command;
 use App\Service\FfcamSynchronizer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
-    name: 'fichier-adherent',
+    name: 'ffcam-file-sync',
     description: 'Synchronise les adhérents depuis un fichier FFCAM'
 )]
-class FichierAdherentCommand extends Command
+class FfcamFileSync extends Command
 {
-    public function __construct(private FfcamSynchronizer $synchronizer, ?string $name = null)
-    {
+    public function __construct(
+        private FfcamSynchronizer $synchronizer,
+        private string $ffcamFilePath,
+        ?string $name = null,
+    ) {
         parent::__construct($name);
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->addArgument('file-path', InputArgument::REQUIRED, 'Chemin du fichier FFCAM à traiter');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $filePath = $input->getArgument('file-path');
 
-        if (!file_exists($filePath)) {
-            $io->error("Le fichier '$filePath' n'existe pas.");
+        if (!file_exists($this->ffcamFilePath)) {
+            $io->error("Le fichier '$this->ffcamFilePath' n'existe pas.");
 
             return Command::FAILURE;
         }
 
-        $this->synchronizer->synchronize($filePath);
+        $this->synchronizer->synchronize($this->ffcamFilePath);
 
         return Command::SUCCESS;
     }

--- a/tests/Command/FfcamFileSyncTest.php
+++ b/tests/Command/FfcamFileSyncTest.php
@@ -7,7 +7,7 @@ use App\Tests\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class FichierAdherentCommandTest extends WebTestCase
+class FfcamFileSyncTest extends WebTestCase
 {
     public function testExecute()
     {
@@ -16,10 +16,10 @@ class FichierAdherentCommandTest extends WebTestCase
         $kernel = $this->createKernel();
         $application = new Application($kernel);
 
-        $command = $application->find('fichier-adherent');
+        $command = $application->find('ffcam-file-sync');
         $commandTester = new CommandTester($command);
 
-        $filePath = FfcamTestHelper::generateFile([
+        FfcamTestHelper::generateFile([
             [
                 'cafnum' => rand(100000000000, 999999999999),
                 'lastname' => 'DUPONT',
@@ -30,8 +30,8 @@ class FichierAdherentCommandTest extends WebTestCase
                 'lastname' => 'MARTIN',
                 'firstname' => 'PIERRE',
             ],
-        ]);
+        ], '/tmp/test_ffcam.txt');
 
-        $this->assertSame(0, $commandTester->execute(['command' => $command->getName(), 'file-path' => $filePath]));
+        $this->assertSame(0, $commandTester->execute(['command' => $command->getName()]));
     }
 }

--- a/tests/TestHelpers/FfcamTestHelper.php
+++ b/tests/TestHelpers/FfcamTestHelper.php
@@ -6,9 +6,12 @@ class FfcamTestHelper
 {
     private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;0687000001;;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
 
-    public static function generateFile(array $members): string
+    public static function generateFile(array $members, ?string $filePath = null): string
     {
-        $filePath = tempnam(sys_get_temp_dir(), 'ffcam_');
+        if (!$filePath) {
+            $filePath = tempnam(sys_get_temp_dir(), 'ffcam_');
+        }
+
         $content = '';
 
         foreach ($members as $member) {


### PR DESCRIPTION
This PR changes the loading logic for the ffcam file to 
rely on an environment variable defining the file location.
