### PR TITLE
fix(comment): éviter l’erreur quand app.user est null pour l’image de profil

### DIFF
--- a/src/Twig/UserProfilePictureExtension.php
+++ b/src/Twig/UserProfilePictureExtension.php
@@ -15,7 +15,7 @@ class UserProfilePictureExtension extends AbstractExtension
         ];
     }
 
-    public function getUserImage(User $user, string $style): string
+    public function getUserImage(?User $user, string $style): string
     {
         switch ($style) {
             case 'pic':
@@ -27,7 +27,9 @@ class UserProfilePictureExtension extends AbstractExtension
                 break;
         }
 
-        $rel = '/ftp/user/' . $user->getId() . '/' . $style . 'profil.jpg';
+        // If user is not provided (e.g., visitor not logged in), fallback to default image
+        $userId = $user?->getId() ?? 0;
+        $rel = '/ftp/user/' . $userId . '/' . $style . 'profil.jpg';
         if (!file_exists(__DIR__ . '/../../public' . $rel)) {
             $rel = '/ftp/user/0/' . $style . 'profil.jpg';
         }


### PR DESCRIPTION
Fix du bug suivant:
<img width="2084" height="1382" alt="image (1)" src="https://github.com/user-attachments/assets/730af830-7f4a-4709-b770-d8cafdef8ea3" />

Objet
- Corriger l'erreur lors de l'affichage de l'image de profil dans les commentaires quand `app.user` est null.

Correctif
- La fonction Twig `user_image` accepte désormais `?User` et applique un fallback vers l'image par défaut (`/ftp/user/0/...`) si l'utilisateur est absent.

Impact
- Empêche l'exception `TypeError` dans `components/add-comment.html.twig` ligne 6.
- Aucun impact fonctionnel pour les utilisateurs connectés; comportement inchangé lorsque la photo existe.

Reproduction
- Page de commentaire non connecté: le template appelait `user_image(app.user, 'pic')` avec `app.user` null.

Vérifications
- [ ] Lint Twig: `bin/console lint:twig templates`
- [ ] Tests: `make tests`
- [ ] Sanity check: affichage formulaire ajout commentaire connecté/déconnecté.
