### PR TITLE
NDF: Fix le probleme de resume immediat

### DIFF
--- a/assets/expense-report-form/src/composables/useExpenseReport.ts
+++ b/assets/expense-report-form/src/composables/useExpenseReport.ts
@@ -29,10 +29,11 @@ export function useExpenseReport(initialEventId: number) {
       details: JSON.stringify(payload.details),
       refundRequired: payload.refundRequired ?? true,
     };
-
+  
     if (payload.status) {
       body = { ...body, status: payload.status };
     }
+  
     await axios.patch<ExpenseReport>(
       `/expense-reports/${expenseReport.value?.id}`,
       body,
@@ -51,10 +52,8 @@ export function useExpenseReport(initialEventId: number) {
   const submit = async (payload: Partial<ExpenseReport>) => {
     try {
       await save({ ...payload, status: "submitted" });
+      await fetchOrCreateExpenseReport(initialEventId);
       toastr?.success("Votre note de frais a bien été envoyée");
-      if (expenseReport.value) {
-        expenseReport.value.status = "submitted";
-      }
     } catch (error) {
       toastr?.error("Une erreur s'est produite");
     }


### PR DESCRIPTION
Lors de la soumission d'une note de frais, le résumé était vide car le composant ne récuperait pas les valeurs saisies.
C'est corrigé en clonant la variable.