### PR TITLE
🐛 Fix: Ajouter la méthode applyToItem manquante dans ExpenseReportExtension

### DIFF
--- a/src/Doctrine/ExpenseReportExtension.php
+++ b/src/Doctrine/ExpenseReportExtension.php
@@ -3,6 +3,7 @@
 namespace App\Doctrine;
 
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\ExpenseReport;
@@ -16,7 +17,7 @@ use Symfony\Bundle\SecurityBundle\Security;
  * - Filtre par utilisateur (sauf pour les admins et gestionnaires de notes de frais)
  * - Exclut les brouillons par défaut (sauf si inclure_brouillons=true)
  */
-final class ExpenseReportExtension implements QueryCollectionExtensionInterface
+final class ExpenseReportExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {
     public function __construct(
         private Security $security
@@ -35,6 +36,18 @@ final class ExpenseReportExtension implements QueryCollectionExtensionInterface
         }
 
         $this->filterExpenseReports($queryBuilder, $context);
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        // Pas de filtrage spécifique pour les items individuels
+        // Les permissions sont gérées par les voters
     }
 
     private function filterExpenseReports(QueryBuilder $queryBuilder, array $context): void


### PR DESCRIPTION
## Summary
- Correction de l'erreur "Undefined method applyToItem" lors de la récupération d'une note de frais individuelle
- Ajout de l'interface `QueryItemExtensionInterface` et de la méthode `applyToItem` (vide) dans `ExpenseReportExtension`
- La méthode est requise par API Platform même si aucune logique spécifique n'est nécessaire pour les items individuels

## Contexte
L'erreur se produisait lors de l'appel GET sur `/api/notes-de-frais/{id}` car API Platform tente d'appliquer l'extension aux opérations sur items uniques, pas seulement aux collections.

## Test plan
- [ ] Vérifier que l'appel GET `/api/notes-de-frais/{id}` fonctionne correctement
- [ ] Vérifier que la liste des notes de frais continue de fonctionner
- [ ] Confirmer que les filtres (utilisateur, brouillons) fonctionnent toujours sur les collections

🤖 Generated with [Claude Code](https://claude.ai/code)