### PR TITLE
fix: page article - balises bloc orangé mal ouvertes/fermées

### DIFF
--- a/legacy/includes/article-fiche.php
+++ b/legacy/includes/article-fiche.php
@@ -57,11 +57,21 @@ if (!$article) {
     // contenu HTML
     echo '<div class="cont_article"><br />';
 
+    if ('1' != $article['topubly_article']
+        || '1' != $article['status_article']
+        || (allowed('article_delete_notmine', 'commission:' . $article['commission_article'])
+            || allowed('article_edit_notmine', 'commission:' . $article['commission_article'])
+            || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
+            || allowed('article_edit')) && user() && $article['user_article'] == (string) getUser()->getId()
+           && 1 == $article['status_article']) {
+        echo '<div class="alerte noprint">';
+    }
+
     // article trouvé mais normalement pas visible, c'est le cas d'un mode admin ou validateur
     if ('1' != $article['topubly_article']) {
-        echo '<div class="alerte noprint"><b>Note :</b> Cet article est en cours de rédaction par <b>' . userlink($article['auteur']['id_user'], $article['auteur']['nickname_user']) . '</b>. La publication n\'a pas encore été demandée.<br />';
+        echo '<b>Note :</b> Cet article est en cours de rédaction par <b>' . userlink($article['auteur']['id_user'], $article['auteur']['nickname_user']) . '</b>. La publication n\'a pas encore été demandée.<br />';
     } elseif ('1' != $article['status_article']) {
-        echo '<div class="alerte noprint"><b>Note :</b> Cet article n\'est pas publié sur le site. Si vous voyez ce message apparaître, c\'est que vous disposez de droits particuliers qui vous autorisent à voir cette page. Les usagers réguliers du site n\'ont pas accès aux informations ci-dessous.<br />';
+        echo '<b>Note :</b> Cet article n\'est pas publié sur le site. Si vous voyez ce message apparaître, c\'est que vous disposez de droits particuliers qui vous autorisent à voir cette page. Les usagers réguliers du site n\'ont pas accès aux informations ci-dessous.<br />';
 
         // Moderation
         if (allowed('article_validate', 'commission:' . $article['commission_article']) || allowed('article_validate_all')) {
@@ -94,7 +104,7 @@ if (!$article) {
          || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
          || allowed('article_edit')) && user() && $article['user_article'] == (string) getUser()->getId()
         && 1 == $article['status_article']) {
-        echo '<div class="alerte noprint"><b>Note :</b> Cet article est publié sur le site et visible par les adhérents !<br />';
+        echo '<b>Note :</b> Cet article est publié sur le site et visible par les adhérents !<br />';
     }
 
     // edition
@@ -171,11 +181,13 @@ if (!$article) {
     }
 
     // mêmes conditions que pour la balise ouvrante
-    if ((allowed('article_delete_notmine', 'commission:' . $article['commission_article'])
-         || allowed('article_edit_notmine', 'commission:' . $article['commission_article'])
-         || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
-         || allowed('article_edit')) && user() && $article['user_article'] == (string) getUser()->getId()
-        && 1 == $article['status_article']) {
+    if ('1' != $article['topubly_article']
+        || '1' != $article['status_article']
+        || (allowed('article_delete_notmine', 'commission:' . $article['commission_article'])
+            || allowed('article_edit_notmine', 'commission:' . $article['commission_article'])
+            || allowed('article_delete') && user() && $article['user_article'] == (string) getUser()->getId()
+            || allowed('article_edit')) && user() && $article['user_article'] == (string) getUser()->getId()
+           && 1 == $article['status_article']) {
         echo '</div><br />';
     }
 


### PR DESCRIPTION
https://app.clickup.com/t/86c3wd996

AVANT
![image](https://github.com/user-attachments/assets/50d5d4d5-f408-48c5-876e-64f137fd7051)
![image](https://github.com/user-attachments/assets/adbc4e41-c52f-4bc0-a324-bd3237999667)

APRÈS
![image](https://github.com/user-attachments/assets/174523e6-ef63-4811-8752-67b0814ddb2c)
![image](https://github.com/user-attachments/assets/d6ca8abf-5338-4c0c-9fb9-4dec33a53770)