### PR TITLE
fix: afficher correctement les brouillons

### DIFF
--- a/legacy/includes/article-tools.php
+++ b/legacy/includes/article-tools.php
@@ -4,16 +4,16 @@ if (user()) {
 	<div class="article-tools">
 
 		<?php
-        // statut de l'article
-        if (0 == $article['topubly_article']) {
-            echo "<p class='draft'>Brouillon (non publié)</p>";
-        } elseif (0 == $article['status_article']) {
-            echo "<p class='alerte'>En attente : cet article n'a pas encore été publié par un responsable.</p>";
-        } elseif (1 == $article['status_article']) {
-            echo '<p class="info">Publié : cet article est en ligne</p>';
-        } elseif (2 == $article['status_article']) {
-            echo "<p class='erreur'>Désactivé : cet article a été refusé par un responsable</p>";
-        }
+    // statut de l'article
+    if (1 == $article['status_article']) {
+        echo '<p class="info">Publié : cet article est en ligne</p>';
+    } elseif (2 == $article['status_article']) {
+        echo "<p class='erreur'>Désactivé : cet article a été refusé par un responsable</p>";
+    } elseif (0 == $article['topubly_article']) {
+        echo "<p class='draft'>Brouillon (non publié)</p>";
+    } elseif (0 == $article['status_article'] && 1 == $article['topubly_article']) {
+        echo "<p class='alerte'>En attente : cet article n'a pas encore été publié par un responsable.</p>";
+    }
 
     // BOUTONS
     // publié ? voir
@@ -34,24 +34,16 @@ if (user()) {
 			<?php
     }
 
-    // lier des co-rédacs
-    /*
+    // on peut toujours modifier
     ?>
-    <a href="javascript:void(0)" title="" class="nice2">
-        Co-rédacteurs
-    </a>
-    <?php
-    */
-
-    // on peut toujours modifier?>
 		<a href="/article/<?php echo (int) $article['id_article']; ?>/edit" title="" class="nice2 orange">
 			Modifier
 		</a>
 		<?php
 
-        // si publié : dépublier
-        if (1 == $article['status_article']) {
-            ?>
+    // si publié : dépublier
+    if (1 == $article['status_article']) {
+        ?>
 			<a href="javascript:$.fancybox($('#depublier-form-<?php echo $article['id_article']; ?>').html());" title="" class="nice2 red" id="button-depublier">
 				Dépublier
 			</a>
@@ -67,7 +59,7 @@ if (user()) {
 				</form>
 			</div>
 			<?php
-        }
+    }
 
     // si dépublié : supprimer
     if (1 != $article['status_article']) {

--- a/src/Security/Voter/SortieValidateVoter.php
+++ b/src/Security/Voter/SortieValidateVoter.php
@@ -34,7 +34,7 @@ class SortieValidateVoter extends Voter
             throw new \InvalidArgumentException(sprintf('The voter "%s" requires an event subject', __CLASS__));
         }
 
-        if (!$subject->getCancelled() && $subject->isPublicStatusValide()) {
+        if (!$subject->getCancelled() && $subject->isPublicStatusValide() || $subject->isDraft()) {
             return false;
         }
 

--- a/templates/profil/sorties.html.twig
+++ b/templates/profil/sorties.html.twig
@@ -37,12 +37,14 @@
                             {% endif %}
 
                             {% if app.user == event.user %}
-                                {% if event.statusLegal == constant('App\\Entity\\Evt::STATUS_LEGAL_VALIDE') %}
+                                {% if event.isDraft %}
+                                    <p class="draft">Brouillon (non publiée)</p>
+                                {% elseif event.statusLegal == constant('App\\Entity\\Evt::STATUS_LEGAL_VALIDE') %}
                                     <p class="info">Publiée et validée par le président</p>
                                 {% elseif event.status == constant('App\\Entity\\Evt::STATUS_PUBLISHED_UNSEEN') %}
                                     <p class="alerte">En attente de publication</p>
                                 {% elseif event.status == constant('App\\Entity\\Evt::STATUS_PUBLISHED_VALIDE') %}
-                                    <p class="draft">Publiée non validée par le président</p>
+                                    <p class="alerte">Publiée non validée par le président</p>
                                 {% elseif event.status == constant('App\\Entity\\Evt::STATUS_PUBLISHED_REFUSE') %}
                                     <p class="erreur">Sortie refusée et non publiée</p>
                                 {% endif %}


### PR DESCRIPTION
https://app.clickup.com/t/86c4m4qex et https://app.clickup.com/t/86c4kt05c

AVANT
<img width="922" height="1126" alt="image" src="https://github.com/user-attachments/assets/2636942c-a92b-4bce-ab97-dd954ac658c0" />
<img width="922" height="1126" alt="image" src="https://github.com/user-attachments/assets/3121cf2b-127e-483d-a250-253497bdd6d4" />

APRÈS
<img width="922" height="1126" alt="image" src="https://github.com/user-attachments/assets/945e4640-36e2-41bd-b8c6-500390f6f178" />
<img width="922" height="1126" alt="image" src="https://github.com/user-attachments/assets/4d35f5d0-0336-4ca0-9df1-a76364f1a55c" />