### PR TITLE
fix: afficher les notes de frais soumises même après la date de clôture

### DIFF
--- a/src/Utils/Enums/ExpenseReportStatusEnum.php
+++ b/src/Utils/Enums/ExpenseReportStatusEnum.php
@@ -9,6 +9,4 @@ enum ExpenseReportStatusEnum: string
     case REJECTED = 'rejected';
     case APPROVED = 'approved';
     case ACCOUNTED = 'accounted';
-
-    case PAID = 'paid';
 }

--- a/src/Validator/ExpenseReport/StatusTransitionValidator.php
+++ b/src/Validator/ExpenseReport/StatusTransitionValidator.php
@@ -30,7 +30,7 @@ class StatusTransitionValidator
             ExpenseReportStatusEnum::SUBMITTED->value => [ExpenseReportStatusEnum::APPROVED->value, ExpenseReportStatusEnum::REJECTED->value],
             ExpenseReportStatusEnum::APPROVED->value => [ExpenseReportStatusEnum::ACCOUNTED->value],
             ExpenseReportStatusEnum::REJECTED->value => [ExpenseReportStatusEnum::SUBMITTED->value],
-            ExpenseReportStatusEnum::ACCOUNTED->value => [ExpenseReportStatusEnum::PAID->value],
+            // ACCOUNTED is a terminal state
         ];
 
         if (!isset($validTransitions[$oldStatus->value]) || !\in_array($newStatus->value, $validTransitions[$oldStatus->value], true)) {

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -372,7 +372,10 @@
 
                 {% if display_notes_de_frais %}
                     {% if event.finished and not event.cancelled and (my_status.role == 'encadrant' or my_status.role == 'coencadrant' or my_status.role == 'stagiaire') %}
-                        {% if not is_event_after_cutoff %}
+                        {% if has_viewable_expense_report %}
+                            {# User already has a submitted/approved/accounted expense report, always show it #}
+                            {% include 'vuejs/expense-report-form.twig' %}
+                        {% elseif not is_event_after_cutoff %}
                             <div class="alerte info-container" style="margin-bottom:2rem !important">
                                 <img src="/img/base/cross.png" alt="" title=""/>
                                 <div class="text-container">


### PR DESCRIPTION
## Summary

- Permet aux utilisateurs de voir leurs notes de frais déjà soumises/approuvées/comptabilisées même si la date de clôture comptable est dépassée
- Ajoute la variable `cutoff_year` au template pour afficher l'année de clôture
- Supprime le statut `PAID` inutilisé (non présent dans la base de données)
- Ajoute 6 tests pour valider le comportement

## Contexte

Avant ce fix, les utilisateurs ne pouvaient plus voir leurs notes de frais une fois la date de clôture passée, même si elles avaient déjà été soumises. Ce fix permet de consulter les notes de frais dans les états suivants après la clôture :
- `submitted` (en vérification)
- `approved` (approuvée)
- `accounted` (comptabilisée)

Les brouillons (`draft`) et les notes rejetées (`rejected`) restent masquées après la clôture.

## Test plan

- [x] Vérifier qu'une note de frais soumise s'affiche pour une sortie de 2024
- [x] Vérifier qu'une note de frais comptabilisée s'affiche pour une sortie de 2024
- [x] Vérifier qu'un brouillon ne s'affiche PAS pour une sortie de 2024 (message "comptes clôturés")
- [x] Tests unitaires ajoutés (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)