### PR TITLE
fix: préserver les images du club dans le HTML sanitizer

### DIFF
--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -6,9 +6,11 @@ framework:
                 allow_elements:
                     a: ['href', 'title', 'target', 'rel']
                     img: ['src', 'alt', 'title', 'width', 'height', 'class', 'style']
+                    figure: ['class', 'style']
                     iframe: ['src', 'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'title']
                 allowed_media_schemes: ['https']
                 allowed_media_hosts:
+                    - '%env(key:host:url:BACKEND_URL)%'
                     - 'youtube.com'
                     - 'www.youtube.com'
                     - 'youtube-nocookie.com'
@@ -21,5 +23,5 @@ framework:
                     - 'www.loom.com'
                     - 'luna.loom.com'
                     - 'cdn.loom.com'
-                allow_relative_medias: false
+                allow_relative_medias: true
                 force_https_urls: true

--- a/tests/Twig/HtmlSanitizerTest.php
+++ b/tests/Twig/HtmlSanitizerTest.php
@@ -84,7 +84,7 @@ class HtmlSanitizerTest extends KernelTestCase
             ],
             'onerror on img' => [
                 '<img src="x" onerror="alert(\'xss\')">',
-                '<img />',
+                '<img src="x" />',
             ],
             'javascript href' => [
                 '<a href="javascript:alert(\'xss\')">Click</a>',
@@ -232,5 +232,25 @@ HTML;
         $this->assertStringNotContainsString('javascript:', $result);
         $this->assertStringNotContainsString('onclick', $result);
         $this->assertStringNotContainsString('stealData', $result);
+    }
+
+    public function testPreservesSiteImages(): void
+    {
+        // Use localhost as it's the BACKEND_URL host in test environment
+        $input = '<figure class="image image_resized" style="width:49.71%;"><img style="aspect-ratio:1999/2999;" src="https://localhost/ftp/uploads/files/photo.jpg" width="1999" height="2999"></figure>';
+
+        $result = $this->sanitizer->sanitize($input);
+
+        // Figure tag with class and style preserved
+        $this->assertStringContainsString('<figure', $result);
+        $this->assertStringContainsString('class="image image_resized"', $result);
+        $this->assertStringContainsString('style="width:49.71%;"', $result);
+
+        // Image tag with all attributes preserved
+        $this->assertStringContainsString('<img', $result);
+        $this->assertStringContainsString('src="https://localhost/ftp/uploads/files/photo.jpg"', $result);
+        $this->assertStringContainsString('style="aspect-ratio:1999/2999;"', $result);
+        $this->assertStringContainsString('width="1999"', $result);
+        $this->assertStringContainsString('height="2999"', $result);
     }
 }


### PR DESCRIPTION
## Summary
- Corrige le bug d'affichage des images dans les articles et sorties
- Le sanitizer supprimait les attributs `src`, `class` et `style` des images/figures hébergées sur le site

## Changements
- Utilise `%env(key:host:url:BACKEND_URL)%` pour extraire dynamiquement le host autorisé (fonctionne pour Lyon, Chambéry, Clermont...)
- Ajoute `figure: ['class', 'style']` aux éléments autorisés
- Active `allow_relative_medias: true` pour les chemins relatifs
- Ajoute un test pour valider le comportement

## Avant / Après

**Avant (bug):**
```html
<figure><img style="aspect-ratio:2971/4452;" width="2971" height="4452" /></figure>
```

**Après (fix):**
```html
<figure class="image image_resized" style="width:47.72%;">
  <img style="aspect-ratio:2971/4452;" src="https://www.clubalpinlyon.fr/ftp/uploads/files/photo.jpg" width="2971" height="4452" />
</figure>
```

## Test plan
- [ ] Vérifier qu'un article avec des images s'affiche correctement
- [ ] Vérifier qu'une sortie avec des images s'affiche correctement
- [ ] Vérifier que les images gardent leur dimensionnement (style width sur figure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)