### PR TITLE
fix: balise correcte pour affichage des vidéos

### DIFF
--- a/public/js/ckeditor5-main.js
+++ b/public/js/ckeditor5-main.js
@@ -257,6 +257,9 @@ const editorConfig = {
 	table: {
 		contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties']
 	},
+	mediaEmbed: {
+		previewsInData: true // Génère des iframes au lieu de oembed
+	},
 	translations: [translations]
 };
 


### PR DESCRIPTION
https://app.clickup.com/t/42653954/86c3mhyxk

<img width="1004" height="984" alt="image" src="https://github.com/user-attachments/assets/3b24c15a-2154-4af8-8d0a-b6368dcd3568" />