### PR TITLE
fix: valider automatiquement le statut légal si aucun rôle n'a evt_legal_accept

### DIFF
--- a/docs/validation-sorties.md
+++ b/docs/validation-sorties.md
@@ -1,0 +1,24 @@
+# Validation des sorties
+
+## Cycle de validation
+
+Une sortie passe par deux étapes de validation indépendantes :
+
+1. **Validation publication** (`evt_validate`) — un responsable de commission (généralement, rôle à choisir dans la matrice des droits) approuve la sortie pour qu'elle soit visible publiquement (`STATUS_PUBLISHED_VALIDE`).
+2. **Validation légale** (`evt_legal_accept` / `evt_legal_refuse`) — une personne habilitée confirme que la sortie est conforme pour être reconnue comme sortie officielle du CAF.
+
+Ces deux étapes sont indépendantes : une sortie peut être publiée sans être validée légalement.
+
+## Matrice des droits
+
+Les droits `evt_validate`, `evt_legal_accept` et `evt_legal_refuse` s'administrent dans la matrice des droits (`/admin/`). Chaque droit peut être assigné à un ou plusieurs rôles, avec ou sans restriction par commission.
+
+La page de validation légale (`/validation-des-sorties.html`) n'est accessible qu'aux utilisateurs dont au moins un rôle possède `evt_legal_accept` ou `evt_legal_refuse`.
+
+## Comportement si aucun rôle n'a `evt_legal_accept`
+
+Si aucun rôle n'est configuré avec le droit `evt_legal_accept` dans la matrice, les sorties sont **automatiquement validées légalement** au moment de leur publication, sans envoi d'email à l'organisateur.
+
+Ce cas se produit typiquement lorsque le club ne souhaite pas de circuit de validation légale distinct et considère que publication vaut validation. La responsabilité légale est déléguée au rôle associé à la publication.
+
+La vérification porte sur la configuration de la matrice (table `caf_usertype_attr`), pas sur l'existence d'utilisateurs affectés à un rôle.

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -25,6 +25,7 @@ use App\Repository\FormationValidationGroupeCompetenceRepository;
 use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
+use App\Repository\UserRightRepository;
 use App\Service\HelloAssoService;
 use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
@@ -457,6 +458,7 @@ class SortieController extends AbstractController
         Mailer $mailer,
         MessageBusInterface $messageBus,
         LoggerInterface $logger,
+        UserRightRepository $userRightRepository,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('sortie_validate', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -467,6 +469,12 @@ class SortieController extends AbstractController
         }
 
         $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE)->setStatusWho($this->getUser());
+
+        if (!$userRightRepository->hasAnyRoleWithRight('evt_legal_accept')) {
+            $event->setStatusLegal(Evt::STATUS_LEGAL_VALIDE)
+                ->setStatusLegalWho(null)
+                ->setLegalStatusChangeDate(new \DateTimeImmutable());
+        }
 
         // créer la campagne hello asso si nécessaire
         if ($event->hasPaymentForm() && !$event->getHelloAssoFormSlug()) {

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -393,7 +393,7 @@ class Evt
         return $this->statusLegalWho;
     }
 
-    public function setStatusLegalWho(User $statusLegalWho): self
+    public function setStatusLegalWho(?User $statusLegalWho): self
     {
         $this->statusLegalWho = $statusLegalWho;
 

--- a/src/Repository/UserRightRepository.php
+++ b/src/Repository/UserRightRepository.php
@@ -38,6 +38,21 @@ class UserRightRepository extends ServiceEntityRepository
         return $this->processRightsResults($results);
     }
 
+    public function hasAnyRoleWithRight(string $rightCode): bool
+    {
+        $sql = '
+            SELECT COUNT(*) AS cnt
+            FROM caf_userright ur
+            INNER JOIN caf_usertype_attr uta ON ur.id_userright = uta.right_usertype_attr
+            WHERE ur.code_userright = :rightCode
+        ';
+
+        $statement = $this->getEntityManager()->getConnection()->prepare($sql);
+        $statement->bindValue('rightCode', $rightCode);
+
+        return (int) $statement->executeQuery()->fetchOne() > 0;
+    }
+
     public function getRightsByUserType(string $userType): array
     {
         $sql = '


### PR DESCRIPTION
## Résumé

- Si aucun rôle n'est configuré dans la matrice des droits pour `evt_legal_accept`, les sorties sont désormais automatiquement validées légalement au moment de leur publication, sans envoi d'email à l'organisateur.
- Corrige l'incohérence entre la colonne DB nullable `status_legal_who_evt` et le setter `setStatusLegalWho(User $user)` qui n'acceptait pas `null`.
- Ajoute la documentation du cycle de validation des sorties.

## Changements

- **`UserRightRepository::hasAnyRoleWithRight(string $rightCode): bool`** — interroge uniquement la matrice (`caf_usertype_attr`) pour savoir si un rôle a le droit, sans tenir compte des affectations utilisateurs.
- **`SortieController::sortieValidate`** — après publication, si `hasAnyRoleWithRight('evt_legal_accept')` retourne `false`, passe le statut légal à `STATUS_LEGAL_VALIDE` avec `statusLegalWho = null`.
- **`Evt::setStatusLegalWho(?User)`** — signature corrigée pour accepter `null`.
- **`docs/validation-sorties.md`** — documentation du cycle de validation (publication + validation légale) et du comportement d'auto-validation.

## Plan de test

- [ ] Retirer `evt_legal_accept` de tous les rôles dans la matrice → publier une sortie → vérifier que `status_legal = 1` et `status_legal_who = null` en base, sans email reçu
- [ ] Avec au moins un rôle ayant `evt_legal_accept` → publier une sortie → vérifier que `status_legal = 0` (en attente de validation manuelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)