### PR TITLE
Fix: amélioration du SEO - simplification du robots.txt

### DIFF
--- a/src/Controller/RobotsController.php
+++ b/src/Controller/RobotsController.php
@@ -36,17 +36,6 @@ class RobotsController
             'User-agent: *',
             '',
             'Disallow: /admin/',
-            'Disallow: /app/',
-            'Disallow: /config/',
-            'Disallow: /css/',
-            'Disallow: /fonts/',
-            'Disallow: /ftp/',
-            'Disallow: /img/',
-            'Disallow: /IMG/',
-            'Disallow: /js/',
-            'Disallow: /scripts/',
-            'Disallow: /templates/',
-            'Disallow: /tools/',
             'Sitemap: ' . $baseUrl . '/sitemap.xml',
         ];
 


### PR DESCRIPTION
## Summary
- Suppression des restrictions inutiles dans robots.txt pour améliorer l'indexation SEO
- Les moteurs de recherche peuvent maintenant accéder aux ressources statiques nécessaires

## Changements
- Suppression des Disallow pour les dossiers de ressources statiques (/css/, /js/, /img/, /fonts/, etc.)
- Conservation uniquement du Disallow pour /admin/ (zone d'administration)
- Le sitemap reste référencé

## Contexte
Les restrictions précédentes empêchaient les moteurs de recherche d'accéder aux CSS, JavaScript et images, ce qui pouvait nuire au rendu et à l'indexation des pages.

## Test plan
- [ ] Vérifier que /robots.txt affiche correctement les nouvelles règles
- [ ] Confirmer que seul /admin/ est bloqué
- [ ] Vérifier que le sitemap est toujours référencé

🤖 Generated with [Claude Code](https://claude.ai/code)