### PR TITLE
fix: restaurer la sauvegarde du statusComment lors du refus d'une not…

### DIFF
--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -10,6 +10,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use App\Dto\ExpenseReportCreateDto;
+use App\Dto\ExpenseReportStatusDto;
 use App\Repository\ExpenseReportRepository;
 use App\State\ExpenseReportCloneProcessor;
 use App\State\ExpenseReportCreateProcessor;
@@ -51,6 +52,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new Patch(
             uriTemplate: '/expense-reports/{id}',
+            input: ExpenseReportStatusDto::class,
             security: 'object.getUser() == user or is_granted("validate_expense_report")',
             // normalizationContext: ['groups' => ['report:read', 'attachment:read', 'user:read', 'event:read']]
         ),


### PR DESCRIPTION
…e de frais

Le champ statusComment n'était plus sauvegardé lors du refus d'une note de frais suite à la suppression du controller personnalisé lors de la migration ApiPlatform.

Configuration du DTO ExpenseReportStatusDto comme input pour l'opération PATCH pour limiter les champs modifiables à status et statusComment uniquement.

🤖 Generated with [Claude Code](https://claude.ai/code)