### PR TITLE
fix: groupes de compétences affichés incorrectement dans "Non attribuée"

### DIFF
--- a/src/Entity/Commission.php
+++ b/src/Entity/Commission.php
@@ -90,7 +90,7 @@ class Commission
     private Collection $formations;
 
     /** @var Collection<int, FormationReferentielGroupeCompetence> */
-    #[ORM\ManyToMany(targetEntity: FormationReferentielGroupeCompetence::class)]
+    #[ORM\ManyToMany(targetEntity: FormationReferentielGroupeCompetence::class, inversedBy: 'commissions')]
     #[ORM\JoinTable(name: 'formation_commission_groupe_competence')]
     #[ORM\JoinColumn(name: 'commission_id', referencedColumnName: 'id_commission', onDelete: 'CASCADE')]
     #[ORM\InverseJoinColumn(name: 'groupe_competence_id', referencedColumnName: 'id', onDelete: 'CASCADE')]

--- a/src/Entity/FormationReferentielGroupeCompetence.php
+++ b/src/Entity/FormationReferentielGroupeCompetence.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Repository\FormationReferentielGroupeCompetenceRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
@@ -28,6 +30,15 @@ class FormationReferentielGroupeCompetence
 
     #[ORM\Column(type: Types::STRING, length: 100, nullable: true)]
     private ?string $activite = null;
+
+    /** @var Collection<int, Commission> */
+    #[ORM\ManyToMany(targetEntity: Commission::class, mappedBy: 'groupesCompetences')]
+    private Collection $commissions;
+
+    public function __construct()
+    {
+        $this->commissions = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
@@ -68,5 +79,11 @@ class FormationReferentielGroupeCompetence
         $this->activite = $activite;
 
         return $this;
+    }
+
+    /** @return Collection<int, Commission> */
+    public function getCommissions(): Collection
+    {
+        return $this->commissions;
     }
 }

--- a/src/Twig/BrevetExtension.php
+++ b/src/Twig/BrevetExtension.php
@@ -89,7 +89,7 @@ class BrevetExtension extends AbstractExtension
         if (!empty($commission) && !$commission->getGroupesCompetences()->contains($groupe)) {
             return null;
         }
-        if (empty($commission) && !empty($groupe->getActivite())) {
+        if (empty($commission) && !$groupe->getCommissions()->isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
## Summary

- Corrige l'affichage incorrect des groupes de compétences dans la colonne "Non attribuée" du profil utilisateur
- Le champ `activite` (métadonnée FFCAM) était utilisé à tort comme proxy pour déterminer la liaison aux commissions
- La condition utilise maintenant la relation ManyToMany réelle entre GC et commissions

## Changements

- `Commission.php` : ajout de `inversedBy: 'commissions'` sur la relation ManyToMany
- `FormationReferentielGroupeCompetence.php` : ajout de la relation inverse `$commissions` avec getter
- `BrevetExtension.php` : remplacement de `!empty($groupe->getActivite())` par `!$groupe->getCommissions()->isEmpty()`

## Test plan

- [ ] Vérifier sur un profil utilisateur que les GCs liés à des commissions n'apparaissent plus dans "Non attribuée"
- [ ] Vérifier que les GCs non liés à aucune commission apparaissent toujours dans "Non attribuée"
- [ ] Vérifier que les colonnes par commission affichent correctement les dates

🤖 Generated with [Claude Code](https://claude.ai/code)