### PR TITLE
Bloc agenda

### DIFF
--- a/src/Repository/EvtRepository.php
+++ b/src/Repository/EvtRepository.php
@@ -74,9 +74,11 @@ class EvtRepository extends ServiceEntityRepository
             ->leftJoin('e.commission', 'c')
             ->where('e.status = :status')
             ->setParameter('status', Evt::STATUS_LEGAL_VALIDE)
-            ->andWhere('e.tsp >= :date')
+            ->andWhere(':date >= e.tsp OR :date <= e.tspEnd')
             ->setParameter('date', $date->getTimestamp())
             ->orderBy('e.tsp', 'asc')
+            ->addOrderBy('c.title', 'ASC')
+            ->addOrderBy('e.titre', 'ASC')
             ->setMaxResults($options['limit'])
         ;
 

--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -81,17 +81,18 @@
                     {% set nInscritsTotal = event.participations() | length %}
                     {% set nPlacesRestantesTotal = max(0, event.ngensMax - nInscritsTotal) %}
                     <a href="/sortie/{{ event.code }}-{{ event.id }}.html?commission={{ event.commission.code }}" title="Voir la sortie">
-                        <span style="color:#fff">{{ event.tsp | intldate('ccc d/MM') | capitalize }} </span> |
+                        <span style="color:#000">{{ event.tsp | intldate('ccc d/MM') | capitalize }} </span> |
                         {% if event.cancelled %}
                             <span class="cancelled">Sortie annulée</span>
                         {% else %}
-                            <span style="color:#4D4D4D">{{ event.commission.title }}
+                            <span style="color:#000">
+                                {{ event.commission.title }}
                             {% if nPlacesRestantesTotal <= 0 %}
                                 <span class="label-complet"> complet </span>
                             {% endif %}
                             </span>
                         {% endif %}
-                        <h2>{{ event.titre }}</h2>
+                        <h2 style="color:#000">{{ event.titre }}</h2>
                     </a>
                 {% else %}
                     {% if current_commission %}


### PR DESCRIPTION
1. [couleur des textes dans le bloc agenda](https://app.clickup.com/t/86c1qjv7z)
2. [ordre des sorties dans le bloc agenda](https://app.clickup.com/t/86c342pwc)
3. [affichage des sorties "en cours" dans le bloc agenda](https://app.clickup.com/t/86c2cq569)

AVANT
![image](https://github.com/user-attachments/assets/89c315f4-ab7f-489a-a541-eb3ee56138c5)

APRÈS
![image](https://github.com/user-attachments/assets/742d5a70-067e-498b-ae70-2003a9dedc9c)
couleur : 
![image](https://github.com/user-attachments/assets/1a921d93-b86c-40a6-9745-4ed9076b9227)