### PR TITLE
Add reusable generic upload component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ public/dev.txt
 /node_modules/
 /public/build/
 ###< pentatrion/vite-bundle ###
+
+###> liip/imagine-bundle ###
+/public/media/cache/
+###< liip/imagine-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "google/apiclient": "^2.18",
         "imagine/imagine": "^1.2",
         "lexik/jwt-authentication-bundle": "^2",
+        "liip/imagine-bundle": "*",
         "nelmio/cors-bundle": "^2.4",
         "pentatrion/vite-bundle": "^7.0",
         "phpdocumentor/reflection-docblock": "^5.3",
@@ -60,7 +61,8 @@
         "symfony/yaml": "6.4.*",
         "twig/extra-bundle": "^3.3",
         "twig/string-extra": "^3.3",
-        "twig/twig": "^3.3"
+        "twig/twig": "^3.3",
+        "vich/uploader-bundle": "^2.6"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2dae4d858d572e8c8eaa72d8cda9c319",
+    "content-hash": "2dd27b5c36c237af6530b824ebdf9319",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1060,16 +1060,16 @@
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
-                "reference": "e858ce0f5c12b266dce7dce24834448355155da7"
+                "reference": "5a6ac7120c2924c4c070a869d08b11ccf9e277b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/e858ce0f5c12b266dce7dce24834448355155da7",
-                "reference": "e858ce0f5c12b266dce7dce24834448355155da7",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/5a6ac7120c2924c4c070a869d08b11ccf9e277b9",
+                "reference": "5a6ac7120c2924c4c070a869d08b11ccf9e277b9",
                 "shasum": ""
             },
             "require": {
@@ -1083,7 +1083,6 @@
                 "composer/semver": "^3.0",
                 "doctrine/coding-standard": "^12",
                 "doctrine/orm": "^2.6 || ^3",
-                "doctrine/persistence": "^2.0 || ^3",
                 "phpstan/phpstan": "^1.4 || ^2",
                 "phpstan/phpstan-deprecation-rules": "^1 || ^2",
                 "phpstan/phpstan-phpunit": "^1 || ^2",
@@ -1126,7 +1125,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/DoctrineMigrationsBundle/issues",
-                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/3.4.1"
+                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/3.4.2"
             },
             "funding": [
                 {
@@ -1142,7 +1141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-27T22:48:22+00:00"
+            "time": "2025-03-11T17:36:26+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -2957,6 +2956,70 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "jms/metadata",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/metadata.git",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.0",
+                "doctrine/coding-standard": "^8.0",
+                "mikey179/vfsstream": "^1.6.7",
+                "phpunit/phpunit": "^8.5|^9.0",
+                "psr/container": "^1.0|^2.0",
+                "symfony/cache": "^3.1|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.1|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Metadata\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "Class/method/property metadata management in PHP",
+            "keywords": [
+                "annotations",
+                "metadata",
+                "xml",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/metadata/issues",
+                "source": "https://github.com/schmittjoh/metadata/tree/2.8.0"
+            },
+            "time": "2023-02-15T13:44:18+00:00"
+        },
+        {
             "name": "laminas/laminas-code",
             "version": "4.16.0",
             "source": {
@@ -3448,6 +3511,112 @@
                 }
             ],
             "time": "2024-04-27T15:46:45+00:00"
+        },
+        {
+            "name": "liip/imagine-bundle",
+            "version": "2.13.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/liip/LiipImagineBundle.git",
+                "reference": "3faccde327f91368e51d05ecad49a9cd915abd81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/3faccde327f91368e51d05ecad49a9cd915abd81",
+                "reference": "3faccde327f91368e51d05ecad49a9cd915abd81",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "imagine/imagine": "^1.3.2",
+                "php": "^7.2|^8.0",
+                "symfony/filesystem": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/finder": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/framework-bundle": "^3.4.23|^4.4|^5.3|^6.0|^7.0",
+                "symfony/mime": "^4.4|^5.3|^6.0|^7.0",
+                "symfony/options-resolver": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/process": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "twig/twig": "^1.44|^2.9|^3.0"
+            },
+            "require-dev": {
+                "amazonwebservices/aws-sdk-for-php": "^1.0",
+                "aws/aws-sdk-php": "^2.4|^3.0",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/persistence": "^1.3|^2.0",
+                "enqueue/enqueue-bundle": "^0.9|^0.10",
+                "ext-gd": "*",
+                "league/flysystem": "^1.0|^2.0|^3.0",
+                "phpstan/phpstan": "^1.10.0",
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/log": "^1.0",
+                "symfony/asset": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/browser-kit": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/cache": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/console": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/dependency-injection": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/form": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/messenger": "^4.4|^5.3|^6.0|^7.0",
+                "symfony/phpunit-bridge": "^7.0.2",
+                "symfony/templating": "^3.4|^4.4|^5.3|^6.0",
+                "symfony/validator": "^3.4|^4.4|^5.3|^6.0|^7.0",
+                "symfony/yaml": "^3.4|^4.4|^5.3|^6.0|^7.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "required for mongodb components",
+                "amazonwebservices/aws-sdk-for-php": "required to use AWS version 1 cache resolver",
+                "aws/aws-sdk-php": "required to use AWS version 2/3 cache resolver",
+                "doctrine/mongodb-odm": "required to use mongodb-backed doctrine components",
+                "enqueue/enqueue-bundle": "^0.9 add if you like to process images in background",
+                "ext-exif": "required to read EXIF metadata from images",
+                "ext-gd": "required to use gd driver",
+                "ext-gmagick": "required to use gmagick driver",
+                "ext-imagick": "required to use imagick driver",
+                "ext-json": "required to read JSON manifest versioning",
+                "ext-mongodb": "required for mongodb components",
+                "league/flysystem": "required to use FlySystem data loader or cache resolver",
+                "monolog/monolog": "A psr/log compatible logger is required to enable logging",
+                "rokka/imagine-vips": "required to use 'vips' driver",
+                "symfony/asset": "If you want to use asset versioning",
+                "symfony/messenger": "If you like to process images in background",
+                "symfony/templating": "required to use deprecated Templating component instead of Twig"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Liip\\ImagineBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Liip and other contributors",
+                    "homepage": "https://github.com/liip/LiipImagineBundle/contributors"
+                }
+            ],
+            "description": "This bundle provides an image manipulation abstraction toolkit for Symfony-based projects.",
+            "homepage": "https://www.liip.ch",
+            "keywords": [
+                "bundle",
+                "image",
+                "imagine",
+                "liip",
+                "manipulation",
+                "photos",
+                "pictures",
+                "symfony",
+                "transformation"
+            ],
+            "support": {
+                "issues": "https://github.com/liip/LiipImagineBundle/issues",
+                "source": "https://github.com/liip/LiipImagineBundle/tree/2.13.3"
+            },
+            "time": "2024-12-12T09:38:23+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -8821,6 +8990,67 @@
             "time": "2025-02-20T12:04:08+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v6.4.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e2a61c16af36c9a07e5c9906498b73e091949a20",
