### PR TITLE
Ajout d'un champ commentaire lors de la préinscription

### DIFF
--- a/legacy/scripts/operations/operations.user_join.php
+++ b/legacy/scripts/operations/operations.user_join.php
@@ -14,6 +14,8 @@ if (isset($_POST['filiations']) && 'on' == $_POST['filiations']) {
 
 $idUsersFiliations = !empty($_POST['id_user_filiation']) ? array_map('intval', $_POST['id_user_filiation']) : [];
 
+$joinMessage = $_POST['message'];
+
 // Evenement défini et utilisateur aussi
 $id_evt = (int) $_POST['id_evt'];
 $id_user = getUser()->getId();
@@ -287,6 +289,7 @@ if (!isset($errTab) || 0 === count($errTab)) {
                 'firstname' => ucfirst(getUser()->getFirstname()),
                 'lastname' => strtoupper(getUser()->getLastname()),
                 'nickname' => getUser()->getNickname(),
+                'message' => $joinMessage,
                 'covoiturage' => $is_covoiturage,
                 'dest_role' => array_key_exists('role_evt_join', $destinataire) ? $destinataire['role_evt_join'] : 'l\'auteur',
             ], [], null, getUser()->getEmail());

--- a/templates/email/transactional/sortie-demande-inscription.html.twig
+++ b/templates/email/transactional/sortie-demande-inscription.html.twig
@@ -18,6 +18,11 @@
         <li>
             <b>Rôle :</b> {{ role }}
         </li>
+        {% if message %}
+        <li>
+            <b>Message :</b> {{ message }}
+        </li>
+        {% endif %}
     </ul>
     <p>
         Vous recevez ce message car vous êtes {{ dest_role }} sur cette sortie.
@@ -34,5 +39,9 @@
 
     Rôle : {{ role }}
 
+    {% if message %}
+    Message : {{ message }}
+
+    {% endif %}
     Vous recevez ce message car vous êtes {{ dest_role }} sur cette sortie.
 {% endblock %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1100,6 +1100,14 @@
                                         </div>
 
                                         <p style="text-align:center">
+                                            <label for="name">Ajouter un message à votre demande (optionnel) :</label><br>
+                                            <textarea name="message" placeholder="Par exemple :
+- J'ai tel niveau et telle expérience
+- J'ai une voiture avec 4 places dispos
+- Je n'ai pas de crampons, ce n'est pas mentionné, est-ce critique ?" class="type1" style="width:50%; height:100px"></textarea>
+                                        </p>
+
+                                        <p style="text-align:center">
                                             <a class="biglink" href="javascript:void(0)" title="Enregistrer" onclick="$(this).parents('form').submit()">
                                                 <span class="bleucaf">&gt;</span>
                                                 {% if not my_status %}


### PR DESCRIPTION
Voir https://app.clickup.com/t/86c3cnumf

## Avant

#### Formulaire
![20250628_inscription_message_avant](https://github.com/user-attachments/assets/3094c60b-2fbe-4c58-a3fa-86a8385be19b)

#### Email
![20250628_inscription_message_avant_mail](https://github.com/user-attachments/assets/a06816ce-0dd7-41bd-806c-763a855571d2)

## Avec le champ, avec le texte placeholder

#### Formulaire
![20250628_inscription_message_après_placeholder](https://github.com/user-attachments/assets/64e749a6-384d-49a4-9c82-07488eb4672a)

#### Email (idem que actuellement car champ vide)
![20250628_inscription_message_après_placeholder_mail_vide](https://github.com/user-attachments/assets/2ee3678b-611b-4d96-8194-36963ac8d4bc)


## Avec le champ, avec un texte entré par l'utilisateur

#### Formulaire
![20250628_inscription_message_après_mesg](https://github.com/user-attachments/assets/98843025-f9db-4bd6-9566-8ed59a1ae213)

#### Email
![20250628_inscription_message_après_mesg_mail](https://github.com/user-attachments/assets/aa9484d8-1d36-43f9-b29e-1928662a49d8)

