### PR TITLE
fix: styles dans le wysiwyg sortie

### DIFF
--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -293,7 +293,7 @@
 
             document_base_url: '{{ url('legacy_root') }}',
 
-            content_css: "{{ vite_entry_link_tags('base-styles') }},{{ vite_entry_link_tags('styles') }},{{ vite_entry_link_tags('fonts') }}",
+            content_css: "{{ vite_entry_link_ref('base-styles') }},{{ vite_entry_link_ref('styles') }},{{ vite_entry_link_ref('fonts') }}",
             body_id: "bodytinymce_user",
             body_class: "description_evt",
             theme_advanced_styles: "Entete Article=ArticleEntete;Titre de menu=menutitle;Bleu clair du CAF=bleucaf;Image flottante gauche=imgFloatLeft;Image flottante droite=imgFloatRight;Lien fancybox=fancybox;Mini=mini;Bloc alerte=erreur;Bloc info=info",


### PR DESCRIPTION
https://app.clickup.com/t/86c4fb5f8

AVANT
<img width="958" height="351" alt="image" src="https://github.com/user-attachments/assets/fe8f5a34-27b3-4de6-a806-dd4ee667ec52" />

APRÈS
<img width="958" height="351" alt="image" src="https://github.com/user-attachments/assets/9b92b6cd-162a-48e3-a790-5a4d366660c0" />