### PR TITLE
fix(expense-report): corrige la création en brouillon (POST)

### DIFF
--- a/assets/expense-report-form/src/composables/useExpenseReport.ts
+++ b/assets/expense-report-form/src/composables/useExpenseReport.ts
@@ -81,7 +81,7 @@ export function useExpenseReport(initialEventId: number) {
       } else {
         const createResponse = await axios.post<ExpenseReport>(
           config.endpoints.notesDeFrais,
-          { sortie: `/api/sorties/${eventId}` },
+          { eventId: eventId },
         );
         fetchedReport = createResponse.data;
       }


### PR DESCRIPTION
Fix: 422 lors de la création d’une note de frais (brouillon)

- Cause: l’API (DTO) attend `eventId`; le front envoyait `sortie` (IRI).
- Changement: le POST `/notes-de-frais` envoie maintenant `{ "eventId": <id> }`.
- Test: créer depuis une sortie sans note existante → statut `draft`, pas de 422.
- Note: recompiler les assets (`make npm-build` ou `npm run build`).
