### PR TITLE
fix: initialiser toutes les clés de newEncadrants pour éviter undefined array key

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -174,7 +174,7 @@ class SortieController extends AbstractController
                 EventParticipation::ROLE_COENCADRANT => 'coencadrants',
                 EventParticipation::ROLE_BENEVOLE => 'benevoles',
             ];
-            $newEncadrants = [];
+            $newEncadrants = array_fill_keys(array_values($rolesMap), []);
             foreach ($rolesMap as $role => $roleName) {
                 if (!empty($formData[$roleName])) {
                     foreach ($formData[$roleName] as $participantId) {


### PR DESCRIPTION
## Problème

Lors de la modification d'une sortie publiée, si aucun initiateur stagiaire (ou encadrant) n'est sélectionné dans le formulaire, la clé correspondante n'était pas ajoutée à `$newEncadrants` (qui n'était initialisé qu'à `[]`).

Deux symptômes selon l'environnement :
- **Dev** : le warning PHP `Undefined array key "initiateurs"` est converti en `ErrorException` → la sauvegarde plante
- **Prod** : PHP retourne `null` silencieusement pour la clé absente → `[] !== null` est toujours `true` → la sortie passe systématiquement en `STATUS_PUBLISHED_UNSEEN` et redemande une validation, même si rien de pertinent n'a changé

## Fix

Initialiser `$newEncadrants` avec toutes les clés du `$rolesMap` à `[]` avant la boucle :

```php
$newEncadrants = array_fill_keys(array_values($rolesMap), []);
```

Ainsi la comparaison avant/après est correcte quel que soit le contenu du formulaire.

## Test plan

- [ ] Modifier uniquement la description d'une sortie publiée → pas de redemande de validation
- [ ] Modifier le lieu ou le nombre de participants → redemande de validation attendue
- [ ] Modifier les encadrants → redemande de validation attendue

🤖 Generated with [Claude Code](https://claude.com/claude-code)