### PR TITLE
feat: bloquer les notes de frais après 120 jours suivant la fin de la sortie

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -394,8 +394,8 @@ class SortieController extends AbstractController
             }
         }
 
-        // Notes de frais must be submitted within 90 days of the event's end date
-        $expenseReportDeadline = $event->getEndDate()->modify('+90 days');
+        // Notes de frais must be submitted within 120 days of the event's end date
+        $expenseReportDeadline = $event->getEndDate()->modify('+120 days');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -56,6 +56,8 @@ use Twig\Error\SyntaxError;
 
 class SortieController extends AbstractController
 {
+    public const EXPENSE_REPORT_DEADLINE_DAYS = 120;
+
     public function __construct(
         protected SlugHelper $slugHelper,
         protected float $defaultLat,
@@ -394,8 +396,8 @@ class SortieController extends AbstractController
             }
         }
 
-        // Notes de frais must be submitted within 120 days of the event's end date
-        $expenseReportDeadline = $event->getEndDate()->modify('+120 days');
+        // Notes de frais must be submitted within EXPENSE_REPORT_DEADLINE_DAYS of the event's end date
+        $expenseReportDeadline = $event->getEndDate()->modify('+' . self::EXPENSE_REPORT_DEADLINE_DAYS . ' days');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;
@@ -423,6 +425,7 @@ class SortieController extends AbstractController
             'current_user_accepted' => $currentUserAccepted,
             'accepted_participations' => $participationRepository->getSortedParticipations($event),
             'is_within_expense_report_deadline' => new \DateTimeImmutable() <= $expenseReportDeadline,
+            'expense_report_deadline_days' => self::EXPENSE_REPORT_DEADLINE_DAYS,
             'has_viewable_expense_report' => $hasViewableExpenseReport,
             'groupes_competences' => $groupesCompRefs,
             'niveaux' => $nivRefs,

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,7 +26,6 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
-use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;
@@ -395,11 +394,8 @@ class SortieController extends AbstractController
             }
         }
 
-        // Date cutoff: September 30 of current year if after Dec 1, otherwise September 30 of previous year
-        $currentMonth = date('m');
-        $currentYear = date('Y');
-        $cutoffYear = $currentMonth >= 12 ? $currentYear : $currentYear - 1;
-        $cutoffDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $cutoffYear . '-' . UserLicenseHelper::LICENSE_TOLERANCY_PERIOD_END);
+        // Notes de frais must be submitted within 90 days of the event's end date
+        $expenseReportDeadline = $event->getEndDate()->modify('+90 days');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;
@@ -426,8 +422,7 @@ class SortieController extends AbstractController
             'current_user_has_paid' => $currentUserHasPaid,
             'current_user_accepted' => $currentUserAccepted,
             'accepted_participations' => $participationRepository->getSortedParticipations($event),
-            'is_event_after_cutoff' => $event->getEndDate() >= $cutoffDate,
-            'cutoff_year' => $cutoffYear,
+            'is_within_expense_report_deadline' => new \DateTimeImmutable() <= $expenseReportDeadline,
             'has_viewable_expense_report' => $hasViewableExpenseReport,
             'groupes_competences' => $groupesCompRefs,
             'niveaux' => $nivRefs,

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -380,7 +380,7 @@
                                 <img src="/img/base/cross.png" alt="" title=""/>
                                 <div class="text-container">
                                     <b>Note de frais non disponible :</b><br />
-                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de 90 jours après la fin de la sortie est dépassé.<br />
+                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de 120 jours après la fin de la sortie est dépassé.<br />
                                     En cas de question, contactez la comptabilité.<br />&nbsp;
                                 </div>
                             </div>

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -380,7 +380,7 @@
                                 <img src="/img/base/cross.png" alt="" title=""/>
                                 <div class="text-container">
                                     <b>Note de frais non disponible :</b><br />
