### PR TITLE
Fix: Correction des erreurs PHPStan et workflow CI/CD

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -100,13 +100,31 @@ jobs:
         id: changed-php-files
         if: github.event_name == 'pull_request'
         run: |
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${{ github.event.pull_request.base.sha }} | grep -E '\.php$' | grep -E '^(src|tests|legacy)/' | xargs -r ls 2>/dev/null | paste -sd " " || true)
-          echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No relevant PHP files changed for PHPStan"
+          # Récupérer les fichiers PHP modifiés
+          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${{ github.event.pull_request.base.sha }} | grep -E '\.php$' | grep -E '^(src|tests|legacy)/' || true)
+
+          # Filtrer les fichiers exclus par PHPStan
+          FILTERED_FILES=""
+          for file in $CHANGED_FILES; do
+            # Exclure les fichiers/dossiers configurés dans phpstan.neon
+            if echo "$file" | grep -qE '^(legacy/pages/|legacy/includes/|legacy/index\.php|legacy/app/ajax/pages_reorder\.php|legacy/app/ajax/get_content_html\.php|legacy/admin/ftp\.php|var/cache/)'; then
+              echo "Excluding from PHPStan: $file"
+            else
+              if [ -f "$file" ]; then
+                FILTERED_FILES="$FILTERED_FILES $file"
+              fi
+            fi
+          done
+
+          # Retirer les espaces en début/fin
+          FILTERED_FILES=$(echo "$FILTERED_FILES" | xargs)
+
+          echo "files=$FILTERED_FILES" >> $GITHUB_OUTPUT
+          if [ -z "$FILTERED_FILES" ]; then
+            echo "No relevant PHP files changed for PHPStan (all files are excluded or don't exist)"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "PHP files changed: $CHANGED_FILES"
+            echo "PHP files to analyze: $FILTERED_FILES"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
       
@@ -114,7 +132,7 @@ jobs:
         if: github.event_name == 'pull_request' && steps.changed-php-files.outputs.has_changes == 'true'
         run: |
           echo "Running PHPStan on changed files with parallel processing..."
-          ./bin/tools/phpstan analyse ${{ steps.changed-php-files.outputs.files }} -c phpstan.neon
+          make phpstan-files FILES="${{ steps.changed-php-files.outputs.files }}"
       
       - name: Run PHPStan (full analysis)
         if: github.event_name != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ phpstan: bin/tools/phpstan ## Analyze PHP code with phpstan
 	$(PHP) -dmemory_limit=-1 ./bin/tools/phpstan analyse legacy public src tests -c phpstan.neon -l 1
 .PHONY: phpstan
 
+phpstan-files: bin/tools/phpstan ## Analyze specific PHP files with phpstan
+	$(PHP) -dmemory_limit=-1 ./bin/tools/phpstan analyse $(FILES) -c phpstan.neon
+.PHONY: phpstan-files
+
 ## —— ✅ Test ——
 .PHONY: tests
 tests: ## Run all tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,11 @@ parameters:
     - legacy
     - src
     - tests
-  
+
+  # Autoloaders pour résoudre les classes
+  bootstrapFiles:
+    - vendor/autoload.php
+
   # Cache pour améliorer les performances
   resultCachePath: %tmpDir%/resultCache.php
   


### PR DESCRIPTION
## Résumé
Correction des erreurs PHPStan qui apparaissent dans le workflow CI/CD lors de l'analyse des fichiers modifiés dans les PR.

## Problèmes corrigés

### 1. PHPStan analyse des fichiers exclus
- Le workflow détectait les fichiers modifiés mais PHPStan échouait avec "No files found to analyse"
- Cause : Les fichiers `legacy/pages/` et `legacy/includes/` sont exclus dans phpstan.neon
- Solution : Filtrage des fichiers exclus AVANT de les passer à PHPStan

### 2. PHPUnit non trouvé dans les tests
- Erreur : "Class extends unknown class PHPUnit\Framework\TestCase"
- Cause : L'autoloader de Composer n'était pas chargé
- Solution : Ajout de `bootstrapFiles: vendor/autoload.php` dans phpstan.neon

### 3. Exécution hors Docker
- PHPStan était exécuté directement sans accès aux dépendances
- Solution : Création d'une target Makefile `phpstan-files` qui utilise Docker

## Changements
- ✅ Ajout du filtrage des fichiers exclus dans le workflow
- ✅ Configuration de l'autoloader dans phpstan.neon
- ✅ Nouvelle target Makefile `phpstan-files` pour analyser des fichiers spécifiques
- ✅ Utilisation de la target make dans le workflow pour exécuter dans Docker

## Test
Le workflow devrait maintenant :
- Ignorer correctement les fichiers exclus sans erreur
- Analyser les fichiers de tests sans erreurs sur PHPUnit
- S'exécuter dans le conteneur Docker avec toutes les dépendances