### PR TITLE
fix: afficher l'année correcte sur les dates longues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "8.3.*",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-intl": "*",
         "ext-zip": "*",
         "api-platform/core": "^3.2",
         "beberlei/doctrineextensions": "^1.5",

--- a/templates/profil/sorties.html.twig
+++ b/templates/profil/sorties.html.twig
@@ -25,8 +25,8 @@
                     {% endif %}
                     <tr>
                         <td class="agenda-gauche">
-                            {% set start = event.tsp | intldate('eee d MMM YYYY') | capitalize %}
-                            {% set end = event.tspEnd | intldate('eee d MMM YYYY') | capitalize %}
+                            {% set start = event.tsp | intldate('eee d MMM yyyy') | capitalize %}
+                            {% set end = event.tspEnd | intldate('eee d MMM yyyy') | capitalize %}
 
                             {% if start == end %}
                                 Le {{ start }}<br />

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -126,7 +126,7 @@
             {% if event.groupe %}
                 <small> ({{ event.groupe.nom }}) </small>
             {% endif %}
-            <span class="date"> / {{ event.tsp | intldate('cccc d MMMM YYYY') }}</span>
+            <span class="date"> / {{ event.tsp | intldate('cccc d MMMM yyyy') }}</span>
         </h1>
 
         <div class="tw-flex tw-gap-4">


### PR DESCRIPTION
https://app.clickup.com/t/86c215xbj

AVANT
![image](https://github.com/user-attachments/assets/f7f9530d-af3e-4712-aae2-3ba407e0649a)
![image](https://github.com/user-attachments/assets/60848f84-07b6-456d-a86b-9b78bea271e4)

APRÈS
![image](https://github.com/user-attachments/assets/2a256dfb-1a3e-45b8-b731-aef834aa3836)
![image](https://github.com/user-attachments/assets/a0400152-aa2b-4b24-9b88-64bdf841f1f2)