### PR TITLE
fix: validate year upper bound in agenda to prevent DateMalformedStringException

### DIFF
--- a/src/Controller/AgendaController.php
+++ b/src/Controller/AgendaController.php
@@ -29,7 +29,7 @@ class AgendaController extends AbstractController
         $year = (int) ($request->query->get('year') ?: date('Y'));
         $month = (int) ($request->query->get('month') ?: date('m'));
 
-        if ($year <= 2000) {
+        if ($year <= 2000 || $year > (int) date('Y') + 2) {
             $year = (int) date('Y');
         }
         if ($month < 1 || $month > 12) {

--- a/tests/Controller/AgendaControllerTest.php
+++ b/tests/Controller/AgendaControllerTest.php
@@ -55,4 +55,11 @@ class AgendaControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
     }
+
+    public function testAgendaWithInvalidYearDoesNotCrash(): void
+    {
+        $this->client->request('GET', '/agenda.html?year=20250&month=9');
+
+        $this->assertResponseIsSuccessful();
+    }
 }


### PR DESCRIPTION
## Summary
- Ajoute une borne supérieure à la validation du paramètre `year` dans l'agenda
- Le paramètre n'était validé que contre `<= 2000`, permettant des valeurs comme `?year=20250` de crasher `DateTimeImmutable`
- La borne supérieure est `année courante + 2`, cohérente avec le `maxYear` déjà utilisé dans le template

## Sentry
- [CLUBALPINLYONFR-1C6](https://club-alpin-lyon.sentry.io/issues/7235104154/) — `DateMalformedStringException` (189 événements, fatal)

## Test plan
- [ ] Visiter `/agenda.html?year=20250&month=9` → doit afficher le mois courant au lieu de crasher
- [ ] Visiter `/agenda.html?year=2025&month=3` → comportement inchangé
- [ ] Test d'intégration ajouté dans `AgendaControllerTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)