### PR TITLE
fix: permettre le marquage "absent" dès le début de la sortie

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -585,7 +585,7 @@ class SortieController extends AbstractController
                 continue;
             }
 
-            if ($event->isFinished() && !\in_array($status, [EventParticipation::STATUS_ABSENT], true)) {
+            if ($event->isStarted() && !\in_array($status, [EventParticipation::STATUS_ABSENT], true)) {
                 continue;
             }
 

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -610,6 +610,15 @@ class Evt
         return $this->endDate < new \DateTimeImmutable();
     }
 
+    public function isStarted(): bool
+    {
+        if (null === $this->startDate) {
+            return false;
+        }
+
+        return $this->startDate <= new \DateTimeImmutable();
+    }
+
     public function getPlace(): ?string
     {
         return $this->place;


### PR DESCRIPTION
## Résumé

- Remplace `isFinished()` par `isStarted()` dans le contrôle de mise à jour en masse des statuts de participation (`SortieController`)
- Ajoute la méthode `isStarted()` sur l'entité `Evt`
- Permet de marquer un participant **"absent"** dès que la sortie a démarré, sans attendre la fin

## Plan de test

- [ ] Lancer une sortie (date de début passée, date de fin future) → vérifier que le marquage "absent" est possible
- [ ] Sur une sortie non commencée → vérifier que le marquage "absent" est toujours bloqué
- [ ] Sur une sortie terminée → comportement inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)