### PR TITLE
ci: restreindre le déploiement prod aux branches production et hotfix-prod-*

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   deploy-to-clevercloud:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod' || startsWith(github.ref, 'refs/heads/hotfix-prod-')
+    if: github.ref == 'refs/heads/production' || startsWith(github.ref, 'refs/heads/hotfix-prod-')
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Supprime `main` et `prod` des branches autorisées pour le déploiement en production
- Seules les branches `production` et `hotfix-prod-*` peuvent maintenant déclencher un déploiement

## Contexte

Alignement avec la nouvelle stratégie de branches :
- `main` = branche de développement principale
- `production` = branche de déploiement en prod
- `hotfix-prod-*` = hotfixes urgents

🤖 Generated with [Claude Code](https://claude.com/claude-code)