### PR TITLE
Add paid status to expense reports

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -134,6 +134,12 @@ services:
     arguments:
       $config: '%expense_report%'
 
+  App\State\UserOwnedExtension:
+        arguments:
+            $security: '@security.helper'
+        tags:
+            - { name: 'api_platform.doctrine.orm.query_extension.collection' }
+            
   # services used in legacy
   legacy_router:
     public: true

--- a/src/Entity/ExpenseReportStatusHistory.php
+++ b/src/Entity/ExpenseReportStatusHistory.php
@@ -2,12 +2,31 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
 use App\Repository\ExpenseReportStatusHistoryRepository;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: ExpenseReportStatusHistoryRepository::class)]
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/expense-reports/{id}/history',
+            uriVariables: [
+                'id' => new Link(
+                    fromClass: ExpenseReport::class,
+                    toProperty: 'expenseReport'
+                ),
+            ],
+            normalizationContext: ['groups' => ['report:read']],
+            security: "is_granted('ROLE_USER')"
+        ),
+    ]
+)]
 class ExpenseReportStatusHistory
 {
     #[ORM\Id]
@@ -20,9 +39,11 @@ class ExpenseReportStatusHistory
     private ?ExpenseReport $expenseReport = null;
 
     #[ORM\Column(enumType: ExpenseReportStatusEnum::class, nullable: true)]
+    #[Groups(['report:read'])]
     private ?ExpenseReportStatusEnum $oldStatus = null;
 
     #[ORM\Column(enumType: ExpenseReportStatusEnum::class)]
+    #[Groups(['report:read'])]
     private ExpenseReportStatusEnum $newStatus;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
@@ -30,6 +51,8 @@ class ExpenseReportStatusHistory
     private ?User $changedBy = null;
 
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    #[Groups(['report:read'])]
+
     private ?\DateTimeImmutable $changedAt = null;
 
     public function getId(): ?int

--- a/src/State/UserOwnedExtension.php
+++ b/src/State/UserOwnedExtension.php
@@ -6,6 +6,7 @@ use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\ExpenseReport;
+use App\Entity\ExpenseReportStatusHistory;
 use App\Security\SecurityConstants;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -18,17 +19,29 @@ final class UserOwnedExtension implements QueryCollectionExtensionInterface
 
     public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
-        if (ExpenseReport::class !== $resourceClass) {
+        if (ExpenseReport::class === $resourceClass) {
+            $user = $this->security->getUser();
+            if (null === $user || $this->security->isGranted(SecurityConstants::ROLE_ADMIN)) {
+                return;
+            }
+            $rootAlias = $queryBuilder->getRootAliases()[0];
+            $queryBuilder->andWhere(sprintf('%s.user = :current_user', $rootAlias))
+                ->setParameter('current_user', $user);
+
             return;
         }
+        if (ExpenseReportStatusHistory::class === $resourceClass) {
+            $user = $this->security->getUser();
+            if (null === $user || $this->security->isGranted(SecurityConstants::ROLE_ADMIN)) {
+                return;
+            }
+            $rootAlias = $queryBuilder->getRootAliases()[0];
+            $queryBuilder
+                ->join(sprintf('%s.expenseReport', $rootAlias), 'er')
+                ->andWhere('er.user = :current_user')
+                ->setParameter('current_user', $user);
 
-        $user = $this->security->getUser();
-        if (null === $user || $this->security->isGranted(SecurityConstants::ROLE_ADMIN)) {
             return;
         }
-
-        $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->andWhere(sprintf('%s.user = :current_user', $rootAlias))
-            ->setParameter('current_user', $user);
     }
 }

--- a/src/Utils/Enums/ExpenseReportStatusEnum.php
+++ b/src/Utils/Enums/ExpenseReportStatusEnum.php
@@ -9,4 +9,6 @@ enum ExpenseReportStatusEnum: string
     case REJECTED = 'rejected';
     case APPROVED = 'approved';
     case ACCOUNTED = 'accounted';
+
+    case PAID = 'paid';
 }

--- a/src/Validator/ExpenseReport/StatusTransitionValidator.php
+++ b/src/Validator/ExpenseReport/StatusTransitionValidator.php
@@ -30,6 +30,7 @@ class StatusTransitionValidator
             ExpenseReportStatusEnum::SUBMITTED->value => [ExpenseReportStatusEnum::APPROVED->value, ExpenseReportStatusEnum::REJECTED->value],
             ExpenseReportStatusEnum::APPROVED->value => [ExpenseReportStatusEnum::ACCOUNTED->value],
             ExpenseReportStatusEnum::REJECTED->value => [ExpenseReportStatusEnum::SUBMITTED->value],
+            ExpenseReportStatusEnum::ACCOUNTED->value => [ExpenseReportStatusEnum::PAID->value],
         ];
 
         if (!isset($validTransitions[$oldStatus->value]) || !\in_array($newStatus->value, $validTransitions[$oldStatus->value], true)) {


### PR DESCRIPTION
Ajout du statut paid pour les notes de frais, avec adaptation de l’API et des règles de transition pour intégrer ce nouveau statut.

Ajout d’un endpoint dédié pour consulter l’historique des statuts d’une note de frais.

Mise en place d’une restriction d’accès : seuls l’utilisateur concerné ou un admin peuvent voir l’historique des statuts et les notes de frais.

Exemple de réponse API 

```
[
    {
        "changedAt": "2025-06-13T22:11:05+02:00",
        "newStatus": "submitted",
        "oldStatus": "draft"
    },
    {
        "changedAt": "2025-06-14T22:11:05+02:00",
        "newStatus": "rejected",
        "oldStatus": "submitted"
    }
]
```