### PR TITLE
fix(ffcam): mettre à jour la date d'adhésion lors de la fusion d'adhérents

### DIFF
--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -98,5 +98,11 @@ class MemberMerger
         ->setCafnumParent($newCafUser->getCafnumParent())
         ->setDoitRenouveler($newCafUser->getDoitRenouveler())
         ->setAlerteRenouveler($newCafUser->getAlerteRenouveler());
+
+        // Mettre à jour la date d'adhésion uniquement si elle est valide
+        // Cela évite d'écraser une date existante avec NULL lors du renouvellement
+        if (null !== $newCafUser->getDateAdhesion()) {
+            $oldCafUser->setDateAdhesion($newCafUser->getDateAdhesion());
+        }
     }
 }


### PR DESCRIPTION
## Contexte

Lors de l'analyse du workflow de synchronisation FFCam, nous avons identifié que la date d'adhésion n'était pas mise à jour lors de la fusion d'adhérents (quand un adhérent renouvelle avec un nouveau numéro de licence).

## Problème

Quand un adhérent renouvelle sa licence et obtient un nouveau numéro FFCam :
- Le système détecte correctement le doublon (même nom, prénom, date de naissance)
- La fusion met à jour toutes les informations SAUF la date d'adhésion
- L'adhérent garde donc son ancienne date d'adhésion expirée

## Impact

- **Incohérence des données** : La date d'adhésion ne reflète pas le renouvellement réel
- **Traçabilité** : Impossible de savoir quand l'adhérent a vraiment renouvelé
- **Risque futur** : Si la logique de blocage change, ces adhérents pourraient être bloqués à tort

## Solution

Ajout de la mise à jour de la date d'adhésion dans `MemberMerger::mergeUser()` avec la même protection contre les valeurs NULL que dans `FfcamSynchronizer::updateExistingUser()`.

## Test

- [ ] Vérifier que la fusion d'adhérents met bien à jour la date d'adhésion
- [ ] Vérifier que les dates NULL ne sont pas écrasées

🤖 Generated with [Claude Code](https://claude.ai/code)