### PR TITLE
Fix: Correction des inclusions JavaScript dans la page adhérents

### DIFF
--- a/legacy/pages/adherents.php
+++ b/legacy/pages/adherents.php
@@ -79,9 +79,7 @@ if (allowed('user_see_all')) {
 			<br />
 			<br />
 			<link rel="stylesheet" href="/tools/datatables/media/css/jquery.dataTables.css" type="text/css" media="screen" />
-			<link rel="stylesheet" href="/tools/datatables/extras/TableTools/media/css/TableTools.css" type="text/css" media="screen" />
 			<script type="text/javascript" src="/tools/datatables/media/js/jquery.dataTables.min.js"></script>
-			<script type="text/javascript" src="/tools/datatables/extras/TableTools/media/js/TableTools.min.js"></script>
 
 			<script type="text/javascript">
 				$(document).ready(function() {

--- a/legacy/pages/adherents.php
+++ b/legacy/pages/adherents.php
@@ -78,7 +78,9 @@ if (allowed('user_see_all')) {
 			<!-- AFFICHAGE DU TABLEAU -->
 			<br />
 			<br />
+			<link rel="stylesheet" href="/tools/datatables/media/css/jquery.dataTables.css" type="text/css" media="screen" />
 			<link rel="stylesheet" href="/tools/datatables/extras/TableTools/media/css/TableTools.css" type="text/css" media="screen" />
+			<script type="text/javascript" src="/tools/datatables/media/js/jquery.dataTables.min.js"></script>
 			<script type="text/javascript" src="/tools/datatables/extras/TableTools/media/js/TableTools.min.js"></script>
 
 			<script type="text/javascript">


### PR DESCRIPTION
## Résumé
- Ajout des includes DataTables manquants
- Suppression de TableTools non utilisé

## Changements
- ✅ Ajout de `jquery.dataTables.css` et `jquery.dataTables.min.js`
- 🗑️ Suppression de TableTools (CSS et JS) qui n'était pas configuré

## Test
La page adhérents fonctionne correctement avec DataTables sans erreur JavaScript.