+                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.4.20"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-10T17:11:00+00:00"
+        },
+        {
             "name": "symfony/property-access",
             "version": "v6.4.18",
             "source": {
@@ -10979,6 +11209,114 @@
             "time": "2025-05-03T07:21:55+00:00"
         },
         {
+            "name": "vich/uploader-bundle",
+            "version": "v2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dustin10/VichUploaderBundle.git",
+                "reference": "28d99f6678135ea61c7c67d6fb52fe63ac2937ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dustin10/VichUploaderBundle/zipball/28d99f6678135ea61c7c67d6fb52fe63ac2937ee",
+                "reference": "28d99f6678135ea61c7c67d6fb52fe63ac2937ee",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^3.0 || ^4.0",
+                "ext-simplexml": "*",
+                "jms/metadata": "^2.4",
+                "php": "^8.1",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher-contracts": "^3.1",
+                "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+                "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+                "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+                "symfony/string": "^5.4 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "league/flysystem": "<2.0"
+            },
+            "require-dev": {
+                "dg/bypass-finals": "^1.9",
+                "doctrine/common": "^3.0",
+                "doctrine/doctrine-bundle": "^2.7",
+                "doctrine/mongodb-odm": "^2.4",
+                "doctrine/orm": "^2.13 || ^3.0",
+                "ext-sqlite3": "*",
+                "knplabs/knp-gaufrette-bundle": "dev-master",
+                "league/flysystem-bundle": "^2.4 || ^3.0",
+                "league/flysystem-memory": "^2.0 || ^3.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^5.1",
+                "mikey179/vfsstream": "^1.6.11",
+                "phpunit/phpunit": "^10.5 || ^11.5 || ^12.0",
+                "symfony/asset": "^5.4 || ^6.0 || ^7.0",
+                "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
+                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
+                "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0",
+                "symfony/form": "^5.4 || ^6.0 || ^7.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^7.2",
+                "symfony/security-csrf": "^5.4 || ^6.0 || ^7.0",
+                "symfony/translation": "^5.4 || ^6.0 || ^7.0",
+                "symfony/twig-bridge": "^5.4 || ^6.0 || ^7.0",
+                "symfony/twig-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "For integration with Doctrine",
+                "doctrine/mongodb-odm-bundle": "For integration with Doctrine ODM",
+                "doctrine/orm": "For integration with Doctrine ORM",
+                "doctrine/phpcr-odm": "For integration with Doctrine PHPCR",
+                "knplabs/knp-gaufrette-bundle": "For integration with Gaufrette",
+                "league/flysystem-bundle": "For integration with Flysystem",
+                "liip/imagine-bundle": "To generate image thumbnails",
+                "oneup/flysystem-bundle": "For integration with Flysystem",
+                "symfony/asset": "To generate better links",
+                "symfony/form": "To handle uploads in forms",
+                "symfony/yaml": "To use YAML mapping"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Vich\\UploaderBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dustin Dobervich",
+                    "email": "ddobervich@gmail.com"
+                }
+            ],
+            "description": "Ease file uploads attached to entities",
+            "homepage": "https://github.com/dustin10/VichUploaderBundle",
+            "keywords": [
+                "file uploads",
+                "upload"
+            ],
+            "support": {
+                "issues": "https://github.com/dustin10/VichUploaderBundle/issues",
+                "source": "https://github.com/dustin10/VichUploaderBundle/tree/v2.6.1"
+            },
+            "time": "2025-03-30T13:31:23+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.11.0",
             "source": {
@@ -12238,67 +12576,6 @@
                 }
             ],
             "time": "2024-11-13T15:06:22+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v6.4.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e2a61c16af36c9a07e5c9906498b73e091949a20",
