### PR TITLE
Fix reading charset for FFCAM file

### DIFF
--- a/src/Service/FfcamFileParser.php
+++ b/src/Service/FfcamFileParser.php
@@ -32,7 +32,7 @@ class FfcamFileParser
 
     private function parseLine(string $line, int $lineNumber): User
     {
-        $line = mb_convert_encoding($line, 'UTF-8');
+        $line = mb_convert_encoding($line, 'UTF-8', 'ISO-8859-1');
         $line = stripslashes($line);
         $line = explode(';', $line);
 


### PR DESCRIPTION
The ffcam puts a text file encoded using ISO-8859.
It seems like mb_convert_encoding is not able to guess the file
encoding correctly so it leads to encoding errors when the file
contains accents.

Specifying the input file encoding fixes the issue.
