### PR TITLE
fix: améliorer les messages d'erreur des notes de frais

### DIFF
--- a/src/Validator/ExpenseReport/AttachmentValidator.php
+++ b/src/Validator/ExpenseReport/AttachmentValidator.php
@@ -8,6 +8,13 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class AttachmentValidator
 {
+    private const EXPENSE_LABELS = [
+        'fuelExpense' => 'Carburant',
+        'rentalPrice' => 'Location',
+        'ticketPrice' => 'Billet de transport',
+        'tollExpense' => 'Péage',
+    ];
+
     public function validate(Collection $attachments, array $requiredAttachments, ExecutionContextInterface $context)
     {
         foreach ($requiredAttachments as $expenseId) {
@@ -22,8 +29,9 @@ class AttachmentValidator
         });
 
         if (!$attachmentExists) {
-            $context->buildViolation('Attachment is missing for expense with ID \'{expenseId}\'.')
-                ->setParameter('{expenseId}', $expenseId)
+            $label = self::EXPENSE_LABELS[$expenseId] ?? $expenseId;
+            $context->buildViolation('Un justificatif est requis pour le champ « {label} ».')
+                ->setParameter('{label}', $label)
                 ->addViolation();
         }
     }

--- a/src/Validator/ExpenseReport/TransportDetailsValidator.php
+++ b/src/Validator/ExpenseReport/TransportDetailsValidator.php
@@ -28,6 +28,22 @@ class TransportDetailsValidator
         'PUBLIC_TRANSPORT' => ['ticketPrice'],
     ];
 
+    private const FIELD_LABELS = [
+        'distance' => 'Distance',
+        'fuelExpense' => 'Carburant',
+        'rentalPrice' => 'Location',
+        'ticketPrice' => 'Billet de transport',
+        'passengerCount' => 'Nombre de passagers',
+        'tollExpense' => 'Péage',
+    ];
+
+    private const TYPE_LABELS = [
+        'PERSONAL_VEHICLE' => 'véhicule personnel',
+        'CLUB_MINIBUS' => 'minibus du club',
+        'RENTAL_MINIBUS' => 'minibus de location',
+        'PUBLIC_TRANSPORT' => 'transport en commun',
+    ];
+
     public function __construct(
         private AttachmentValidator $attachmentValidator
     ) {
@@ -51,7 +67,7 @@ class TransportDetailsValidator
     private function isValidTransportObject($transport, ExecutionContextInterface $context): bool
     {
         if (!\is_array($transport)) {
-            $context->buildViolation('Transport details must be an object.')
+            $context->buildViolation('Les détails du transport sont invalides.')
                 ->atPath('details.transport')
                 ->addViolation();
 
@@ -59,7 +75,7 @@ class TransportDetailsValidator
         }
 
         if (!isset($transport['type'])) {
-            $context->buildViolation('Transport type is missing.')
+            $context->buildViolation('Le type de transport est requis.')
                 ->atPath('details.transport.type')
                 ->addViolation();
 
@@ -72,7 +88,7 @@ class TransportDetailsValidator
     private function isValidTransportType(string $type, ExecutionContextInterface $context): bool
     {
         if (!\in_array($type, self::VALID_TYPES, true)) {
-            $context->buildViolation('Invalid transport type.')
+            $context->buildViolation('Type de transport invalide.')
                 ->atPath('details.transport.type')
                 ->addViolation();
 
@@ -85,10 +101,12 @@ class TransportDetailsValidator
     private function validateRequiredFields(array $transport, string $type, ExecutionContextInterface $context): void
     {
         $requiredFields = self::REQUIRED_FIELDS[$type] ?? [];
+        $typeLabel = self::TYPE_LABELS[$type] ?? $type;
 
         foreach ($requiredFields as $field) {
             if (!isset($transport[$field])) {
-                $context->buildViolation("{$field} is required for {$type}.")
+                $fieldLabel = self::FIELD_LABELS[$field] ?? $field;
+                $context->buildViolation("Le champ « {$fieldLabel} » est requis pour le {$typeLabel}.")
                     ->atPath("details.transport.{$field}")
                     ->addViolation();
             }


### PR DESCRIPTION
## Problème

Quand un utilisateur soumet une note de frais avec une erreur de validation (ex: justificatif manquant pour le carburant d'un minibus de location), le toast affiche simplement **"Une erreur s'est produite"** sans aucun détail.



## Solution

### Frontend (`useExpenseReport.ts`)
- Parser les erreurs de validation retournées par l'API (format API Platform)
- Afficher chaque message d'erreur dans un toast séparé
- Conserver le message générique en fallback si l'erreur n'est pas parsable

### Backend (Validators PHP)
- Traduire les messages d'erreur en français
- Utiliser les libellés des champs au lieu des identifiants techniques

## Résultat

| Avant | Après |
|-------|-------|
| "Une erreur s'est produite" | "Un justificatif est requis pour le champ « Carburant »." |
| | "Le champ « Distance » est requis pour le véhicule personnel." |

<img width="394" height="158" alt="Capture d’écran 2026-01-07 à 10 57 38" src="https://github.com/user-attachments/assets/afd31fcc-4e44-44f4-b110-b29c0965c6db" />


## Fichiers modifiés

- `assets/expense-report-form/src/composables/useExpenseReport.ts`
- `src/Validator/ExpenseReport/AttachmentValidator.php`
- `src/Validator/ExpenseReport/TransportDetailsValidator.php`

## Test plan

- [ ] Soumettre une note de frais minibus de location sans justificatif carburant → message clair
- [ ] Soumettre une note de frais véhicule personnel sans distance → message clair
- [ ] Soumettre une note de frais valide → succès normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)