-                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.20"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-03-10T17:11:00+00:00"
         },
         {
             "name": "symfony/web-profiler-bundle",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -19,4 +19,6 @@ return [
     Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
     Gesdinet\JWTRefreshTokenBundle\GesdinetJWTRefreshTokenBundle::class => ['all' => true],
     Pentatrion\ViteBundle\PentatrionViteBundle::class => ['all' => true],
+    Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
+    Vich\UploaderBundle\VichUploaderBundle::class => ['all' => true],
 ];

--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -1,0 +1,19 @@
+# Documentation on how to configure the bundle can be found at: https://symfony.com/doc/current/bundles/LiipImagineBundle/basic-usage.html
+liip_imagine:
+    # valid drivers options include "gd" or "gmagick" or "imagick"
+    driver: "gd"
+
+    resolvers:
+        default:
+            web_path: ~
+
+    filter_sets:
+        wide_thumbnail:
+            quality: 85
+            filters:
+                thumbnail: { size: [665, 365], mode: outbound }
+                
+        min_thumbnail:
+            quality: 85
+            filters:
+                thumbnail: { size: [198, 138], mode: outbound }

--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -1,0 +1,10 @@
+vich_uploader:
+    db_driver: orm
+
+    mappings:
+        files:
+            uri_prefix: /uploads/files
+            upload_destination: '%kernel.project_dir%/public/uploads/files'
+            namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
+            delete_on_update: true
+            delete_on_remove: true

--- a/config/routes/liip_imagine.yaml
+++ b/config/routes/liip_imagine.yaml
@@ -1,0 +1,2 @@
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.yaml"

--- a/migrations/Version20250511160816.php
+++ b/migrations/Version20250511160816.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250511160816 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE media_upload (id INT AUTO_INCREMENT NOT NULL, uploaded_by_id BIGINT NOT NULL, filename VARCHAR(255) NOT NULL, original_filename VARCHAR(255) DEFAULT NULL, mime_type VARCHAR(50) DEFAULT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', used TINYINT(1) DEFAULT NULL, INDEX IDX_ABC47CC1A2B28FE8 (uploaded_by_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE media_upload ADD CONSTRAINT FK_ABC47CC1A2B28FE8 FOREIGN KEY (uploaded_by_id) REFERENCES caf_user (id_user)');
+        $this->addSql('ALTER TABLE caf_article ADD media_upload_id INT DEFAULT NULL, CHANGE cont_article cont_article TEXT NOT NULL');
+        $this->addSql('ALTER TABLE caf_article ADD CONSTRAINT FK_A0BDE6C7E9AF09BF FOREIGN KEY (media_upload_id) REFERENCES media_upload (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_A0BDE6C7E9AF09BF ON caf_article (media_upload_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE caf_article DROP FOREIGN KEY FK_A0BDE6C7E9AF09BF');
+        $this->addSql('ALTER TABLE media_upload DROP FOREIGN KEY FK_ABC47CC1A2B28FE8');
+        $this->addSql('DROP TABLE media_upload');
+        $this->addSql('DROP INDEX IDX_A0BDE6C7E9AF09BF ON caf_article');
+        $this->addSql('ALTER TABLE caf_article DROP media_upload_id, CHANGE cont_article cont_article MEDIUMTEXT NOT NULL');
+    }
+}

