### PR TITLE
Disable default operation on API resources

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -22,3 +22,12 @@ api_platform:
       rfc_7807_compliant_errors: true
   event_listeners_backward_compatibility_layer: false
   keep_legacy_inflector: false
+
+when@prod:
+  api_platform:
+    enable_swagger: false
+    enable_swagger_ui: false
+    enable_docs: false
+    enable_re_doc: false
+    graphql:
+      enabled: false

--- a/src/Entity/Commission.php
+++ b/src/Entity/Commission.php
@@ -11,7 +11,9 @@ use Symfony\Component\Serializer\Attribute\Groups;
  */
 #[ORM\Table(name: 'caf_commission')]
 #[ORM\Entity]
-#[ApiResource]
+#[ApiResource(
+    operations: []
+)]
 class Commission
 {
     /**

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -13,8 +13,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  */
 #[ORM\Table(name: 'caf_evt')]
 #[ORM\Entity]
-#[ApiResource]
-
+#[ApiResource(
+    operations: []
+)]
 class Evt
 {
     public const STATUS_PUBLISHED_UNSEEN = 0;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\Ignore;
 
 /**
  * User.
@@ -18,7 +19,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 #[ORM\Table(name: 'caf_user')]
 #[ORM\Index(name: 'id_user', columns: ['id_user'])]
 #[ORM\Entity(repositoryClass: UserRepository::class)]
-#[ApiResource(normalizationContext: ['groups' => ['user:read']])]
+#[ApiResource(operations: [], normalizationContext: ['groups' => ['user:read']])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSerializable
 {
     /**
@@ -43,6 +44,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
      * @var string
      */
     #[ORM\Column(name: 'mdp_user', type: 'string', length: 1024, nullable: true)]
+    #[Ignore]
     private $mdp;
 
     /**
@@ -156,6 +158,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
      * @var string
      */
     #[ORM\Column(name: 'cookietoken_user', type: 'string', length: 32, nullable: true)]
+    #[Ignore]
     private $cookietoken;
 
     /**


### PR DESCRIPTION
This PR fixes a few security issues due to automatic route generation by API Platform

It's not possible to disable operation generation globally so we have to take care doing it in the future on other resources. 
Docs are now disabled in production environment too.

https://app.clickup.com/t/86c2p2bjy
