### PR TITLE
ajout de la date dans les mails de nouvelles sorties

### DIFF
--- a/templates/email/transactional/notification-new-sortie.html.twig
+++ b/templates/email/transactional/notification-new-sortie.html.twig
@@ -4,7 +4,7 @@
     {{ prefix }}[{{ entity.commission.title }}] {{ entity.titre }} <span class="date"> / {{ entity.tsp | intldate('cccc d MMMM') }}</span>
 {%- endblock %}
 
-{% block rappel_objet 'Nouvelle sortie: ' ~ entity.titre ~ ' / ' ~ {{ entity.tsp | intldate('cccc d MMMM') }} %}
+{% block rappel_objet 'Nouvelle sortie: ' ~ entity.titre ~ ' / ' ~ entity.tsp | intldate('cccc d MMMM') %}
 
 {% block inner_html %}
     <p>


### PR DESCRIPTION
Modification de l'objet du mail annoncant une nouvelle sortie, ainsi que du titre pour y ajouter la date de la sortie.

Voir ticket ici : https://app.clickup.com/t/86c20gq8k