### PR TITLE
feat: table liaison brevets FFCAM ↔ commissions club

### DIFF
--- a/src/Entity/BrevetReferentiel.php
+++ b/src/Entity/BrevetReferentiel.php
@@ -3,8 +3,6 @@
 namespace App\Entity;
 
 use App\Repository\BrevetReferentielRepository;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -23,18 +21,6 @@ class BrevetReferentiel
 
     #[ORM\Column(name: 'intitule', type: Types::STRING, length: 255)]
     private string $intitule;
-
-    /** @var Collection<int, Commission> */
-    #[ORM\ManyToMany(targetEntity: Commission::class, inversedBy: 'brevets')]
-    #[ORM\JoinTable(name: 'formation_brevet_commission')]
-    #[ORM\JoinColumn(name: 'brevet_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\InverseJoinColumn(name: 'commission_id', referencedColumnName: 'id_commission', onDelete: 'CASCADE')]
-    private Collection $commissions;
-
-    public function __construct()
-    {
-        $this->commissions = new ArrayCollection();
-    }
 
     public function getId(): int
     {
@@ -68,28 +54,6 @@ class BrevetReferentiel
     public function setIntitule(string $intitule): self
     {
         $this->intitule = $intitule;
-
-        return $this;
-    }
-
-    /** @return Collection<int, Commission> */
-    public function getCommissions(): Collection
-    {
-        return $this->commissions;
-    }
-
-    public function addCommission(Commission $commission): self
-    {
-        if (!$this->commissions->contains($commission)) {
-            $this->commissions->add($commission);
-        }
-
-        return $this;
-    }
-
-    public function removeCommission(Commission $commission): self
-    {
-        $this->commissions->removeElement($commission);
 
         return $this;
     }

--- a/src/Entity/Commission.php
+++ b/src/Entity/Commission.php
@@ -74,7 +74,10 @@ class Commission
     private array $mandatoryFields = self::CONFIGURABLE_FIELDS;
 
     /** @var Collection<int, BrevetReferentiel> */
-    #[ORM\ManyToMany(targetEntity: BrevetReferentiel::class, mappedBy: 'commissions')]
+    #[ORM\ManyToMany(targetEntity: BrevetReferentiel::class)]
+    #[ORM\JoinTable(name: 'formation_brevet_commission')]
+    #[ORM\JoinColumn(name: 'commission_id', referencedColumnName: 'id_commission', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'brevet_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private Collection $brevets;
 
     public function __construct(string $title, string $code, int $ordre)
@@ -171,5 +174,21 @@ class Commission
     public function getBrevets(): Collection
     {
         return $this->brevets;
+    }
+
+    public function addBrevet(BrevetReferentiel $brevet): self
+    {
+        if (!$this->brevets->contains($brevet)) {
+            $this->brevets->add($brevet);
+        }
+
+        return $this;
+    }
+
+    public function removeBrevet(BrevetReferentiel $brevet): self
+    {
+        $this->brevets->removeElement($brevet);
+
+        return $this;
     }
 }


### PR DESCRIPTION
## Summary

Ajoute la table `formation_brevet_commission` pour lier les brevets FFCAM aux commissions du club.

## Structure

Table de liaison N:N :
- `brevet_id` → FK vers `formation_brevet_referentiel(id)`
- `commission_id` → FK vers `caf_commission(id_commission)`
- PK composite (brevet_id, commission_id)
- FK CASCADE sur les deux côtés

## Exemple

| brevet_id | commission_id |
|-----------|---------------|
| 12 (BF1-ESC) | 5 (escalade) |
| 15 (BF2-ALP) | 3 (alpinisme) |

## Test plan

- [ ] Vérifier que la migration s'exécute sans erreur
- [ ] Vérifier les FK CASCADE (suppression brevet ou commission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)