### PR TITLE
feat: séparer endpoints notes de frais user/admin

### DIFF
--- a/src/Entity/ExpenseReport.php
+++ b/src/Entity/ExpenseReport.php
@@ -46,6 +46,10 @@ use Symfony\Component\Validator\Constraints as Assert;
             uriTemplate: '/notes-de-frais',
             security: "is_granted('ROLE_USER')",
         ),
+        new GetCollection(
+            uriTemplate: '/admin/notes-de-frais',
+            security: "is_granted('ROLE_ADMIN') or is_granted('manage_expense_reports')",
+        ),
         new Get(
             uriTemplate: '/notes-de-frais/{id}',
             security: "is_granted('ROLE_ADMIN') or object.getUser() == user or is_granted('manage_expense_reports')",


### PR DESCRIPTION
## Summary

- Ajoute un nouvel endpoint `/admin/notes-de-frais` pour les administrateurs et gestionnaires
- L'endpoint `/notes-de-frais` est maintenant **toujours filtré** par l'utilisateur connecté (même pour les admins)
- Approche "sécurité par défaut" : tout nouvel endpoint sera filtré automatiquement

## Motivation

Un administrateur utilisant le site principal voyait toutes les notes de frais au lieu de voir uniquement les siennes. Cette PR sépare les cas d'usage :

| Endpoint | Utilisateur | Résultat |
|----------|-------------|----------|
| `/notes-de-frais` | Tous | Ses propres notes uniquement |
| `/admin/notes-de-frais` | Admin/Gestionnaire | Toutes les notes |

## Impact

- **App Vue.js (site)** : Aucun changement nécessaire
- **App compta (NextJS)** : Doit être mise à jour pour utiliser `/admin/notes-de-frais`

## Test plan

- [ ] Vérifier qu'un utilisateur lambda voit uniquement ses notes sur `/notes-de-frais`
- [ ] Vérifier qu'un admin voit uniquement ses notes sur `/notes-de-frais`
- [ ] Vérifier qu'un admin voit toutes les notes sur `/admin/notes-de-frais`
- [ ] Vérifier qu'un utilisateur lambda reçoit 403 sur `/admin/notes-de-frais`

🤖 Generated with [Claude Code](https://claude.com/claude-code)