### PR TITLE
fix: erreur si apostrophe dans certains champs

### DIFF
--- a/legacy/includes/evt/creer.php
+++ b/legacy/includes/evt/creer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 // message d'erreur
 if (isset($_POST['operation']) && isset($errTab) && count($errTab) > 0) {
     echo '<div class="erreur">Erreur : <ul><li>' . implode('</li><li>', $errTab) . '</li></ul>';
-    echo '<b>Attention :</b> Le marqueur rouge sur la carte a peut-être été déplacé !';
+    echo '<b>Attention :</b> Le marqueur bleu sur la carte a peut-être été déplacé !';
     echo '</div>';
 }
 // message d'info : si c'est une modification de sortie

--- a/legacy/scripts/operations/operations.evt_save.php
+++ b/legacy/scripts/operations/operations.evt_save.php
@@ -27,6 +27,8 @@ if (!isset($errTab) || 0 === count($errTab)) {
     $matos_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($matos_evt);
     $itineraire = LegacyContainer::get('legacy_mysqli_handler')->escapeString($itineraire);
     $difficulte_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($difficulte_evt);
+    $denivele_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($denivele_evt);
+    $distance_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($distance_evt);
     $description_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($description_evt);
     $details_caches_evt = LegacyContainer::get('legacy_mysqli_handler')->escapeString($details_caches_evt);
 


### PR DESCRIPTION
https://app.clickup.com/t/86c0v0jef

APRÈS
![image](https://github.com/user-attachments/assets/b857c60e-8743-4565-b5b1-9c3c051d2992)
(on peut bien enregistrer des apostrophes dans ces champs)