### PR TITLE
fix: manque une puce dans menu vert

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -229,7 +229,9 @@
                                 <div class="nav-user">
                                     <p class="menutitle">Articles</p>
 
+                                    <ul>
                                     {% if allowed('article_create') %}
+                                        <li>
                                         <a href="/article/new{{ current_commission ? '?commission=' ~ current_commission : '' }}" title="">
                                             rédiger un article
                                         </a>


### PR DESCRIPTION
AVANT
![image](https://github.com/user-attachments/assets/a35488b9-528f-4b19-92d8-17b9e353bd3b)

APRÈS
![image](https://github.com/user-attachments/assets/c42c738e-d4bb-4cfa-9d7c-05fbae93b063)