### PR TITLE
fix: retrait champ inutilisé

### DIFF
--- a/legacy/pages/adherents-modifier.php
+++ b/legacy/pages/adherents-modifier.php
@@ -109,45 +109,13 @@ if (!isGranted(SecurityConstants::ROLE_ADMIN) && !allowed('user_edit_notme')) {
             } ?>
 
 			<br />
-			E-mail* :<br />
+			E-mail * :<br />
 			<input type="text" name="email_user" class="type1" value="<?php echo $userEmail; ?>" placeholder="" />
 			<br />
 
-			Mot de passe :<br />
-			<input type="text" name="mdp_user" class="type1" value="" placeholder="" /> (pour ne pas le modifier, laisser vide)
-			<br />
-			<!--
-			Confirmer le mot de passe* :<br />
-			<input type="password" name="mdp_user_confirm" class="type1" value="" placeholder="" />
-			<br />
- -->
 			Numéro de licence :<br />
 			<input type="text" name="cafnum_user" class="type1" value="<?php echo $cafnumUser; ?>" readonly />
 			<br />
-
-			<!--
-			Date de naissance :<br />
-			<input type="text" name="birthday_user" class="type1" value="<?php echo $birthdayUser; ?>" placeholder="jj/mm/aaaa" />
-			<br />
-
-			Numéro de téléphone personnel :<br />
-			<input type="text" name="tel_user" class="type1" value="<?php echo $telUser; ?>" placeholder="" />
-
-			<br />
-			Numéro de téléphone de sécurité :<br />
-			<input type="text" name="tel2_user" class="type1" value="<?php echo $telSecuUser; ?>" placeholder="" />
-
-			<br />
-			Adresse <br />
-			<input type="text" name="adresse_user" class="type1" value="<?php echo $adresseUser; ?>" placeholder="Numéro, rue..." /><br />
-			<input type="text" name="cp_user" style="width:70px" class="type1" value="<?php echo $cpUser; ?>" placeholder="Code postal" />
-			<input type="text" name="ville_user" class="type1" value="<?php echo $villeUser; ?>" placeholder="Ville" /><br />
-			<input type="text" name="pays_user" class="type1" value="<?php echo $paysUser; ?>" placeholder="Pays" /><br />
-
-
-
-			-->
-
 
 			<br />
 			Qui peut le / la contacter sur le site, via un formulaire de contact (adresse e-mail jamais dévoilée) ?<br />

--- a/legacy/scripts/operations/operations.user_edit.php
+++ b/legacy/scripts/operations/operations.user_edit.php
@@ -3,23 +3,13 @@
 use App\Legacy\LegacyContainer;
 
 $userTab = [];
-$userTab['cafnum_user'] = trim(stripslashes($_POST['cafnum_user']));
 $userTab['email_user'] = trim(stripslashes($_POST['email_user']));
-$userTab['mdp_user'] = trim(stripslashes($_POST['mdp_user']));
 $userTab['id_user'] = trim(stripslashes($_POST['id_user']));
 $userTab['auth_contact_user'] = trim(stripslashes($_POST['auth_contact_user']));
-$userTab['lastname_user'] = trim(stripslashes($_POST['lastname_user']));
 
 // vérification du format des données
 if (!isMail($userTab['email_user'])) {
     $errTab[] = 'Adresse e-mail invalide';
-}
-if ('' !== $userTab['mdp_user'] && (strlen($userTab['mdp_user']) < 6 || strlen($userTab['mdp_user']) > 12)) {
-    $errTab[] = 'Le mot de passe doit faire de 6 à 12 caractères';
-}
-
-if (!preg_match('/^(N_D)?\d{12}$/', $userTab['cafnum_user'])) {
-    $errTab[] = "Numéro d'adhérent invalide : " . $userTab['cafnum_user'];
 }
 
 if (!isset($errTab) || 0 === count($errTab)) {


### PR DESCRIPTION
https://app.clickup.com/t/86c5hw879

champs présent dans le formulaire mais non traité à la sauvegarde
comme on n'arriverait pas à gérer correctement le salt & co de symfony depuis une page legacy => on enlève le champ (il y a la fonctionnalité "mot de passe oublié" par ailleurs)