### PR TITLE
fix: éviter le passage sur 2 colonnes de la description complète

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -736,9 +736,9 @@
 
         {% if not event.cancelled %}
             <ul class="nice-list">
-                <li class="wide"><b>DESCRIPTION COMPLÈTE :</b>
-                <div class="description_evt">{{ event.description | raw }}</div></li>
+                <li class="wide"><b>DESCRIPTION COMPLÈTE :</b></li>
             </ul>
+            <div class="description_evt">{{ event.description | raw }}</div>
             <hr style="clear:both" />
 
             {% if allowed('user_read_limited') and (event.tarif > 0 or event.tarifDetail) %}


### PR DESCRIPTION
en retirant le décalage gauche
https://app.clickup.com/t/86c3f25em

AVANT
![image](https://github.com/user-attachments/assets/249a511c-44f5-42be-a8be-0f08a859fe05)

APRÈS
![image](https://github.com/user-attachments/assets/28e86d04-63ad-4c48-a81f-2054033225aa)