### PR TITLE
feat: afficher les détails de la note de frais en lecture seule pour tous les statuts finaux

### DIFF
--- a/assets/expense-report-form/src/ExpenseReportForm.vue
+++ b/assets/expense-report-form/src/ExpenseReportForm.vue
@@ -16,16 +16,10 @@
     <div class="tw-py-4">
       <div v-if="isLoading">Chargement de la note de frais...</div>
       <div v-else-if="expenseReport">
-        <div v-if="expenseReport.status === ExpenseStatus.SUBMITTED">
-          <p>
-            <ExpenseReportSummary :expense-report="expenseReport" />
-          </p>
-        </div>
-        <div v-else-if="expenseReport.status === ExpenseStatus.APPROVED">
-          Votre note de frais a été acceptée.
-        </div>
-        <div v-else-if="expenseReport.status === ExpenseStatus.ACCOUNTED">
-          Votre note de frais a été intégrée dans l'outil de comptabilité et n'est donc plus modifiable.
+        <div v-if="expenseReport.status === ExpenseStatus.SUBMITTED || 
+                     expenseReport.status === ExpenseStatus.APPROVED || 
+                     expenseReport.status === ExpenseStatus.ACCOUNTED">
+          <ExpenseReportSummary :expense-report="expenseReport" />
         </div>
         <div v-else>
           <div

--- a/assets/expense-report-form/src/components/ExpenseReportSummary.vue
+++ b/assets/expense-report-form/src/components/ExpenseReportSummary.vue
@@ -55,7 +55,7 @@
         </div>
       </div>
   
-      <div class="tw-mt-6 tw-rounded-lg tw-bg-amber-50 tw-p-4">
+      <div v-if="expenseReport.status === ExpenseStatus.SUBMITTED || expenseReport.status === ExpenseStatus.APPROVED" class="tw-mt-6 tw-rounded-lg tw-bg-amber-50 tw-p-4">
         <p class="tw-text-sm tw-text-amber-800">
           Si vous avez fait une erreur et souhaitez modifier votre note de frais, merci d'en faire la demande auprès de la comptabilité: 
           <a href="mailto:comptabilite@clubalpinlyon.fr" class="tw-font-medium tw-underline hover:tw-text-amber-900">

--- a/assets/expense-report-form/src/components/ExpenseReportSummary.vue
+++ b/assets/expense-report-form/src/components/ExpenseReportSummary.vue
@@ -2,9 +2,16 @@
     <div class="tw-bg-white tw-rounded-lg tw-shadow-sm tw-p-6">
       <div class="tw-mb-8">
         <h2 class="tw-text-xl tw-font-medium tw-mb-4">Récapitulatif de votre note de frais</h2>
-        <div class="tw-bg-blue-50 tw-p-4 tw-rounded-lg">
+        <div v-if="expenseReport.status === ExpenseStatus.SUBMITTED" class="tw-bg-blue-50 tw-p-4 tw-rounded-lg">
           <p class="tw-text-blue-700">Votre note de frais est en attente de vérification par la comptabilité.</p>
           <p class="tw-text-blue-700">Vous serez informé(e) de son acceptation ou de son refus par email.</p>
+        </div>
+        <div v-else-if="expenseReport.status === ExpenseStatus.APPROVED" class="tw-bg-green-50 tw-p-4 tw-rounded-lg">
+          <p class="tw-text-green-700">Votre note de frais a été acceptée.</p>
+          <p class="tw-text-green-700">Elle sera prochainement intégrée dans l'outil de comptabilité.</p>
+        </div>
+        <div v-else-if="expenseReport.status === ExpenseStatus.ACCOUNTED" class="tw-bg-purple-50 tw-p-4 tw-rounded-lg">
+          <p class="tw-text-purple-700">Votre note de frais a été intégrée dans l'outil de comptabilité et n'est donc plus modifiable.</p>
         </div>
       </div>
   
@@ -62,7 +69,7 @@
   
   <script setup lang="ts">
   import { computed } from 'vue';
-  import { ExpenseReport } from '../types/api';
+  import { ExpenseReport, ExpenseStatus } from '../types/api';
   import ExpenseReportSection from './ExpenseReportSection.vue';
   import { 
     formatTransport, 


### PR DESCRIPTION
## Summary
- Affiche le récapitulatif complet des notes de frais pour les statuts SUBMITTED, APPROVED et ACCOUNTED
- Ajoute des messages contextuels spécifiques à chaque statut
- Améliore l'UX en permettant la consultation des détails après validation

## Changements
- Modification de `ExpenseReportForm.vue` pour afficher le composant summary pour les 3 statuts finaux
- Adaptation de `ExpenseReportSummary.vue` avec des messages et couleurs spécifiques par statut:
  - **SUBMITTED** (bleu): "En attente de vérification"
  - **APPROVED** (vert): "Acceptée, en attente d'intégration"  
  - **ACCOUNTED** (violet): "Comptabilisée et non modifiable"

## Test plan
- [ ] Créer une note de frais et vérifier l'affichage en statut brouillon
- [ ] Soumettre la note et vérifier le message "en attente" avec détails en lecture seule
- [ ] Faire approuver la note et vérifier le message "acceptée" avec détails
- [ ] Faire comptabiliser la note et vérifier le message "comptabilisée" avec détails
- [ ] Vérifier que les totaux et détails s'affichent correctement dans tous les cas