### PR TITLE
fix: add User serialization methods to prevent TypeError on session restore

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -613,6 +613,27 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
         // $this->plainPassword = null;
     }
 
+    public function __serialize(): array
+    {
+        return [
+            'id' => isset($this->id) ? $this->id : null,
+            'email' => $this->email,
+            'mdp' => $this->mdp,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        // Support both new format (from __serialize) and legacy native PHP
+        // serialization format where private property keys are mangled as
+        // "\0ClassName\0propertyName" and bigint $id is stored as string.
+        $p = "\0" . self::class . "\0";
+        $id = $data['id'] ?? $data[$p . 'id'] ?? null;
+        $this->id = null !== $id ? (int) $id : null;
+        $this->email = $data['email'] ?? $data[$p . 'email'] ?? null;
+        $this->mdp = $data['mdp'] ?? $data[$p . 'mdp'] ?? null;
+    }
+
     /**
      * A visual identifier that represents this user.
      *

--- a/tests/Entity/UserSerializationTest.php
+++ b/tests/Entity/UserSerializationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserSerializationTest extends TestCase
+{
+    public function testSerializeAndUnserialize(): void
+    {
+        $user = new User(42);
+        $user->setEmail('test@example.com');
+        $user->setMdp('hashed_password');
+
+        $serialized = serialize($user);
+        $restored = unserialize($serialized);
+
+        $this->assertSame(42, $restored->getId());
+        $this->assertSame('test@example.com', $restored->getEmail());
+        $this->assertSame('hashed_password', $restored->getMdp());
+    }
+
+    public function testUnserializeLegacyFormat(): void
+    {
+        // Simulate native PHP serialization format where $id is a string
+        // (bigint returned by Doctrine) and keys are mangled with class name.
+        $prefix = "\0" . User::class . "\0";
+        $legacyData = [
+            $prefix . 'id' => '12345',
+            $prefix . 'email' => 'legacy@example.com',
+            $prefix . 'mdp' => 'old_hash',
+        ];
+
+        $user = (new \ReflectionClass(User::class))->newInstanceWithoutConstructor();
+        $user->__unserialize($legacyData);
+
+        $this->assertSame(12345, $user->getId());
+        $this->assertSame('legacy@example.com', $user->getEmail());
+        $this->assertSame('old_hash', $user->getMdp());
+    }
+
+    public function testUnserializeWithNullId(): void
+    {
+        $user = new User();
+        $user->setEmail('noid@example.com');
+        $user->setMdp('pwd');
+
+        $serialized = serialize($user);
+        $restored = unserialize($serialized);
+
+        $this->assertNull($restored->getId());
+        $this->assertSame('noid@example.com', $restored->getEmail());
+    }
+}


### PR DESCRIPTION
## Summary
- Ajoute `__serialize()` / `__unserialize()` sur l'entité User
- Doctrine retourne les `bigint` comme strings. Quand le User est sérialisé en session, `$id` est stocké comme string. À la désérialisation, PHP 8+ refuse d'assigner un string à `?int $id`
- Ne sérialise que le minimum nécessaire pour la sécurité Symfony (`id`, `email`, `mdp`) — le UserProvider recharge le reste depuis la DB
- Gère les sessions existantes (format natif PHP avec clés manglées `\0ClassName\0property`)

## Sentry
- [CLUBALPINLYONFR-1CD](https://club-alpin-lyon.sentry.io/issues/7254898008/) — `TypeError: Cannot assign string to property App\Entity\User::$id of type ?int` (30 événements, fatal)

## Test plan
- [ ] Se connecter → fermer le navigateur → revenir → la session doit être restaurée sans erreur
- [ ] Tests unitaires ajoutés : sérialisation/désérialisation nouveau format, format legacy, et id null
- [x] `php bin/phpunit tests/Entity/UserSerializationTest.php` — 3 tests, 8 assertions, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)