### PR TITLE
fix: afficher la photo de l'utilisateur connecté

### DIFF
--- a/templates/components/add-comment.html.twig
+++ b/templates/components/add-comment.html.twig
@@ -3,7 +3,7 @@
     <input type="hidden" name="unlock1" value="0" />
 
     <div style="float:left; width:75px; padding-top:3px;">
-        <img src="{{ user_image(article.user, 'pic') }}" alt="Profil" title="{{ article.user.nickname }}" />
+        <img src="{{ user_image(app.user, 'pic') }}" alt="Profil" title="{{ article.user.nickname }}" />
     </div>
     <div style="float:left; width:530px;">
         <textarea name="cont_comment" class="type2" style="width:460px; height:90px;" placeholder="Laisser un commentaire" ></textarea>


### PR DESCRIPTION
pas celle de l'auteur de l'article
https://app.clickup.com/t/86c538r69

AVANT
<img width="1275" height="1530" alt="image" src="https://github.com/user-attachments/assets/1ba41063-6e0b-4c9f-a2e1-fa88ba5a5701" />

APRÈS
<img width="1407" height="1492" alt="image" src="https://github.com/user-attachments/assets/e48ba839-e325-4b25-9e3b-2f82e8c84479" />
