### PR TITLE
feat: ajouter le nom de la commission dans l'API expense-reports

### DIFF
--- a/src/Entity/Commission.php
+++ b/src/Entity/Commission.php
@@ -55,7 +55,7 @@ class Commission
      * @var string
      */
     #[ORM\Column(name: 'title_commission', type: 'string', length: 30, nullable: false)]
-    #[Groups('commission:read')]
+    #[Groups(['commission:read', 'event:read'])]
     private $title;
 
     /**

--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -57,7 +57,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     provider: ExpenseReportProvider::class,
     security: "is_granted('ROLE_USER')",
-    normalizationContext: ['groups' => ['report:read', 'attachment:read', 'user:read', 'event:read'], 'skip_null_values' => false],
+    normalizationContext: ['groups' => ['report:read', 'attachment:read', 'user:read', 'event:read', 'commission:read'], 'skip_null_values' => false],
 )]
 
 #[ApiFilter(SearchFilter::class, properties: ['event' => 'exact'])]


### PR DESCRIPTION
## Summary
- Ajout du nom de la commission dans la réponse de l'API expense-reports
- L'objet commission complet est maintenant inclus avec son ID et son nom
- Améliore l'UX en évitant des requêtes API supplémentaires

## Changements techniques
- Ajout du groupe de sérialisation `commission:read` dans la configuration de normalisation de `ExpenseReport`
- Ajout du groupe `event:read` au champ `title` de l'entité `Commission`

## Impact
L'endpoint `/api/expense-reports/{id}` retourne maintenant :
```json
{
  "event": {
    "id": 123,
    "commission": {
      "id": 5,
      "title": "Alpinisme"  // <- Nouveau champ disponible
    }
  }
}
```

## Test plan
- [ ] Appeler l'endpoint GET /api/expense-reports/{id}
- [ ] Vérifier que l'objet event contient l'objet commission avec id et title
- [ ] Vérifier que le nom de la commission s'affiche correctement
- [ ] Tester aussi sur la liste GET /api/expense-reports