### PR TITLE
fix: sauvegarde du commentaire lors du rejet d'une note de frais

### DIFF
--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -53,7 +53,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Patch(
             uriTemplate: '/notes-de-frais/{id}',
             security: 'object.getUser() == user or is_granted("manage_expense_reports")',
-            // normalizationContext: ['groups' => ['report:read', 'attachment:read', 'user:read', 'event:read']]
+            denormalizationContext: ['groups' => ['report:read']],
         ),
     ],
     security: "is_granted('ROLE_USER')",


### PR DESCRIPTION
## Summary

- Corrige le bug où le commentaire de statut (`commentaireStatut`) n'était pas sauvegardé lors du rejet d'une note de frais
- Les mails de notification étaient envoyés sans le commentaire

## Investigation

### Symptômes rapportés
- Les commentaires lors de la validation ou du rejet d'une note de frais ne sont pas enregistrés
- Les mails d'information sont envoyés mais sans le commentaire

### Analyse du code

1. **Client compta-club** : Envoie correctement `commentaireStatut` dans le JSON (vérifié dans `app/lib/hooks/useExpenseAction.ts`)

2. **API Symfony** : Le champ `statusComment` a un `#[SerializedName('commentaireStatut')]` mais le `status` n'en a pas

3. **Test du serializer** :
```
Avec groups: ['report:read'] → denormalize(commentaireStatut): statusComment  ✅
Sans context               → denormalize(commentaireStatut): commentaireStatut ❌
```

Le `MetadataAwareNameConverter` de Symfony **nécessite un contexte de groupes** pour effectuer la conversion inverse des `SerializedName`.

### Commit responsable

**`f415419a`** du 28 août 2025 ("refactor: remplacer Hydra par format JSON avec métadonnées")

Ce commit a :
- Ajouté `#[SerializedName('commentaireStatut')]` au champ `statusComment`
- Supprimé la config `use_symfony_listeners: true`
- Migré de JSON-LD (Hydra) vers JSON simple
- **Sans ajouter de `denormalizationContext`** sur l'opération PATCH

### Pourquoi `status` fonctionne mais pas `statusComment` ?

| Champ | SerializedName | Résultat |
|-------|----------------|----------|
| `status` | ❌ Aucun | Le nom PHP `status` est utilisé directement → ✅ fonctionne |
| `statusComment` | ✅ `commentaireStatut` | Sans contexte de groupes, `commentaireStatut` n'est pas converti en `statusComment` → ❌ ignoré |

## Solution

Ajout de `denormalizationContext: ['groups' => ['report:read']]` sur l'opération PATCH.

Cela active le mapping des noms sérialisés lors de la dénormalisation, permettant au serializer de convertir `commentaireStatut` → `statusComment`.

## Effets de bord

Aucun risque. Ce changement ne fait qu'activer le mapping correct des noms de champs. Les seuls champs modifiables via PATCH sont ceux avec le groupe `report:read` :
- `status` ✅
- `statusComment` ✅  
- `details` ✅
- `refundRequired` ✅

Les champs `user`, `event`, `attachments` ne sont pas modifiables (groupes différents), ce qui est le comportement souhaité.

## Test plan

- [ ] Rejeter une note de frais avec un commentaire via l'app compta
- [ ] Vérifier que le commentaire est enregistré en base de données
- [ ] Vérifier que le mail de notification contient le commentaire

🤖 Generated with [Claude Code](https://claude.com/claude-code)