--- a/public/js/file-upload-component.js
+++ b/public/js/file-upload-component.js
@@ -1,0 +1,106 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const imageUploadComponents = document.querySelectorAll('.image-upload-component');
+    
+    imageUploadComponents.forEach(component => {
+        initImageUploadComponent(component);
+    });
+    
+    function initImageUploadComponent(component) {
+        const uploadUrl = component.dataset.uploadUrl;
+        const mediaIdInputId = component.dataset.mediaIdInput;
+        const maxFileSize = parseInt(component.dataset.maxFileSize) || 5;
+        
+        const fileInput = component.querySelector('input[type="file"]');
+        const previewDiv = component.querySelector('.upload-preview');
+        const loadingIndicator = component.querySelector('[id$="-loading-indicator"]');
+        const templateId = fileInput.id.replace('-file-input', '-image-preview-template');
+        const template = document.getElementById(templateId);
+        
+        fileInput.addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            
+            if (file.size > maxFileSize * 1024 * 1024) {
+                alert(`Le fichier est trop volumineux. La taille maximale est de ${maxFileSize} Mo.`);
+                this.value = '';
+                return;
+            }
+            
+            const formData = new FormData();
+            formData.append('file', file);
+            
+            loadingIndicator.style.display = 'flex';
+            
+            const placeholder = component.querySelector('.upload-placeholder');
+            if (placeholder) placeholder.style.display = 'none';
+            
+            const existingImage = component.querySelector('.preview-image');
+            if (existingImage) existingImage.style.display = 'none';
+            
+            const existingOverlay = component.querySelector('.preview-overlay');
+            if (existingOverlay) existingOverlay.style.display = 'none';
+            
+            fetch(uploadUrl, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Erreur lors du téléchargement');
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (mediaIdInputId) {
+                    const mediaIdInput = document.getElementById(mediaIdInputId);
+                    if (mediaIdInput) {
+                        mediaIdInput.value = data.id;
+                    }
+                }
+                
+                loadingIndicator.style.display = 'none';
+                
+                if (placeholder) {
+                    placeholder.remove();
+                }
+                
+                if (existingImage) {
+                    existingImage.src = data.url;
+                    existingImage.style.display = 'block';
+                    if (existingOverlay) {
+                        existingOverlay.style.display = 'flex';
+                    }
+                } else {
+                    const clone = document.importNode(template.content, true);
+                    
+                    const img = clone.querySelector('.preview-image');
+                    img.src = data.url;
+                    
+                    previewDiv.appendChild(clone);
+                }
+                
+                const overlay = previewDiv.querySelector('.preview-overlay');
+                overlay.style.opacity = '0';
+                if (overlay) {
+                    previewDiv.addEventListener('mouseenter', function() {
+                        overlay.style.opacity = '1';
+                    });
+                    previewDiv.addEventListener('mouseleave', function() {
+                        overlay.style.opacity = '0';
+                    });
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                loadingIndicator.style.display = 'none';
+                
+                if (placeholder) placeholder.style.display = 'block';
+                if (existingImage) {
+                    existingImage.style.display = 'block';
+                    if (existingOverlay) existingOverlay.style.display = 'flex';
+                }
+                
+                alert('Erreur lors du téléchargement du fichier. Veuillez réessayer.');
+            });
+        });
+    }
+}); 

