### PR TITLE
fix: ajouter protection authentification sur opérations sensibles

### DIFF
--- a/legacy/scripts/operations.php
+++ b/legacy/scripts/operations.php
@@ -12,6 +12,13 @@ $operationsDir = __DIR__ . '/operations/';
 
 $operation = $_POST['operation'] ?? null;
 
+// Protection : whitelist des opérations publiques autorisées
+$publicOperations = ['user_subscribe'];
+if ($operation && !in_array($operation, $publicOperations, true) && !user()) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
 if (user()) {
     // COMMISSIONS : ACTIVER / DESACTIVER
     if ('commission_majvis' == $operation) {


### PR DESCRIPTION
## 🔒 Correctif de sécurité critique

Ce PR corrige une vulnérabilité de sécurité critique permettant de compromettre des comptes utilisateurs sans authentification.

## Problème identifié

Une vulnérabilité a été reportée par un utilisateur anonyme :
- L'opération `user_edit` permettait de modifier l'email de n'importe quel utilisateur en connaissant uniquement son numéro CAF
- 10+ autres opérations sensibles étaient également exposées sans authentification :
  - `user_create` - Création de comptes
  - `user_update` - Modification de profil
  - `user_attr_add/del` - Gestion des droits utilisateurs
  - `comment_hide` - Masquage de commentaires
  - `partenaire_edit/add/delete` - Gestion des partenaires

## Solution implémentée

Ajout d'une protection par authentification avec principe **"deny by default"** dans `legacy/scripts/operations.php` :

```php
// Protection : whitelist des opérations publiques autorisées
$publicOperations = ['user_subscribe'];
if ($operation && !in_array($operation, $publicOperations, true) && !user()) {
    http_response_code(403);
    exit('Forbidden');
}
```

### Whitelist justifiée (1 seule opération publique)

- `user_subscribe` : Permet aux adhérents d'activer leur compte pré-créé par le cron FFCAM

### Opérations publiques via URL (non concernées par cette protection)

- `user-confirm` : Validation de compte (protégé par token)
- `email-change` : Confirmation changement email (protégé par token)

Ces opérations utilisent `$p1` (paramètres d'URL) et non `$operation` (POST).

## Impact

✅ Correction de 10+ vulnérabilités critiques  
✅ Aucun impact sur les fonctionnalités légitimes  
✅ Protection automatique contre les exploits futurs  
✅ Solution minimaliste (7 lignes ajoutées)

## Test plan

- [ ] Vérifier que l'inscription (`user_subscribe`) fonctionne toujours pour les nouveaux adhérents
- [ ] Vérifier que les opérations authentifiées fonctionnent normalement
- [ ] Vérifier que le PoC fourni retourne maintenant un 403 Forbidden
- [ ] Vérifier que `user-confirm` et `email-change` fonctionnent toujours

Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)