### PR TITLE
fix: modifications de la config Docker

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@
 
 SITENAME="Club Alpin Français de Lyon-Villeurbanne"
 CAF_ID="lyon"
+PROJECT_NAME=caflyon
 
 ANALYTICS_ACCOUNT=
 GOOGLE_SITE_VERIFICATION=

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PHP = $(EXEC) php
 COMPOSER = $(EXEC) composer
 NPM = $(EXEC) npm
 SYMFONY_CONSOLE = $(PHP) bin/console
-MYSQL = $(DOCKER_COMPOSE) --project-directory . --project-name caflyon -f docker-compose.yml exec -T cafdb mysql
+MYSQL = $(DOCKER_COMPOSE) -f docker-compose.yml exec -T cafdb mysql
 
 # Colors
 GREEN = echo "\x1b[32m\#\# $1\x1b[0m"


### PR DESCRIPTION
sans ces modifs, impossible d'exécuter `make database-init`
à voir si ça vient de mon côté uniquement

j'ai ajouté `PROJECT_NAME` dans le `.env` pour garder le nom de projet
et `.` est, normalement, le chemin par défaut donc pas utile, à mon sens, de le préciser