### PR TITLE
feat: autoriser les images externes dans le HTML sanitizer

### DIFF
--- a/config/packages/html_sanitizer.yaml
+++ b/config/packages/html_sanitizer.yaml
@@ -9,19 +9,9 @@ framework:
                     figure: ['class', 'style']
                     iframe: ['src', 'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'title']
                 allowed_media_schemes: ['https']
-                allowed_media_hosts:
-                    - '%env(key:host:url:BACKEND_URL)%'
-                    - 'youtube.com'
-                    - 'www.youtube.com'
-                    - 'youtube-nocookie.com'
-                    - 'www.youtube-nocookie.com'
-                    - 'vimeo.com'
-                    - 'player.vimeo.com'
-                    - 'dailymotion.com'
-                    - 'www.dailymotion.com'
-                    - 'loom.com'
-                    - 'www.loom.com'
-                    - 'luna.loom.com'
-                    - 'cdn.loom.com'
+                # Images: all HTTPS domains allowed
+                # Iframes: restricted by IframeSrcSanitizer to video platforms only
                 allow_relative_medias: true
                 force_https_urls: true
+                with_attribute_sanitizers:
+                    - App\HtmlSanitizer\IframeSrcSanitizer

--- a/src/HtmlSanitizer/IframeSrcSanitizer.php
+++ b/src/HtmlSanitizer/IframeSrcSanitizer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\HtmlSanitizer;
+
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+use Symfony\Component\HtmlSanitizer\Visitor\AttributeSanitizer\AttributeSanitizerInterface;
+
+/**
+ * Sanitizes iframe src attributes to only allow specific video hosting domains.
+ * Images are not affected by this sanitizer (they allow all HTTPS domains).
+ */
+class IframeSrcSanitizer implements AttributeSanitizerInterface
+{
+    private const ALLOWED_IFRAME_HOSTS = [
+        'youtube.com',
+        'www.youtube.com',
+        'youtube-nocookie.com',
+        'www.youtube-nocookie.com',
+        'vimeo.com',
+        'player.vimeo.com',
+        'dailymotion.com',
+        'www.dailymotion.com',
+        'loom.com',
+        'www.loom.com',
+        'luna.loom.com',
+        'cdn.loom.com',
+    ];
+
+    public function getSupportedElements(): ?array
+    {
+        return ['iframe'];
+    }
+
+    public function getSupportedAttributes(): ?array
+    {
+        return ['src'];
+    }
+
+    public function sanitizeAttribute(string $element, string $attribute, string $value, HtmlSanitizerConfig $config): ?string
+    {
+        if ('iframe' !== $element || 'src' !== $attribute) {
+            return $value;
+        }
+
+        $parsedUrl = parse_url($value);
+
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
+            // Return empty string to clear the src attribute (null causes issues with chained sanitizers)
+            return '';
+        }
+
+        // Only allow HTTPS
+        if (!isset($parsedUrl['scheme']) || 'https' !== $parsedUrl['scheme']) {
+            return '';
+        }
+
+        $host = strtolower($parsedUrl['host']);
+
+        if (in_array($host, self::ALLOWED_IFRAME_HOSTS, true)) {
+            return $value;
+        }
+
+        // Unauthorized domain: clear the src
+        return '';
+    }
+}


### PR DESCRIPTION
## Summary
- **Images** : autorise tous les domaines HTTPS (les utilisateurs insèrent des images de sites externes)
- **Iframes** : restreint aux plateformes vidéo autorisées (YouTube, Vimeo, Dailymotion, Loom)
- Ajoute un `IframeSrcSanitizer` custom pour filtrer les domaines des iframes

## Changements
- `config/packages/html_sanitizer.yaml` : supprime la whitelist globale, ajoute le custom sanitizer
- `src/HtmlSanitizer/IframeSrcSanitizer.php` : nouveau sanitizer qui filtre les src des iframes
- `tests/Twig/HtmlSanitizerTest.php` : ajoute tests pour images externes

## Sécurité
- HTTPS obligatoire pour tous les médias
- Iframes limitées aux plateformes vidéo de confiance (pas de risque XSS)
- Images externes : risque de tracking accepté (contexte club communautaire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)