-                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de 120 jours après la fin de la sortie est dépassé.<br />
+                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de {{ expense_report_deadline_days }} jours après la fin de la sortie est dépassé.<br />
                                     En cas de question, contactez la comptabilité.<br />&nbsp;
                                 </div>
                             </div>

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -375,12 +375,12 @@
                         {% if has_viewable_expense_report %}
                             {# User already has a submitted/approved/accounted expense report, always show it #}
                             {% include 'vuejs/expense-report-form.twig' %}
-                        {% elseif not is_event_after_cutoff %}
+                        {% elseif not is_within_expense_report_deadline %}
                             <div class="alerte info-container" style="margin-bottom:2rem !important">
                                 <img src="/img/base/cross.png" alt="" title=""/>
                                 <div class="text-container">
                                     <b>Note de frais non disponible :</b><br />
-                                    Il n'est plus possible de déposer une note de frais pour cette sortie car les comptes du Club pour l'année {{ cutoff_year }} ont été clôturés.<br />
+                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de 90 jours après la fin de la sortie est dépassé.<br />
                                     En cas de question, contactez la comptabilité.<br />&nbsp;
                                 </div>
                             </div>

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -564,9 +564,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a submitted expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormVisibleForSubmittedReportPastCutoff()
+    public function testExpenseReportFormVisibleForSubmittedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -584,9 +584,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an approved expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormVisibleForApprovedReportPastCutoff()
+    public function testExpenseReportFormVisibleForApprovedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -604,9 +604,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an accounted expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormVisibleForAccountedReportPastCutoff()
+    public function testExpenseReportFormVisibleForAccountedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -624,9 +624,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a draft expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormNotVisibleForDraftReportPastCutoff()
+    public function testExpenseReportFormNotVisibleForDraftReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -644,9 +644,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a rejected expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormNotVisibleForRejectedReportPastCutoff()
+    public function testExpenseReportFormNotVisibleForRejectedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -664,9 +664,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user without any expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 90-day deadline.
      */
-    public function testExpenseReportFormNotVisibleWithoutReportPastCutoff()
+    public function testExpenseReportFormNotVisibleWithoutReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -683,14 +683,14 @@ class SortieControllerTest extends WebTestCase
     }
 
     /**
-     * Helper method to create a past event (before cutoff date).
+     * Helper method to create a past event (ended more than 90 days ago).
      */
     protected function createPastEvent($user): Evt
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         $commission = $this->createCommission();
 
-        // Create an event that ended 2 years ago (definitely past any cutoff)
+        // Create an event that ended 2 years ago (definitely past the 90-day deadline)
         $event = new Evt(
             $user,
             $commission,

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -564,7 +564,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a submitted expense report can see the form
-     * even if the event is past the 90-day deadline.
+     * even if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormVisibleForSubmittedReportPastDeadline()
     {
@@ -584,7 +584,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an approved expense report can see the form
-     * even if the event is past the 90-day deadline.
+     * even if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormVisibleForApprovedReportPastDeadline()
     {
@@ -604,7 +604,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an accounted expense report can see the form
-     * even if the event is past the 90-day deadline.
+     * even if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormVisibleForAccountedReportPastDeadline()
     {
@@ -624,7 +624,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a draft expense report cannot see the form
-     * if the event is past the 90-day deadline.
+     * if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormNotVisibleForDraftReportPastDeadline()
     {
@@ -644,7 +644,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a rejected expense report cannot see the form
-     * if the event is past the 90-day deadline.
+     * if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormNotVisibleForRejectedReportPastDeadline()
     {
@@ -664,7 +664,7 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user without any expense report cannot see the form
-     * if the event is past the 90-day deadline.
+     * if the event is past the 120-day deadline.
      */
     public function testExpenseReportFormNotVisibleWithoutReportPastDeadline()
     {
@@ -690,7 +690,7 @@ class SortieControllerTest extends WebTestCase
         $em = $this->getContainer()->get('doctrine')->getManager();
         $commission = $this->createCommission();
 
-        // Create an event that ended 2 years ago (definitely past the 90-day deadline)
+        // Create an event that ended 2 years ago (definitely past the 120-day deadline)
         $event = new Evt(
             $user,
             $commission,

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -683,7 +683,7 @@ class SortieControllerTest extends WebTestCase
     }
 
     /**
-     * Helper method to create a past event (ended more than 90 days ago).
+     * Helper method to create a past event (ended more than 120 days ago).
      */
     protected function createPastEvent($user): Evt
     {


### PR DESCRIPTION
## Résumé

- Remplace la date butoire fixe (30 septembre de l'année de référence) par une règle glissante de **120 jours** après le dernier jour de la sortie
- Mise à jour du message d'erreur affiché à l'utilisateur
- Mise à jour des tests et commentaires associés

## Comportement

| Situation | Avant | Après |
|-----------|-------|-------|
| Sortie terminée il y a < 120 jours | Dépend de la date (30 sept.) | ✅ Formulaire disponible |
| Sortie terminée il y a > 120 jours | Bloqué après le 30 sept. | 🚫 Délai dépassé |
| Note déjà soumise/approuvée/comptabilisée | Toujours visible | Toujours visible |

## Plan de test

- [ ] Vérifier qu'une sortie terminée il y a < 120 jours affiche bien le formulaire
- [ ] Vérifier qu'une sortie terminée il y a > 120 jours affiche le message de blocage
- [ ] Vérifier que le message ne mentionne plus l'année comptable
- [ ] Vérifier qu'une note déjà soumise reste visible même après 120 jours

🤖 Generated with [Claude Code](https://claude.com/claude-code)