### PR TITLE
docs: déplacer le warning Clever Cloud au bon endroit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,6 @@
 ![Database](https://img.shields.io/badge/MySQL-8.0-4479A1?logo=mysql)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## ⚠️ TOKEN CLEVER CLOUD - ATTENTION CRITIQUE
-
-**🔴 UN SEUL TOKEN PARTAGÉ POUR TOUS LES CLUBS (Lyon, Chambéry, Clermont, etc.)**
-- **Token nominatif** lié à un compte personnel (pas de compte service)
-- **Expire après 1 AN** - Renouveler IMPÉRATIVEMENT avant expiration
-- **Si le détenteur quitte le projet** : Renouveler IMMÉDIATEMENT
-- **Impact** : Une expiration bloque TOUS les déploiements de TOUS les clubs
-
-**Secrets GitHub à maintenir :**
-- `CLEVER_TOKEN` : Token partagé unique
-- `CLEVER_SECRET` : Secret associé
-
 ## 🏔️ À propos
 
 Application web permettant de gérer un Club Alpin Francais! Ce projet est utilisé par plusieurs clubs alpins pour gérer leurs activités, adhérents et sorties.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -21,3 +21,32 @@ Nous disposons de deux environnements hébergés sur [Clever Cloud](https://www.
 - Base de données MySQL 8.0 (hébergée et managée par Clever Cloud)
 - Variables d'environnement gérées dans la console de Clever Cloud
 - filesystem fourni par Clever Cloud: 1 pour le dossier `ftp` et un pour l'upload du fichier de la FFCAM.
+
+## Gestion des déploiements
+
+### Token d'authentification Clever Cloud
+
+> **Note importante** : Un seul token Clever Cloud est partagé entre tous les clubs utilisant cette plateforme (Lyon, Chambéry, Clermont, etc.)
+
+Le déploiement automatique via GitHub Actions nécessite un token d'authentification Clever Cloud avec les contraintes suivantes :
+
+- **Expiration** : Le token expire après 1 an et doit être renouvelé avant cette date
+- **Type de compte** : Token nominatif lié à un compte personnel (Clever Cloud ne propose pas de compte service)
+- **Impact** : Une expiration ou révocation du token empêche tous les déploiements automatiques pour tous les clubs
+- **Renouvellement** : Si le détenteur du token quitte le projet, il faut le renouveler immédiatement
+
+#### Configuration dans GitHub
+
+Les secrets suivants doivent être configurés dans les paramètres du repository :
+- `CLEVER_TOKEN` : Token d'authentification Clever Cloud
+- `CLEVER_SECRET` : Secret associé au token
+
+#### Renouvellement du token
+
+1. Se connecter à [Clever Cloud Console](https://console.clever-cloud.com/)
+2. Aller dans Profile > Tokens
+3. Créer un nouveau token et noter la date d'expiration
+4. Mettre à jour les secrets `CLEVER_TOKEN` et `CLEVER_SECRET` dans GitHub
+5. Documenter le changement et la nouvelle date d'expiration dans ce fichier
+
+Pour plus d'informations : [Documentation API Clever Cloud](https://www.clever-cloud.com/doc/extend/cc-api/#tokens)


### PR DESCRIPTION
## 📋 Description

Réorganisation du README pour rendre le warning sur le token Clever Cloud moins prominent et mieux placé.

## 🎯 Changements

### ✅ README.md
- Suppression du warning "ATTENTION CRITIQUE" en haut du fichier (trop alarmiste et mal placé)
- README plus accueillant pour les nouveaux contributeurs

### ✅ docs/environments.md  
- Ajout d'une section "Gestion des déploiements"
- Documentation complète sur le token Clever Cloud
- Instructions claires pour le renouvellement
- Ton professionnel et informatif

## 💡 Pourquoi ce changement ?

Le warning en haut du README était :
- ❌ Trop prominent pour les nouveaux contributeurs
- ❌ Pas à sa place logique
- ❌ Formulé de manière alarmiste

Maintenant :
- ✅ L'info est dans la doc d'infrastructure (logique)
- ✅ Les personnes concernées la trouveront naturellement
- ✅ Le README est plus accueillant
- ✅ Le ton est professionnel

## 📖 Impact

Aucun impact fonctionnel, uniquement de la réorganisation de documentation.