### PR TITLE
feat: option pour ne pas envoyer l'alerte mail "Nouvelle sortie"

### DIFF
--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -59,6 +59,9 @@ class Evt
     #[ORM\Column(name: 'auto_accept', type: 'boolean', nullable: false, options: ['default' => false])]
     private bool $autoAccept = false;
 
+    #[ORM\Column(name: 'skip_new_sortie_alert', type: 'boolean', nullable: false, options: ['default' => false])]
+    private bool $skipNewSortieAlert = false;
+
     #[ORM\Column(name: 'is_draft', type: 'boolean', nullable: false, options: ['default' => true])]
     private bool $isDraft = true;
 
@@ -846,6 +849,18 @@ class Evt
     public function setAutoAccept(bool $autoAccept): self
     {
         $this->autoAccept = $autoAccept;
+
+        return $this;
+    }
+
+    public function isSkipNewSortieAlert(): bool
+    {
+        return $this->skipNewSortieAlert;
+    }
+
+    public function setSkipNewSortieAlert(bool $skipNewSortieAlert): self
+    {
+        $this->skipNewSortieAlert = $skipNewSortieAlert;
 
         return $this;
     }

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -388,6 +388,10 @@ class EventType extends AbstractType
                     new NotBlank(),
                 ],
             ])
+            ->add('skipNewSortieAlert', CheckboxType::class, [
+                'label' => 'Cocher cette case si le groupe est déjà constitué (cycle par exemple) : ne pas envoyer d\'alerte par mail "Nouvelle sortie"',
+                'required' => false,
+            ])
             ->add('autoAccept', CheckboxType::class, [
                 'label' => 'Accepter automatiquement les demandes d\'inscription',
                 'required' => false,

--- a/src/Messenger/MessageHandler/SortiePublieeHandler.php
+++ b/src/Messenger/MessageHandler/SortiePublieeHandler.php
@@ -29,6 +29,10 @@ class SortiePublieeHandler
             return;
         }
 
+        if ($evt->isSkipNewSortieAlert()) {
+            return;
+        }
+
         $commissionCode = $evt->getCommission()->getCode();
 
         foreach ($this->userRepository->findUsersIdWithAlert($commissionCode, AlertType::Sortie) as $userId) {

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -138,6 +138,13 @@
             <br style="clear:both" />
 
             <div>
+                <label for="{{ form.skipNewSortieAlert.vars.id }}" class="{% if form.skipNewSortieAlert.vars.data %}up{% else %}down{% endif %}">
+                    {{ form_widget(form.skipNewSortieAlert) }}
+                    {{ field_label(form.skipNewSortieAlert) }}
+                </label>
+            </div>
+
+            <div>
                 <label for="{{ form.autoAccept.vars.id }}" class="{% if form.autoAccept.vars.data %}up{% else %}down{% endif %}">
                     {{ form_widget(form.autoAccept) }}
                     {{ field_label(form.autoAccept) }}


### PR DESCRIPTION
## Résumé

- Ajout d'une case à cocher dans le module **Inscriptions** du formulaire de sortie, au-dessus de "Accepter automatiquement les demandes d'inscription"
- Label : _"Cocher cette case si le groupe est déjà constitué (cycle par exemple) : ne pas envoyer d'alerte par mail "Nouvelle sortie""_
- Si la case est cochée lors de la publication, le `SortiePublieeHandler` retourne immédiatement sans envoyer les notifications aux abonnés

## Plan de test

- [ ] Créer une sortie, cocher la nouvelle case, publier → vérifier qu'aucune alerte mail "Nouvelle sortie" n'est envoyée
- [ ] Créer une sortie sans cocher la case, publier → vérifier que les alertes sont envoyées normalement
- [ ] Vérifier que la case est bien positionnée au-dessus de "Accepter automatiquement..." dans le module Inscriptions
- [ ] Lancer la migration Doctrine (`php bin/console doctrine:migrations:diff && php bin/console doctrine:migrations:migrate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)