### PR TITLE
✨ feat: Activer le contrôle client de la pagination dans l'API

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -12,6 +12,7 @@ api_platform:
   error_formats:
     jsonproblem: ["application/problem+json"]
   defaults:
+    pagination_client_enabled: true
     pagination_client_items_per_page: true
     pagination_maximum_items_per_page: 30
     stateless: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -297,13 +297,48 @@ GET /api/participation-sorties/{id}
 
 ## Pagination
 
-La pagination est disponible sur tous les endpoints de collection :
+La pagination est disponible sur tous les endpoints de collection avec des options de contrôle côté client :
+
+### Paramètres de pagination
 
 ```http
 GET /api/sorties?page=2&itemsPerPage=10
 ```
 
-Les métadonnées de pagination sont toujours incluses dans la réponse :
+**Paramètres disponibles :**
+- `page` : Numéro de la page à récupérer (défaut: 1)
+- `itemsPerPage` : Nombre d'éléments par page (défaut: 30, max: 30)
+- `pagination` : Active/désactive la pagination (défaut: true)
+
+### Désactiver la pagination
+
+Pour récupérer tous les résultats sans pagination :
+
+```http
+GET /api/sorties?pagination=false
+```
+
+⚠️ **Attention** : Désactiver la pagination peut retourner un grand nombre de résultats et impacter les performances.
+
+### Exemples d'utilisation
+
+```bash
+# 50 éléments par page (limité à 30 max)
+GET /api/notes-de-frais?itemsPerPage=50
+
+# Tous les résultats sans pagination
+GET /api/notes-de-frais?pagination=false
+
+# Page 3 avec 15 éléments par page
+GET /api/participation-sorties?page=3&itemsPerPage=15
+
+# Combiné avec des filtres
+GET /api/notes-de-frais?itemsPerPage=20&inclure_brouillons=true&page=2
+```
+
+### Métadonnées de pagination
+
+Les métadonnées de pagination sont toujours incluses dans la réponse (sauf si `pagination=false`) :
 - `page` : Page actuelle
 - `perPage` : Nombre d'éléments par page
 - `total` : Nombre total d'éléments


### PR DESCRIPTION
## Summary
- Activation de `pagination_client_enabled` pour permettre aux clients de désactiver la pagination
- Documentation mise à jour avec exemples d'utilisation détaillés
- Le paramètre `pagination_client_items_per_page` était déjà activé

## Nouvelles fonctionnalités

Les clients de l'API peuvent maintenant :
- **Désactiver la pagination** : `GET /api/ressource?pagination=false` pour récupérer tous les résultats
- **Contrôler le nombre d'items** : `GET /api/ressource?itemsPerPage=20` (limité à 30 max)
- **Combiner avec d'autres paramètres** : `GET /api/notes-de-frais?pagination=false&inclure_brouillons=true`

## Changements
- `config/packages/api_platform.yaml` : Ajout de `pagination_client_enabled: true`
- `docs/api.md` : Documentation complète de la pagination avec exemples

## Test plan
- [ ] Tester que `?pagination=false` retourne tous les résultats
- [ ] Vérifier que `?itemsPerPage=X` fonctionne (avec limite à 30)
- [ ] Confirmer que la pagination par défaut reste active sans paramètres
- [ ] Tester la combinaison avec d'autres filtres

🤖 Generated with [Claude Code](https://claude.ai/code)