### PR TITLE
fix: changer la date butoire des notes de frais au 31 décembre de l'année précédente

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,7 +26,6 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
-use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;
@@ -395,11 +394,9 @@ class SortieController extends AbstractController
             }
         }
 
-        // Date cutoff: September 30 of current year if after Dec 1, otherwise September 30 of previous year
-        $currentMonth = date('m');
-        $currentYear = date('Y');
-        $cutoffYear = $currentMonth >= 12 ? $currentYear : $currentYear - 1;
-        $cutoffDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $cutoffYear . '-' . UserLicenseHelper::LICENSE_TOLERANCY_PERIOD_END);
+        // Date cutoff: December 31 of the previous year
+        $cutoffYear = (int) date('Y') - 1;
+        $cutoffDate = new \DateTimeImmutable($cutoffYear . '-12-31 23:59:59');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;


### PR DESCRIPTION
## Résumé

- Remplace la date butoire du **30 septembre** (avec une logique conditionnelle sur le mois courant) par le **31 décembre de l'année précédente**, fixe et sans ambiguïté
- Suppression de l'import `UserLicenseHelper` devenu inutile dans ce contexte

## Changement

| | Avant | Après |
|---|---|---|
| Date butoire | 30 sept. de l'année courante (si déc.) sinon 30 sept. de l'année précédente | 31 déc. de l'année précédente |
| Logique | Conditionnelle selon le mois | Toujours `année courante - 1` |

## Plan de test

- [ ] Vérifier qu'une sortie de l'année en cours affiche bien le formulaire de note de frais
- [ ] Vérifier qu'une sortie de l'année précédente affiche le message de blocage
- [ ] Vérifier que le message mentionne toujours la bonne année clôturée

🤖 Generated with [Claude Code](https://claude.com/claude-code)