### PR TITLE
Fix: vérifier la limite de participants avant l'acceptation automatique

### DIFF
--- a/legacy/scripts/operations/operations.user_join.php
+++ b/legacy/scripts/operations/operations.user_join.php
@@ -139,15 +139,36 @@ if (!isset($errTab) || 0 === count($errTab)) {
 
         // si on accepte les demandes automatiquement
         $status_evt_join = 0;
-        $stmt = LegacyContainer::get('legacy_mysqli_handler')->prepare('SELECT auto_accept FROM caf_evt WHERE id_evt = ? LIMIT 1');
+        $stmt = LegacyContainer::get('legacy_mysqli_handler')->prepare('SELECT auto_accept, ngens_max_evt FROM caf_evt WHERE id_evt = ? LIMIT 1');
         $stmt->bind_param('i', $id_evt);
         $stmt->execute();
         $result = $stmt->get_result();
         $row = $result->fetch_row();
         $stmt->close();
         if (1 === $row[0]) {
-            $status_evt_join = 1;
-            $auto_accept = true;
+            // Si auto_accept est activé, vérifier qu'on n'a pas atteint la limite
+            $ngens_max = $row[1];
+            if ($ngens_max && $ngens_max > 0) {
+                // Compter le nombre actuel de participants acceptés
+                $stmt = LegacyContainer::get('legacy_mysqli_handler')->prepare('SELECT COUNT(id_evt_join) FROM caf_evt_join WHERE evt_evt_join = ? AND status_evt_join = 1');
+                $stmt->bind_param('i', $id_evt);
+                $stmt->execute();
+                $result = $stmt->get_result();
+                $count_row = $result->fetch_row();
+                $stmt->close();
+                $current_participants = $count_row[0];
+                
+                // Vérifier si on peut accepter au moins une nouvelle inscription
+                if ($current_participants < $ngens_max) {
+                    $status_evt_join = 1;
+                    $auto_accept = true;
+                }
+                // Si on a atteint la limite, ne pas accepter automatiquement
+            } else {
+                // Si pas de limite définie, accepter automatiquement
+                $status_evt_join = 1;
+                $auto_accept = true;
+            }
         }
 
         $evt = get_evt($id_evt);


### PR DESCRIPTION
## Résumé
- Ajout d'une vérification du nombre maximum de participants lors de l'acceptation automatique des inscriptions
- Empêche le dépassement de la limite définie (ngens_max_evt) même quand auto_accept est activé

## Problème résolu
Auparavant, lorsqu'une sortie avait l'acceptation automatique activée, le système acceptait toutes les demandes d'inscription sans vérifier si la limite maximale de participants était atteinte. Cela pouvait conduire à accepter un nombre illimité d'inscriptions même pour une sortie limitée à 12 personnes par exemple.

## Solution
Le code vérifie maintenant :
1. Si l'acceptation automatique est activée
2. Si une limite de participants est définie (ngens_max_evt)
3. Le nombre actuel de participants acceptés
4. N'accepte automatiquement que s'il reste de la place

## Tests
- [ ] Vérifier qu'une sortie avec auto_accept et limite fonctionne correctement
- [ ] Vérifier qu'une sortie avec auto_accept sans limite continue de fonctionner
- [ ] Vérifier que les inscriptions manuelles ne sont pas impactées