### PR TITLE
Add endpoint to clone an expense report

### DIFF
--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Dto\ExpenseReportCreateDto;
 use App\Repository\ExpenseReportRepository;
+use App\State\ExpenseReportCloneProcessor;
 use App\State\ExpenseReportCreateProcessor;
 use App\State\ExpenseReportProvider;
 use App\Utils\Enums\ExpenseReportStatusEnum;
@@ -33,6 +34,12 @@ use Symfony\Component\Validator\Constraints as Assert;
             input: ExpenseReportCreateDto::class,
             processor: ExpenseReportCreateProcessor::class,
             security: "is_granted('ROLE_USER')",
+        ),
+        new Post(
+            uriTemplate: '/expense-reports/{id}/clone',
+            processor: ExpenseReportCloneProcessor::class,
+            security: "is_granted('ROLE_USER')",
+            name: 'clone',
         ),
         new GetCollection(
             uriTemplate: '/expense-reports',

--- a/tests/State/ExpenseReportCloneProcessorTest.php
+++ b/tests/State/ExpenseReportCloneProcessorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Tests\State;
+
+use App\Entity\ExpenseAttachment;
+use App\Entity\ExpenseReport;
+use App\Entity\User;
+use App\State\ExpenseReportCloneProcessor;
+use App\Tests\WebTestCase;
+use App\Utils\Enums\ExpenseReportStatusEnum;
+use App\Utils\FileUploader;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class ExpenseReportCloneProcessorTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private Security $security;
+    private string $kernelProjectDir;
+    private FileUploader $fileUploader;
+    private ExpenseReportCloneProcessor $processor;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityManager = $this->getContainer()->get(EntityManagerInterface::class);
+        $this->security = $this->getContainer()->get(Security::class);
+        $this->kernelProjectDir = $this->getContainer()->getParameter('kernel.project_dir');
+        $this->fileUploader = $this->getContainer()->get(FileUploader::class);
+
+        $this->processor = new ExpenseReportCloneProcessor(
+            $this->entityManager,
+            $this->security,
+            $this->kernelProjectDir,
+            $this->fileUploader
+        );
+
+        $this->user = $this->signup();
+        $this->signin($this->user);
+    }
+
+    public function testCloneExpenseReport(): void
+    {
+        $event = $this->createEvent($this->user);
+
+        $originalReport = new ExpenseReport();
+        $originalReport->setStatus(ExpenseReportStatusEnum::SUBMITTED);
+        $originalReport->setRefundRequired(true);
+        $originalReport->setUser($this->user);
+        $originalReport->setEvent($event);
+        $originalReport->setDetails('{"someKey": "someValue"}');
+
+        $this->entityManager->persist($originalReport);
+        $this->entityManager->flush();
+
+        $this->createMockAttachment($originalReport);
+
+        $operation = new \ApiPlatform\Metadata\Post(name: 'clone');
+        $uriVariables = ['id' => $originalReport->getId()];
+
+        $clonedReport = $this->processor->process(null, $operation, $uriVariables);
+
+        $this->assertInstanceOf(ExpenseReport::class, $clonedReport);
+        $this->assertNotSame($originalReport->getId(), $clonedReport->getId());
+        $this->assertEquals(ExpenseReportStatusEnum::DRAFT, $clonedReport->getStatus());
+        $this->assertEquals($originalReport->isRefundRequired(), $clonedReport->isRefundRequired());
+        $this->assertSame($this->user, $clonedReport->getUser());
+        $this->assertSame($event, $clonedReport->getEvent());
+        $this->assertEquals($originalReport->getDetails(), $clonedReport->getDetails());
+
+        $this->assertCount(1, $clonedReport->getAttachments());
+
+        $originalAttachment = $originalReport->getAttachments()->first();
+        $clonedAttachment = $clonedReport->getAttachments()->first();
+
+        $this->assertNotSame($originalAttachment->getId(), $clonedAttachment->getId());
+        $this->assertEquals($originalAttachment->getExpenseId(), $clonedAttachment->getExpenseId());
+        $this->assertNotEquals($originalAttachment->getFilePath(), $clonedAttachment->getFilePath());
+        $this->assertStringContainsString('clone_', $clonedAttachment->getFileName());
+    }
+
+    private function createMockAttachment(ExpenseReport $report): ExpenseAttachment
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_');
+        file_put_contents($tempFile, 'test content');
+
+        $uploadDir = $this->kernelProjectDir . '/public/ftp/user/' . $this->user->getId() . '/expense-attachments';
+        if (!file_exists($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+
+        $testFileName = 'test_file.txt';
+        $testFilePath = $uploadDir . '/' . $testFileName;
+        copy($tempFile, $testFilePath);
+
+        $attachment = new ExpenseAttachment();
+        $attachment->setExpenseId('TEST123');
+        $attachment->setFileName($testFileName);
+        $attachment->setFilePath($testFilePath);
+        $attachment->setFileUrl('http://example.com/test_file.txt');
+        $attachment->setUser($this->user);
+        $attachment->setExpenseReport($report);
+
+        $report->addAttachment($attachment);
+
+        $this->entityManager->persist($attachment);
+        $this->entityManager->flush();
+
+        return $attachment;
+    }
+
+    protected function tearDown(): void
+    {
+        $uploadDir = $this->kernelProjectDir . '/public/ftp/user/' . $this->user->getId();
+        if (file_exists($uploadDir)) {
+            $this->removeDirectory($uploadDir);
+        }
+
+        parent::tearDown();
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Utils/FileUploaderTest.php
+++ b/tests/Utils/FileUploaderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Utils;
+
+use App\Tests\WebTestCase;
+use App\Utils\FileUploader;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class FileUploaderTest extends WebTestCase
+{
+    private FileUploader $fileUploader;
+    private string $publicDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fileUploader = static::getContainer()->get(FileUploader::class);
+        $this->publicDir = static::getContainer()->getParameter('kernel.project_dir') . '/public';
+    }
+
+    public function testUpload(): void
+    {
+        $user = $this->signup();
+        $this->signin($user);
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_upload_');
+        file_put_contents($tempFile, 'test content');
+
+        $uploadedFile = new UploadedFile(
+            $tempFile,
+            'test_file.txt',
+            'text/plain',
+            null,
+            true
+        );
+
+        $uploadedFileObj = $this->fileUploader->upload($uploadedFile, 'test-directory');
+
+        $this->assertInstanceOf(File::class, $uploadedFileObj);
+        $this->assertFileExists($uploadedFileObj->getPathname());
+
+        $expectedPathPattern = "#^{$this->publicDir}/ftp/user/{$user->getId()}/test-directory/#";
+        $this->assertMatchesRegularExpression($expectedPathPattern, $uploadedFileObj->getPathname());
+
+        if (file_exists($uploadedFileObj->getPathname())) {
+            unlink($uploadedFileObj->getPathname());
+        }
+    }
+
+    public function testDuplicateFile(): void
+    {
+        $user = $this->signup();
+        $this->signin($user);
+
+        $sourceDir = $this->publicDir . '/ftp/user/' . $user->getId() . '/source-dir';
+        if (!file_exists($sourceDir)) {
+            mkdir($sourceDir, 0755, true);
+        }
+
+        $sourceFile = $sourceDir . '/original-file.txt';
+        file_put_contents($sourceFile, 'original content');
+
+        $duplicatedFile = $this->fileUploader->duplicateFile($sourceFile, 'target-dir');
+
+        $this->assertInstanceOf(File::class, $duplicatedFile);
+        $this->assertFileExists($duplicatedFile->getPathname());
+
+        $expectedPathPattern = "#^{$this->publicDir}/ftp/user/{$user->getId()}/target-dir/clone_#";
+        $this->assertMatchesRegularExpression($expectedPathPattern, $duplicatedFile->getPathname());
+
+        $this->assertEquals('original content', file_get_contents($duplicatedFile->getPathname()));
+
+        if (file_exists($sourceFile)) {
+            unlink($sourceFile);
+        }
+        if (file_exists($duplicatedFile->getPathname())) {
+            unlink($duplicatedFile->getPathname());
+        }
+    }
+
+    public function testDuplicateNonExistentFile(): void
+    {
+        $user = $this->signup();
+        $this->signin($user);
+
+        $nonExistentFile = $this->publicDir . '/non-existent-file.txt';
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->fileUploader->duplicateFile($nonExistentFile, 'target-dir');
+    }
+
+    public function testGetUserUploadUrl(): void
+    {
+        $user = $this->signup();
+
+        $url = $this->fileUploader->getUserUploadUrl($user, 'test-file.txt', 'test-directory');
+
+        $expectedPattern = "#/ftp/user/{$user->getId()}/test-directory/test-file.txt#";
+        $this->assertMatchesRegularExpression($expectedPattern, $url);
+    }
+}


### PR DESCRIPTION
This PR adds an endpoint to clone an expense report.
To avoid issues with shared attachments, attachments are cloned too.
