### PR TITLE
fix: réduire la période de tolérance pour les adhérents non licenciés

### DIFF
--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -21,7 +21,7 @@ class FfcamSynchronizer
     ) {
         $today = new \DateTime();
         $startDate = new \DateTime($today->format('Y') . '-08-25');
-        $endDate = new \DateTime($today->format('Y') . '-10-31');
+        $endDate = new \DateTime($today->format('Y') . '-09-30');
 
         $this->hasTolerancyPeriodPassed = !($today >= $startDate && $today <= $endDate);
     }

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -117,7 +117,7 @@ class FfcamSynchronizerTest extends WebTestCase
             ],
         ]);
 
-        ClockMock::freeze(new \DateTime('2024-10-15'));
+        ClockMock::freeze(new \DateTime('2024-09-15'));
 
         $existingUser = $this->signup();
         $existingUser
@@ -156,7 +156,7 @@ class FfcamSynchronizerTest extends WebTestCase
             ],
         ]);
 
-        ClockMock::freeze(new \DateTime('2024-11-15'));
+        ClockMock::freeze(new \DateTime('2024-10-15'));
 
         $existingUser = $this->signup();
         $existingUser
@@ -195,7 +195,7 @@ class FfcamSynchronizerTest extends WebTestCase
             ],
         ]);
 
-        ClockMock::freeze(new \DateTime('2024-11-01'));
+        ClockMock::freeze(new \DateTime('2024-10-01'));
 
         $expiredUser = $this->signup();
         $expiredUser


### PR DESCRIPTION
## 📝 Description

Cette PR réduit la période de tolérance durant laquelle les adhérents non licenciés peuvent encore participer aux sorties du club.

### Changements effectués :
- **Ancienne période** : du 25 août au 31 octobre (2 mois)
- **Nouvelle période** : du 25 août au 30 septembre (1 mois)

## 🎯 Motivation

Encourager les adhérents à renouveler leur licence plus rapidement après la rentrée de septembre, tout en leur laissant un mois complet pour effectuer leur renouvellement.

## 🔧 Modifications techniques

- Modification de la date de fin dans `FfcamSynchronizer.php` : passage du 31 octobre au 30 septembre
- Ajustement des tests unitaires pour refléter la nouvelle période de tolérance

## ✅ Tests

Les tests unitaires ont été mis à jour pour valider le nouveau comportement :
- Les dates de test ont été ajustées pour vérifier que la tolérance s'applique bien jusqu'au 30 septembre
- Après le 30 septembre, les adhérents non licenciés sont correctement marqués comme devant renouveler

## 🚀 Impact

Les adhérents qui n'ont pas renouvelé leur licence seront bloqués plus tôt dans la saison (dès le 1er octobre au lieu du 1er novembre), ce qui devrait inciter à un renouvellement plus rapide des adhésions.

🤖 Generated with [Claude Code](https://claude.ai/code)