### PR TITLE
feat: retirer le livret d'accueil du menu vert

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -190,11 +190,6 @@
                             <p class="menutitle">Outils</p>
                             <ul>
                             {% if caf_id == 'lyon' %}
-                                <li>
-                                    <a href="https://www.clubalpinlyon.fr/ftp/telechargements/livretaccueil-v3.pdf" title="">
-                                    livret d'accueil des adhérents
-                                    </a>
-                                </li>
                                 {% if allowed('user_read_private') %} {# utilisation d'une permission existante données uniquement aux co-encadrants, encadrants et stagiaires #}
                                 <li>
                                     <a href="/pages/boite-outils-des-encadrants.html" title="">


### PR DESCRIPTION
## Summary
- Suppression du lien vers le livret d'accueil des adhérents dans la section "Outils" du menu vert

## Test plan
- [ ] Vérifier que le menu vert s'affiche correctement
- [ ] Vérifier que la section "Outils" ne contient plus le lien vers le livret d'accueil
- [ ] Vérifier que les autres liens de la section fonctionnent toujours

🤖 Generated with [Claude Code](https://claude.ai/code)