### PR TITLE
feat: ajouter guides encadrement et responsables dans le bandeau

### DIFF
--- a/templates/header.html.twig
+++ b/templates/header.html.twig
@@ -187,11 +187,25 @@
                         <div class="nav-user">
                             <p class="menutitle">Outils</p>
                             <ul>
-                            {% if caf_id == 'lyon' %}
-                                {% if allowed('user_read_private') %} {# utilisation d'une permission existante données uniquement aux co-encadrants, encadrants et stagiaires #}
+                            {% if app.user and caf_id == 'lyon' %}
+                                {% if app.user.hasAttribute(constant('App\\Entity\\UserAttr::ENCADRANT'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::COENCADRANT'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::STAGIAIRE'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::BENEVOLE'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::SALARIE')) %}
                                 <li>
-                                    <a href="/pages/boite-outils-des-encadrants.html" title="">
-                                        boite à outils encadrant
+                                    <a href="/pages/guide-encadrement.html" title="">
+                                        Guide de l'encadrement
+                                    </a>
+                                </li>
+                                {% endif %}
+                                {% if app.user.hasAttribute(constant('App\\Entity\\UserAttr::RESPONSABLE_COMMISSION'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::PRESIDENT'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::VICE_PRESIDENT'))
+                                    or app.user.hasAttribute(constant('App\\Entity\\UserAttr::SALARIE')) %}
+                                <li>
+                                    <a href="/pages/guide-responsable-commission.html" title="">
+                                        Guide des responsables de commission
                                     </a>
                                 </li>
                                 {% endif %}


### PR DESCRIPTION
## Summary

- Retire le lien "Boite à outils des encadrants" du bandeau vert (la page reste accessible via son URL actuelle)
- Ajoute le lien **Guide de l'encadrement** (`/pages/guide-encadrement.html`) accessible aux :
  - Encadrants
  - Co-encadrants
  - Initiateurs stagiaires
  - Bénévoles d'encadrement
  - Salariés (accueil)
- Ajoute le lien **Guide des responsables de commission** (`/pages/guide-responsable-commission.html`) accessible aux :
  - Responsables de commission
  - Président
  - Vice-président
  - Salariés (accueil)

Demandé pour l'AG de jeudi. Accord Karim + Florent + Nicolas.

## Test plan

- [ ] Vérifier que le lien "Guide de l'encadrement" apparaît pour un encadrant
- [ ] Vérifier que le lien "Guide des responsables de commission" apparaît pour un responsable de commission
- [ ] Vérifier que les deux liens apparaissent pour un salarié
- [ ] Vérifier que la page `/pages/boite-outils-des-encadrants.html` reste accessible directement

🤖 Generated with [Claude Code](https://claude.com/claude-code)