### PR TITLE
Fix: utilisation de la bonne date (updated at) dans le mail de recap

### DIFF
--- a/templates/email/transactional/expense-report-status-email.html.twig
+++ b/templates/email/transactional/expense-report-status-email.html.twig
@@ -163,10 +163,10 @@ Votre note de frais {% if report.event %}pour "{{ report.event.titre }}"{% endif
 Message laissé par la comptabilité : "{{ report.statusComment }}"
     {% endif %}
 
-- Encadrant.e: {{ report.user.firstname }} {{ report.user.lastname }}
-{% if report.event.tsp %}- Date de la sortie: {{ report.event.tsp | date('d-m-Y') }}{% endif %}
-{% if report.updatedAt %}- Date de la soumission de la note de frais: {{ report.updatedAt | date('d-m-Y') }}{% endif %}
-- Type: {% if report.refundRequired %}Demande de remboursement par virement{% else %}Abandon de frais{% endif %}
+- Encadrant.e : {{ report.user.firstname }} {{ report.user.lastname }}
+{% if report.event.tsp %}- Date de la sortie : {{ report.event.tsp | date('d-m-Y') }}{% endif %}
+{% if report.updatedAt %}- Date de la soumission de la note de frais : {{ report.updatedAt | date('d-m-Y') }}{% endif %}
+- Type : {% if report.refundRequired %}Demande de remboursement par virement{% else %}Abandon de frais{% endif %}
 
 
     {# ================== Section TRANSPORT ================== #}


### PR DESCRIPTION
Ajout de la date de la sortie et de la date de soumission de la note de frais
après:
![Capture d’écran 2025-05-06 à 22 12 15](https://github.com/user-attachments/assets/2fd5f907-2633-4fb2-865c-16fe69fe0cd6)

