### PR TITLE
fix: fermer correctement les balises ouvertes

### DIFF
--- a/legacy/includes/article-fiche.php
+++ b/legacy/includes/article-fiche.php
@@ -170,14 +170,12 @@ if (!$article) {
 				</script>';
     }
 
-    if ('1' != $article['topubly_article']
-        || allowed('article_validate_all')
-        || allowed('article_validate', 'commission:' . $article['commission_article'])
-        || allowed('article_delete_notmine', 'commission:' . $article['commission_article'])
-        || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
-        || allowed('article_edit_notmine', 'commission:' . $article['commission_article'])
-        || allowed('article_edit') && user() && $article['user_article'] == (string) getUser()->getId()
-    ) {
+    // mêmes conditions que pour la balise ouvrante
+    if ((allowed('article_delete_notmine', 'commission:' . $article['commission_article'])
+         || allowed('article_edit_notmine', 'commission:' . $article['commission_article'])
+         || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
+         || allowed('article_edit')) && user() && $article['user_article'] == (string) getUser()->getId()
+        && 1 == $article['status_article']) {
         echo '</div><br />';
     }
 


### PR DESCRIPTION
pour ne pas casser l'html et le design

AVANT
![image](https://github.com/user-attachments/assets/2121515c-8399-4ed9-967e-c9a1a7eb03b7)

APRÈS
![image](https://github.com/user-attachments/assets/f3410a06-8f39-4d42-95d6-d138d3b5287a)