### PR TITLE
fix: liens sortie et article

### DIFF
--- a/legacy/includes/agenda-evt-courant.php
+++ b/legacy/includes/agenda-evt-courant.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Entity\EventParticipation;
+use App\Legacy\LegacyContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 ?>
-<a class="agenda-evt-courant" href="/sortie/<?php echo html_utf8($evt['code_evt']) . '-' . (int) $evt['id_evt']; ?>.html?commission=<?php echo $evt['code_commission']; ?>" title="">
+<a class="agenda-evt-courant" href="<?php echo LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($evt['code_evt']), 'id' => (int) $evt['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL); ?>?commission=<?php echo $evt['code_commission']; ?>" title="">
 
 	<!-- picto (retiré) -->
 	<div class="picto">

--- a/legacy/includes/agenda-evt-debut.php
+++ b/legacy/includes/agenda-evt-debut.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Entity\EventParticipation;
+use App\Legacy\LegacyContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-echo '<a class="agenda-evt-debut" target="_top" href="/sortie/' . html_utf8($evt['code_evt']) . '-' . (int) $evt['id_evt'] . '.html?commission=' . $evt['code_commission'];
+echo '<a class="agenda-evt-debut" target="_top" href="' . LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($evt['code_evt']), 'id' => (int) $evt['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL) . '?commission=' . $evt['code_commission'];
 if (allowed('evt_validate') && isset($evt['status_evt']) && 1 != $evt['status_evt']) {
     echo '&forceshow=true';
 }

--- a/legacy/includes/article-lien-small.php
+++ b/legacy/includes/article-lien-small.php
@@ -2,8 +2,9 @@
 // URL
 
 use App\Legacy\LegacyContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-$url = 'article/' . html_utf8($article['code_article']) . '-' . (int) $article['id_article'] . '.html';
+$url = LegacyContainer::get('legacy_router')->generate('article_view', ['code' => html_utf8($article['code_article']), 'id' => (int) $article['id_article']], UrlGeneratorInterface::ABSOLUTE_URL);
 if (isset($current_commission) && $current_commission) {
     $url .= '?commission=' . $current_commission;
 }

--- a/legacy/includes/article-lien.php
+++ b/legacy/includes/article-lien.php
@@ -2,8 +2,9 @@
 // URL
 
 use App\Legacy\LegacyContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-$url = 'article/' . html_utf8($article['code_article']) . '-' . (int) $article['id_article'] . '.html';
+$url = LegacyContainer::get('legacy_router')->generate('article_view', ['code' => html_utf8($article['code_article']), 'id' => (int) $article['id_article']], UrlGeneratorInterface::ABSOLUTE_URL);
 if ($article['code_commission'] ?? null) {
     $url .= '?commission=' . $article['code_commission'];
 } // commission de la sortie associée
@@ -59,7 +60,7 @@ elseif (0 == $article['commission_article']) {
 }
 // -1 = compte rendu de sortie (code_commission compris dans evt)
 elseif (-1 == $article['commission_article']) {
-    $urlEvt = 'sortie/' . $article['evt']['code_evt'] . '-' . $article['evt']['id_evt'] . '.html?commission=' . html_utf8($article['evt']['code_commission']); ?>
+    $urlEvt = LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($article['evt']['code_evt']), 'id' => (int) $article['evt']['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL) . '?commission=' . html_utf8($article['evt']['code_commission']); ?>
 			<a href="<?php echo $urlEvt; ?>" title="Voir la sortie liée à cet article : &laquo; <?php echo html_utf8($article['evt']['titre_evt']); ?> &raquo;">
 				compte rendu de sortie
 			</a>

--- a/legacy/includes/droite-actus.php
+++ b/legacy/includes/droite-actus.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Legacy\LegacyContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 if ($current_commission) {
     echo '<h1 class="actus-h1"><a href="/accueil/' . $current_commission . '.html" title="Afficher tous les articles pour cette commission">actus</a></h1>';
@@ -50,7 +51,7 @@ while ($handle = $handleSql->fetch_array(\MYSQLI_ASSOC)) {
     // AFFICHAGE
     $article = $handle;
 
-    $url = 'article/' . html_utf8($article['code_article']) . '-' . (int) $article['id_article'] . '.html';
+    $url = LegacyContainer::get('legacy_router')->generate('article_view', ['code' => html_utf8($article['code_article']), 'id' => (int) $article['id_article']], UrlGeneratorInterface::ABSOLUTE_URL);
     if ($current_commission) {
         $url .= '?commission=' . $current_commission;
     } ?>
@@ -88,7 +89,7 @@ while ($handle = $handleSql->fetch_array(\MYSQLI_ASSOC)) {
     }
     // -1 = compte rendu de sortie
     elseif (-1 == $article['commission_article']) {
-        $urlEvt = 'sortie/' . $article['evt']['code_evt'] . '-' . $article['evt']['id_evt'] . '.html'; ?>
+        $urlEvt = LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($article['evt']['code_evt']), 'id' => (int) $article['evt']['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL); ?>
                 <a href="<?php echo $urlEvt; ?>" title="Voir la sortie liée à cet article : &laquo; <?php echo html_utf8($article['evt']['titre_evt']); ?> &raquo;">
                     compte rendu de sortie
                 </a>

--- a/legacy/pages/adherents-consulter.php
+++ b/legacy/pages/adherents-consulter.php
@@ -218,7 +218,7 @@ if (!isGranted(SecurityConstants::ROLE_ADMIN) && !allowed('user_edit_notme')) {
             }
             ++$rowValueHeader[$evt['role_evt_join']];
 
-            $row = '<a target="_blank" href="/sortie/' . html_utf8($evt['code_evt']);
+            $row = '<a target="_blank" href="' . LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($evt['code_evt']), 'id' => (int) $evt['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL);
             if (allowed('evt_validate') && 1 != $evt['status_evt']) {
                 $row .= '&forceshow=true';
             }

--- a/legacy/scripts/operations/operations.user_contact.php
+++ b/legacy/scripts/operations/operations.user_contact.php
@@ -103,9 +103,9 @@ if (!isset($errTab) || 0 === count($errTab)) {
     $eventLink = $articleLink = null;
 
     if ($event) {
-        $eventLink = LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL) . 'sortie/' . $event['code_evt'] . '-' . $event['id_evt'] . '.html';
+        $eventLink = LegacyContainer::get('legacy_router')->generate('sortie', ['code' => html_utf8($event['code_evt']), 'id' => (int) $event['id_evt']], UrlGeneratorInterface::ABSOLUTE_URL);
     } elseif ($article) {
-        $articleLink = LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL) . 'article/' . $article['code_article'] . '-' . $article['id_article'] . '.html';
+        $articleLink = LegacyContainer::get('legacy_router')->generate('article_view', ['code' => html_utf8($article['code_article']), 'id' => (int) $article['id_article']], UrlGeneratorInterface::ABSOLUTE_URL);
     }
     LegacyContainer::get('legacy_mailer')->send($destinataire['email_user'], 'transactional/contact-form', [
         'contact_name' => $nom,

--- a/src/Controller/RssController.php
+++ b/src/Controller/RssController.php
@@ -29,7 +29,8 @@ class RssController extends AbstractController
         CommissionRepository $commissionRepository,
         ArticleRepository $articleRepository,
         EvtRepository $evtRepository,
-        CacheManager $cacheManager
+        CacheManager $cacheManager,
+        UrlGeneratorInterface $urlGenerator,
     ) {
         $comTab = [];
 
@@ -57,7 +58,10 @@ class RssController extends AbstractController
 
             foreach ($articleRepository->getArticles($commission, ['limit' => $rssLimit]) as $article) {
                 $entry['title'] = $article->getTitre();
-                $entry['link'] = LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL) . 'article/' . $article->getCode() . '-' . $article->getId() . '.html';
+                $entry['link'] = $urlGenerator->generate('article_view', [
+                    'code' => $article->getCode(),
+                    'id' => $article->getId(),
+                ], UrlGeneratorInterface::ABSOLUTE_URL);
                 $entry['description'] = $article->getCont();
                 $entry['timestamp'] = $article->getCreatedAt()->getTimestamp();
 
@@ -85,7 +89,10 @@ class RssController extends AbstractController
 
             foreach ($evtRepository->getUpcomingEvents($commission, ['limit' => $rssLimit]) as $event) {
                 $entry['title'] = $event->getTitre();
-                $entry['link'] = LegacyContainer::get('legacy_router')->generate('legacy_root', [], UrlGeneratorInterface::ABSOLUTE_URL) . 'sortie/' . $event->getCode() . '-' . $event->getId() . '.html';
+                $entry['link'] = $urlGenerator->generate('sortie', [
+                    'code' => $event->getCode(),
+                    'id' => $event->getId(),
+                ], UrlGeneratorInterface::ABSOLUTE_URL);
                 $entry['description'] = '';
                 if ($event->getCommission()) {
                     $entry['description'] .= 'Commission ' . $event->getCommission()->getTitle();

--- a/templates/macros/event-line.html.twig
+++ b/templates/macros/event-line.html.twig
@@ -150,10 +150,10 @@
                         <b style="margin-left: 20px">Attention au timing :</b>
                         {% for empietement in empietements %}
                             {% if empietement.status == constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME') %}
-                                <br />- Vous êtes aussi pré-inscrit sur la sortie <a href="/sortie/{{ empietement.event.code }}-{{ empietement.event.id }}.html" title="">{{ empietement.event.titre }}</a>
+                                <br />- Vous êtes aussi pré-inscrit sur la sortie <a href="{{ path('sortie', {'code': empietement.event.code, 'id': empietement.event.id}) }}" title="">{{ empietement.event.titre }}</a>
                             {% endif %}
                             {% if empietement.status == constant('App\\Entity\\EventParticipation::STATUS_VALIDE') %}
-                                <br />- Vous êtes aussi <span style="color:red">confirmé</span> sur la sortie <a href="/sortie/{{ empietement.event.code }}-{{ empietement.event.id }}.html" title="">{{ empietement.event.titre }}</a>
+                                <br />- Vous êtes aussi <span style="color:red">confirmé</span> sur la sortie <a href="{{ path('sortie', {'code': empietement.event.code, 'id': empietement.event.id}) }}" title="">{{ empietement.event.titre }}</a>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/templates/profil/sorties.html.twig
+++ b/templates/profil/sorties.html.twig
@@ -171,10 +171,10 @@
                                             <b style="margin-left: 20px">Attention au timing :</b>
                                             {% for empietement in empietements %}
                                                 {% if empietement.status == constant('App\\Entity\\EventParticipation::STATUS_NON_CONFIRME') %}
-                                                    <br />- Vous êtes aussi pré-inscrit sur la sortie <a href="/sortie/{{ empietement.event.code }}-{{ empietement.event.id }}.html" title="">{{ empietement.event.titre }}</a>
+                                                    <br />- Vous êtes aussi pré-inscrit sur la sortie <a href="{{ path('sortie', {'code': empietement.event.code, 'id': empietement.event.id}) }}" title="">{{ empietement.event.titre }}</a>
                                                  {% endif %}
                                                 {% if empietement.status == constant('App\\Entity\\EventParticipation::STATUS_VALIDE') %}
-                                                    <br />- Vous êtes aussi <span style="color:red">confirmé</span> sur la sortie <a href="/sortie/{{ empietement.event.code }}-{{ empietement.event.id }}.html" title="">{{ empietement.event.titre }}</a>
+                                                    <br />- Vous êtes aussi <span style="color:red">confirmé</span> sur la sortie <a href="{{ path('sortie', {'code': empietement.event.code, 'id': empietement.event.id}) }}" title="">{{ empietement.event.titre }}</a>
                                                 {% endif %}
                                             {% endfor %}
                                         </div>

--- a/templates/right-column.html.twig
+++ b/templates/right-column.html.twig
@@ -49,7 +49,7 @@
                 {% for event in list_events(get_commission(current_commission)) %}
                     {% set nInscritsTotal = event.participations() | length %}
                     {% set nPlacesRestantesTotal = max(0, event.ngensMax - nInscritsTotal) %}
-                    <a href="/sortie/{{ event.code }}-{{ event.id }}.html?commission={{ event.commission.code }}" title="Voir la sortie">
+                    <a href="{{ path('sortie', {'code': event.code, 'id': event.id}) }}?commission={{ event.commission.code }}" title="Voir la sortie">
                         <span style="color:#000">{{ event.startDate | intldate('ccc d/MM') | capitalize }} </span> |
                         {% if event.cancelled %}
                             <span class="cancelled">Sortie annulée</span>


### PR DESCRIPTION
depuis la refonte symfony des pages de visualisation sortie et article, certains liens n'ont pas été mis à jour et peuvent générer des erreurs d'inclusion