### PR TITLE
feat: formulaire HelloAsso sans limite de places

### DIFF
--- a/src/Service/HelloAssoService.php
+++ b/src/Service/HelloAssoService.php
@@ -69,6 +69,8 @@ class HelloAssoService
                 [
                     'label' => 'Frais d\'inscription',
                     'price' => (int) ($event->getPaymentAmount() * 100),        // prix en centimes
+                    // maxPayers volontairement absent : le formulaire HelloAsso est illimité,
+                    // la gestion des places est assurée par ngensMax côté plateforme.
                 ],
             ],
         ];


### PR DESCRIPTION
## Résumé

- Le formulaire HelloAsso est créé sans `maxPayers` dans le `tierList` afin d'être illimité côté HelloAsso
- La gestion du nombre maximum de participants (`ngensMax`) reste inchangée sur la sortie côté plateforme
- Ajout d'un commentaire explicite dans `HelloAssoService::createFormForEvent()` pour documenter ce choix

## Plan de test

- [ ] Créer une sortie avec paiement HelloAsso activé et un `ngensMax` défini
- [ ] Valider la sortie pour déclencher la création du formulaire HelloAsso
- [ ] Vérifier dans l'interface HelloAsso que le formulaire n'a pas de limite de places
- [ ] Vérifier que le `ngensMax` est toujours affiché et fonctionnel sur la page sortie de la plateforme

🤖 Generated with [Claude Code](https://claude.com/claude-code)