### PR TITLE
feat: ajouter disclaimer phase de test pour l'affichage des compétences

### DIFF
--- a/templates/commission/brevets.html.twig
+++ b/templates/commission/brevets.html.twig
@@ -92,7 +92,7 @@
 
     <p class="mini" style="margin-top: 10px; color: #666;">
         ⚠️ <strong>Phase de test :</strong> Cet affichage des compétences est expérimental.
-        Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
+        Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" rel="noopener noreferrer" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
     </p>
     {% endif %}
 {% endblock %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -506,7 +506,7 @@
 
                     <p class="mini event-user-skill" style="margin-top: 10px; color: #666;">
                         ⚠️ <strong>Phase de test :</strong> Cet affichage des compétences est expérimental.
-                        Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
+                        Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" rel="noopener noreferrer" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
                     </p>
                     {% endif %}
                 </div>

--- a/templates/user/full.html.twig
+++ b/templates/user/full.html.twig
@@ -104,7 +104,7 @@
 
         <p class="mini" style="margin-top: 10px; color: #666;">
             ⚠️ <strong>Phase de test :</strong> Cet affichage des compétences est expérimental.
-            Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
+            Si vous constatez des erreurs, <a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" rel="noopener noreferrer" style="color: #0066cc;">signalez-les nous via ce formulaire</a>.
         </p>
 
         <br style="clear:both" />


### PR DESCRIPTION
## Summary
- Ajoute un message d'avertissement sous les tableaux de compétences/brevets/formations
- Présent sur les 3 pages : fiche adhérent, brevets commission, et gestion sortie
- Inclut un lien vers un formulaire ClickUp pour signaler les erreurs

## Test plan
- [ ] Vérifier l'affichage du disclaimer sur la fiche adhérent (onglet compétences)
- [ ] Vérifier l'affichage sur la page brevets d'une commission
- [ ] Vérifier l'affichage sur la page sortie en mode "vue compétences"
- [ ] Tester le lien vers le formulaire ClickUp

🤖 Generated with [Claude Code](https://claude.com/claude-code)