### PR TITLE
Hide status bar in tinymce editor

### DIFF
--- a/legacy/editElt.php
+++ b/legacy/editElt.php
@@ -86,7 +86,7 @@ if (isGranted(SecurityConstants::ROLE_CONTENT_MANAGER)) {
 
 							theme_advanced_toolbar_location : "top",
 							theme_advanced_toolbar_align : "left",
-							theme_advanced_statusbar_location : "bottom",
+							theme_advanced_statusbar_location : "none",
 							theme_advanced_resizing : true,
 
 							content_css : "css/base.css,css/style1.css,fonts/stylesheet.css",

--- a/legacy/includes/evt/creer.php
+++ b/legacy/includes/evt/creer.php
@@ -392,7 +392,7 @@ inclure('infos-matos', 'mini');
 
         theme_advanced_toolbar_location : "top",
         theme_advanced_toolbar_align : "left",
-        theme_advanced_statusbar_location : "bottom",
+        theme_advanced_statusbar_location : "none",
         theme_advanced_resizing : true,
 
         document_base_url : '<?php echo LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL); ?>',

--- a/legacy/pages/article-edit.php
+++ b/legacy/pages/article-edit.php
@@ -314,7 +314,7 @@ else {
 
 						theme_advanced_toolbar_location: "top",
 						theme_advanced_toolbar_align: "left",
-						theme_advanced_statusbar_location: "bottom",
+						theme_advanced_statusbar_location: "none",
 						theme_advanced_resizing: true,
 
 						document_base_url: '<?php echo LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL); ?>',

--- a/legacy/pages/article-new.php
+++ b/legacy/pages/article-new.php
@@ -312,7 +312,7 @@ if (isset($_GET['compterendu']) && $_GET['compterendu']) {
 
 						theme_advanced_toolbar_location: "top",
 						theme_advanced_toolbar_align: "left",
-						theme_advanced_statusbar_location: "bottom",
+						theme_advanced_statusbar_location: "none",
 						theme_advanced_resizing: true,
 
 						document_base_url: '<?php echo LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL); ?>',


### PR DESCRIPTION
In some weird cases, the status bar is very long due to the long element path in it
This status is absolutely useless so this PR disables it
