### PR TITLE
feat: bloquer les notes de frais pour les sorties trop anciennes

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -314,12 +314,12 @@
 
                 {% if display_notes_de_frais %}
                     {% if event.finished and not event.cancelled and (my_status.role == 'encadrant' or my_status.role == 'coencadrant' or my_status.role == 'stagiaire') %}
-                        {# Date cutoff: September 30 of current year if after Oct 1, otherwise September 30 of previous year #}
+                        {# Date cutoff: September 30 of current year if after Dec 1, otherwise September 30 of previous year #}
                         {% set current_month = "now"|date("n")|number_format %}
                         {% set current_year = "now"|date("Y")|number_format %}
-                        {% set cutoff_year = current_month >= 10 ? current_year : current_year - 1 %}
+                        {% set cutoff_year = current_month >= 12 ? current_year : current_year - 1 %}
                         {% set cutoff_date = date(cutoff_year ~ '-09-30') %}
-                        {% set is_event_after_cutoff = event.startDate >= cutoff_date %}
+                        {% set is_event_after_cutoff = (event.endDate ?? event.startDate) >= cutoff_date %}
 
                         {% if not is_event_after_cutoff %}
                             <div class="alerte info-container" style="margin-bottom:2rem !important">


### PR DESCRIPTION
## Summary
- Bloque la saisie de notes de frais pour les sorties antérieures au 30 septembre de l'année comptable en cours
- Affiche un message explicatif indiquant que les comptes ont été clôturés
- La date butoir est le 30 septembre de l'année en cours si on est à partir du 1er décembre, sinon le 30 septembre de l'année précédente

## Changements
- `templates/sortie/sortie.html.twig` : ajout de la vérification de date et du message d'information

## Test plan
- [ ] Vérifier qu'une sortie récente (après le 30/09 de l'année comptable) affiche bien le formulaire de note de frais
- [ ] Vérifier qu'une sortie ancienne (avant le 30/09) affiche le message "comptes clôturés"
- [ ] Vérifier que le message affiche la bonne année

🤖 Generated with [Claude Code](https://claude.com/claude-code)