### PR TITLE
NDF: fix note de frais non trouvée

### DIFF
--- a/assets/expense-report-form/src/composables/useExpenseReport.ts
+++ b/assets/expense-report-form/src/composables/useExpenseReport.ts
@@ -70,7 +70,7 @@ export function useExpenseReport(initialEventId: number) {
   const fetchOrCreateExpenseReport = async (eventId: number) => {
     try {
       const response = await axios.get<ExpenseReport[]>(
-        `/expense-reports?include_drafts=true&event=${eventId}`,
+        `/expense-reports?include_drafts=true&filter_by_owner=true&event=${eventId}`,
       );
 
       let fetchedReport: ExpenseReport;

--- a/src/Controller/Api/ExpenseAttachmentController.php
+++ b/src/Controller/Api/ExpenseAttachmentController.php
@@ -36,7 +36,7 @@ class ExpenseAttachmentController extends AbstractController
 
         $body = $request->getPayload()->all();
 
-        $expenseReport = $this->expenseReportRepository->getExpenseReportByEventAndUser($expenseReportId, $user);
+        $expenseReport = $this->expenseReportRepository->findOneBy(['id' => $expenseReportId, 'user' => $user]);
         if (!$expenseReport) {
             throw $this->createNotFoundException('ExpenseReport not found');
         }

--- a/src/State/ExpenseReportProvider.php
+++ b/src/State/ExpenseReportProvider.php
@@ -22,6 +22,7 @@ class ExpenseReportProvider implements ProviderInterface
 
         $filters = $context['filters'] ?? [];
         $includeDrafts = isset($filters['include_drafts']) && 'true' === $filters['include_drafts'];
+        $filterByOwner = isset($filters['filter_by_owner']) && 'true' === $filters['filter_by_owner'];
 
         if ($operation instanceof \ApiPlatform\Metadata\CollectionOperationInterface) {
             $qb = $this->expenseReportRepository->createQueryBuilder('er');
@@ -30,7 +31,7 @@ class ExpenseReportProvider implements ProviderInterface
                    ->setParameter('event', $filters['event']);
             }
 
-            if (!$canValidateReport) {
+            if (!$canValidateReport || $filterByOwner) {
                 $qb->andWhere('er.user = :user')
                    ->setParameter('user', $this->security->getUser());
             }


### PR DESCRIPTION
### Problème corrigé

Les utilisateurs ayant le droit `validate_expense_report` (comptables ou développeurs) récupéraient **toutes les notes de frais**, y compris celles des autres utilisateurs.

Cela posait un problème dans les interfaces où l’on s’attend à ne récupérer **que la note de frais de l’utilisateur courant** pour une sortie donnée. Par exemple, lors de l’ajout d’un justificatif à une note de frais, si la première note retournée ne correspond pas à l’utilisateur connecté, une erreur se produit (car l’utilisateur tente de modifier une note qui ne lui appartient pas).

---

### Solution apportée

Ajout d’un filtre optionnel `filter_by_owner=true` permettant de restreindre explicitement la requête aux notes de frais de l’utilisateur connecté, même s’il dispose du droit de validation.

Cela permet d’écrire des requêtes plus précises dans les cas où l'on doit impérativement travailler sur **ses propres** notes de frais, par exemple :
```
/expense-reports?include_drafts=true&filter_by_owner=true&event={eventId}
```
