### PR TITLE
Fix logic error in FFCAM file synchronization

### DIFF
--- a/tests/TestHelpers/FfcamTestHelper.php
+++ b/tests/TestHelpers/FfcamTestHelper.php
@@ -4,7 +4,7 @@ namespace App\Tests\TestHelpers;
 
 class FfcamTestHelper
 {
-    private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;0687000001;;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
+    private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;%s;;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
 
     public static function generateFile(array $members, ?string $filePath = null): string
     {
@@ -21,6 +21,7 @@ class FfcamTestHelper
             $firstname = $member['firstname'] ?? 'JEAN';
             $adhesionDate = $member['adhesionDate'] ?? '0000-00-00';
             $birthday = $member['birthday'] ?? '1990-01-01';
+            $tel = $member['tel'] ?? '0687000001';
 
             $content .= sprintf(
                 self::TEMPLATE,
@@ -30,6 +31,7 @@ class FfcamTestHelper
                 $adhesionDate,
                 $lastname,
                 $firstname,
+                $tel,
             ) . "\n";
         }
 


### PR DESCRIPTION
Fix processing logic to insert user if it exists before trying to merge it
with a previous one. In some cases, the previous flawed logic led to errors. 
