### PR TITLE
fix: retirer l'import inutilisé UserLicenseHelper dans SortieController

### DIFF
--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,7 +26,6 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
-use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;


### PR DESCRIPTION
## Summary

- Retire `use App\Service\UserLicenseHelper;` dans `src/Controller/SortieController.php` — import devenu orphelin après le revert de #1724 (PR du revert avait remis l'import alors que #1723 mergé entre-temps en avait supprimé la seule utilisation).
- Résout l'échec CI `PHP CS Fixer` (`no_unused_imports`) qui bloque les PR ouvertes touchant à ce fichier (notamment #1721).

## Contexte

Sur `main` :
1. `698b9b33` (fix #1724) : retirait `use UserLicenseHelper` + virait son utilisation dans la logique cutoff
2. `047b88ec` (feat #1723) : supprimait l'utilisation de `UserLicenseHelper` (la logique cutoff a été remplacée)
3. `666fcfb8` (revert #1724) : revert du commit 1, qui a remis l'import

Résultat : l'import est dans `SortieController.php` mais n'est plus utilisé nulle part → CI CS Fixer échoue avec `no_unused_imports`.

## Test plan

- [x] `./bin/tools/php-cs-fixer fix --dry-run src/Controller/SortieController.php` → 0 violations
- [x] `grep UserLicenseHelper src/Controller/SortieController.php` → 0 matches
- [x] `php -l src/Controller/SortieController.php` → No syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)