--- a/src/Command/CleanUnusedMediaCommand.php
+++ b/src/Command/CleanUnusedMediaCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\MediaUploadRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:clean-unused-media',
+    description: 'Clean unused media uploads older than a specified time',
+)]
+class CleanUnusedMediaCommand extends Command
+{
+    public function __construct(
+        private MediaUploadRepository $mediaUploadRepository,
+        private EntityManagerInterface $entityManager
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $date = new \DateTimeImmutable('-1 day');
+        $unusedMedia = $this->mediaUploadRepository->findUnusedOlderThan($date);
+
+        $output->writeln(sprintf('Found %d unused media to delete', \count($unusedMedia)));
+
+        foreach ($unusedMedia as $media) {
+            $this->entityManager->remove($media);
+            $output->writeln(sprintf('Deleting media #%d: %s', $media->getId(), $media->getFilename()));
+        }
+
+        $this->entityManager->flush();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/MediaUploadController.php
+++ b/src/Controller/MediaUploadController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\MediaUpload;
+use App\Repository\MediaUploadRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Vich\UploaderBundle\Handler\UploadHandler;
+
+#[AsController]
+class MediaUploadController extends AbstractController
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private MediaUploadRepository $mediaUploadRepository,
+        private Security $security,
+        private UploadHandler $uploadHandler,
+        private CacheManager $imagineCacheManager
+    ) {
+    }
+
+    #[Route('/upload-image', name: 'media_upload_image', methods: ['POST'])]
+    public function __invoke(Request $request, ValidatorInterface $validator): Response
+    {
+        return $this->upload($request, $validator, new File([
+            'maxSize' => '5M',
+            'extensions' => ['jpg', 'jpeg', 'png', 'gif', 'webp'],
+        ]));
+    }
+
+    #[Route('/upload-file', name: 'media_upload_file', methods: ['POST'])]
+    public function uploadFile(Request $request, ValidatorInterface $validator): Response
+    {
+        return $this->upload($request, $validator, new File([
+            'maxSize' => '5M',
+            'extensions' => ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx'],
+        ]));
+    }
+
+    public function upload(Request $request, ValidatorInterface $validator, File $fileConstraints): Response
+    {
+        $user = $this->security->getUser();
+        if (!$user) {
+            throw $this->createAccessDeniedException('User must be logged in');
+        }
+
+        $file = $request->files->get('file');
+        if (!$file) {
+            throw new BadRequestHttpException('File is required');
+        }
+
+        $errors = $validator->validate($file, $fileConstraints);
+
+        if ($errors->count() > 0) {
+            throw new BadRequestHttpException((string) $errors);
+        }
+
+        $mediaUpload = new MediaUpload();
+        $mediaUpload->setUploadedBy($user);
+        $mediaUpload->setFile($file);
+
+        $this->entityManager->persist($mediaUpload);
+        $this->entityManager->flush();
+
+        $this->uploadHandler->upload($mediaUpload, 'file');
+
+        $this->entityManager->flush();
+
+        $imagePath = $request->getSchemeAndHttpHost() . '/uploads/files/' . $mediaUpload->getFilename();
+
+        $thumbnails = [];
+        if (\in_array(strtolower($file->getClientOriginalExtension()), ['jpg', 'jpeg', 'png', 'gif', 'webp'], true)) {
+            try {
+                // Chemin relatif pour LiipImagine
+                $relativeImagePath = 'uploads/files/' . $mediaUpload->getFilename();
+
+                // Générer les URLs des thumbnails
+                $thumbnails = [
+                    'wide' => $this->imagineCacheManager->getBrowserPath($relativeImagePath, 'wide_thumbnail'),
+                    'min' => $this->imagineCacheManager->getBrowserPath($relativeImagePath, 'min_thumbnail'),
+                ];
+            } catch (NotLoadableException $e) {
+                throw new BadRequestHttpException('Image non valide');
+            }
+        }
+
+        return $this->json([
+            'id' => $mediaUpload->getId(),
+            'filename' => $mediaUpload->getFilename(),
+            'url' => $imagePath,
+            'thumbnails' => $thumbnails,
+            'createdAt' => $mediaUpload->getCreatedAt()->format('c'),
+        ], Response::HTTP_CREATED);
+    }
+}

