### PR TITLE
Fix: changement visibilité lien boite a outils encadrants

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -198,7 +198,9 @@
                                 <a href="/profil/infos.html" title="">mes infos publiques</a><br />
                                 <a href="/profil/infos.html#private" title="">mes infos privées</a><br />
                                 {% if caf_id == 'lyon' %}
-                                    <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
+                                    {% if allowed('article_create') %}
+                                        <a href="/pages/boite-outils-des-encadrants.html" title="">boite à outils encadrant</a><br />
+                                    {% endif %}
                                     <a href="{{ path('profil_alertes') }}" title="">mes alertes</a>
                                 {% endif %}
                             </div>


### PR DESCRIPTION
La permission `article_create` est true pour ces roles:
![Capture d’écran 2025-02-20 à 21 10 31](https://github.com/user-attachments/assets/ed539fcc-9c49-486b-8137-8b2006b65bff)