--- a/src/Entity/MediaUpload.php
+++ b/src/Entity/MediaUpload.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\MediaUploadRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\HttpFoundation\File\File;
+use Vich\UploaderBundle\Mapping\Annotation as Vich;
+
+#[ORM\Entity(repositoryClass: MediaUploadRepository::class)]
+#[ORM\HasLifecycleCallbacks]
+#[Vich\Uploadable]
+class MediaUpload
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $filename = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $originalFilename = null;
+
+    #[ORM\Column(length: 50, nullable: true)]
+    private ?string $mimeType = null;
+
+    #[Vich\UploadableField(mapping: 'files', fileNameProperty: 'filename', originalName: 'originalFilename', mimeType: 'mimeType')]
+    private ?File $file = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $createdAt = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, referencedColumnName: 'id_user')]
+    private ?User $uploadedBy = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $used = false;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->used = false;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFilename(): ?string
+    {
+        return $this->filename;
+    }
+
+    public function setFilename(?string $filename): self
+    {
+        $this->filename = $filename;
+
+        return $this;
+    }
+
+    public function getOriginalFilename(): ?string
+    {
+        return $this->originalFilename;
+    }
+
+    public function setOriginalFilename(?string $originalFilename): self
+    {
+        $this->originalFilename = $originalFilename;
+
+        return $this;
+    }
+
+    public function getMimeType(): ?string
+    {
+        return $this->mimeType;
+    }
+
+    public function setMimeType(?string $mimeType): self
+    {
+        $this->mimeType = $mimeType;
+
+        return $this;
+    }
+
+    public function getFile(): ?File
+    {
+        return $this->file;
+    }
+
+    public function setFile(?File $file): self
+    {
+        $this->file = $file;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUploadedBy(): ?User
+    {
+        return $this->uploadedBy;
+    }
+
+    public function setUploadedBy(?User $uploadedBy): self
+    {
+        $this->uploadedBy = $uploadedBy;
+
+        return $this;
+    }
+
+    public function isUsed(): ?bool
+    {
+        return $this->used;
+    }
+
+    public function setUsed(?bool $used): self
+    {
+        $this->used = $used;
+
+        return $this;
+    }
+}

--- a/src/Repository/MediaUploadRepository.php
+++ b/src/Repository/MediaUploadRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\MediaUpload;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class MediaUploadRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, MediaUpload::class);
+    }
+
+    public function findUnusedOlderThan(\DateTimeInterface $date)
+    {
+        return $this->createQueryBuilder('m')
+            ->where('m.used = :used')
+            ->andWhere('m.createdAt < :date')
+            ->setParameter('used', false)
+            ->setParameter('date', $date)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -78,6 +78,19 @@
             "config/packages/lexik_jwt_authentication.yaml"
         ]
     },
+    "liip/imagine-bundle": {
+        "version": "2.13",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.8",
+            "ref": "d1227d002b70d1a1f941d91845fcd7ac7fbfc929"
+        },
+        "files": [
+            "config/packages/liip_imagine.yaml",
+            "config/routes/liip_imagine.yaml"
+        ]
+    },
     "nelmio/alice": {
         "version": "3.13",
         "recipe": {
@@ -353,5 +366,17 @@
     },
     "twig/extra-bundle": {
         "version": "v3.10.0"
+    },
+    "vich/uploader-bundle": {
+        "version": "2.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.13",
+            "ref": "1b3064c2f6b255c2bc2f56461aaeb76b11e07e36"
+        },
+        "files": [
+            "config/packages/vich_uploader.yaml"
+        ]
     }
 }

--- a/templates/components/file_upload.html.twig
+++ b/templates/components/file_upload.html.twig
@@ -1,0 +1,64 @@
+{#
+  Composant d'upload d'image avec prévisualisation
+  Paramètres:
+  - id: identifiant unique du composant (obligatoire)
+  - width: largeur du composant (défaut: w-64)
+  - height: hauteur du composant (défaut: h-32)
+  - uploadUrl: URL pour l'upload (obligatoire)
+  - currentImageUrl: URL de l'image actuelle (optionnel)
+  - mediaIdInputId: ID de l'input hidden qui stockera l'ID du média (obligatoire)
+  - maxFileSize: taille maximale en Mo (défaut: 5)
+  - accept: format accepté (ex: image/*)
+#}
+
+{% set width = width|default('tw-w-64') %}
+{% set height = height|default('tw-h-32') %}
+{% set maxFileSize = maxFileSize|default(5) %}
+
+<div class="image-upload-component" data-upload-url="{{ uploadUrl }}" data-media-id-input="{{ mediaIdInputId }}" data-max-file-size="{{ maxFileSize }}" data-accept="{{ accept|default('image/*') }}">
+    <input type="file" id="{{ id }}-file-input" accept="{{ accept }}" style="display: none;" />
+    <div class="{{ width }} {{ height }} tw-rounded-md tw-overflow-hidden tw-border tw-border-gray-300 tw-border-dashed tw-relative">
+        <div class="upload-preview tw-flex tw-items-center tw-justify-center tw-h-full tw-cursor-pointer group" onclick="document.getElementById('{{ id }}-file-input').click()">
+            {% if currentImageUrl %}
+                <img src="{{ currentImageUrl }}" alt="{{ currentImageAlt|default('') }}" class="preview-image tw-w-full tw-h-full tw-object-cover group-hover:tw-blur-sm tw-transition-all" />
+                <div class="preview-overlay tw-absolute tw-inset-0 tw-bg-black tw-bg-opacity-40 tw-flex tw-items-center tw-justify-center tw-transition-opacity">
+                    <div class="tw-text-white tw-text-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="tw-h-8 tw-w-8 tw-mx-auto tw-mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0l-4 4m4-4v12" />
+                        </svg>
+                        <div>Remplacer le fichier</div>
+                    </div>
+                </div>
+            {% else %}
+                <div class="upload-placeholder tw-text-center tw-text-gray-500">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="tw-h-8 tw-w-8 tw-mx-auto tw-mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                    </svg>
+                    <div>Cliquer pour envoyer un fichier</div>
+                </div>
+            {% endif %}
+            <div id="{{ id }}-loading-indicator" class="tw-absolute tw-inset-0 tw-bg-white tw-items-center tw-justify-center" style="display: none;">
+                <div class="tw-text-center tw-text-gray-600">
+                    <svg class="tw-animate-spin tw-h-8 tw-w-8 tw-mx-auto tw-mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="tw-opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="tw-opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <div>Chargement...</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Template pour l'image après upload (caché) -->
+    <template id="{{ id }}-image-preview-template">
+        <img class="preview-image tw-w-full tw-h-full tw-object-cover group-hover:tw-blur-sm tw-transition-all" alt="Aperçu" />
+        <div class="preview-overlay tw-absolute tw-inset-0 tw-bg-black tw-bg-opacity-40 tw-flex tw-items-center tw-justify-center tw-transition-opacity">
+            <div class="tw-text-white tw-text-center">
+                <svg xmlns="http://www.w3.org/2000/svg" class="tw-h-8 tw-w-8 tw-mx-auto tw-mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0l-4 4m4-4v12" />
+                </svg>
+                <div>Remplacer le fichier</div>
+            </div>
+        </div>
+    </template>
+</div> 


### PR DESCRIPTION

This PR adds a generic upload component to be used in Twig templates
It's a first shot for a nicer upload component in the future!

Usage 

```
{% include 'components/file_upload.html.twig' with {
    id: 'cover-image',
    width: 'tw-w-64',
    height: 'tw-h-32',
    uploadUrl: '/upload-image',
    mediaIdInputId: form.mediaUploadId.vars.id,
    maxFileSize: 5,
    accept: 'image/*'
} %}
```


<img width="284" alt="Screenshot 2025-05-11 at 19 38 20" src="https://github.com/user-attachments/assets/b10ca86f-2bfd-4e53-bf7d-558776f18dee" />
<img width="284" alt="Screenshot 2025-05-11 at 19 38 13" src="https://github.com/user-attachments/assets/3b8f0954-aaed-4233-a4ca-fb8679a578ac" />
<img width="284" alt="Screenshot 2025-05-11 at 19 31 19" src="https://github.com/user-attachments/assets/90dac7e1-f966-4495-a460-77d2c6efcbbc" />
