### PR TITLE
fix: corrections bilan carbone suite retours bénévoles

### DIFF
--- a/.env
+++ b/.env
@@ -224,7 +224,7 @@ OSRM_TIMEOUT=5
 
 ###> coefficients bilan carbone ###
 # Taux en gCO2e/km. Le coût total stocké en BDD = taux × distance × nombre (personnes ou véhicules).
-# Train/bus/avion : multiplié par le nombre de participants (coût individuel par personne)
+# Train/bus : multiplié par le nombre de participants (coût individuel par personne)
 # Covoiturage/minibus/car affrété : multiplié par le nombre de véhicules (coût par véhicule)
 PUBLIC_TRAIN_CARBON_COST_RATE=10
 PUBLIC_COACH_CARBON_COST_RATE=122
@@ -233,5 +233,4 @@ MINIVAN_CARBON_COST_RATE=327
 BIKE_OR_WALK_CARBON_COST_RATE=0
 THERMIC_CARPOOLING_CARBON_COST_RATE=219
 ELECTRIC_CARPOOLING_CARBON_COST_RATE=102
-PLANE_CARBON_COST_RATE=10000
 ###< coefficients bilan carbone ###

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public/dev.txt
 /bin/tools
 
 /.php-cs-fixer.cache
+/.phpstan-tmp/
 
 ###> symfony/framework-bundle ###
 /.env.local
@@ -33,6 +34,7 @@ public/dev.txt
 /playwright/.cache/
 /e2e/.auth/
 .env.test
+/.playwright-mcp/
 ###< playwright ###
 
 ###> lexik/jwt-authentication-bundle ###

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ database-init-test: ## Init database for test
 	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/schema_caf.sql
 	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/data_caf.sql
 	$(SYMFONY_CONSOLE) doctrine:migrations:migrate --no-interaction --env=test
+	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/data_communes_seed.sql
 	$(MAKE) args="--env=test --no-interaction" database-fixtures-load
 .PHONY: database-init-test
 
@@ -142,13 +143,23 @@ npm-watch: ## Watch the frontend files
 .PHONY: npm-watch
 
 ## —— 📊 Database ——
-database-init: ## Init database
+database-init: ## Init database (seed minimal de communes — CI rapide)
 	$(MAKE) database-drop
 	$(MAKE) database-create
 	$(MAKE) database-import
 	$(MAKE) database-migrate
+	$(MAKE) database-seed-communes
 	$(MAKE) args="--env=dev --no-interaction" database-fixtures-load
 .PHONY: database-init
+
+database-bootstrap: ## Setup dev complet : database-init + import des ~39 000 communes (~2 min réseau)
+	$(MAKE) database-init
+	$(MAKE) database-import-communes
+.PHONY: database-bootstrap
+
+database-seed-communes: ## Seed minimal de communes montagne (Lyon, Mont-Blanc, Écrins, Vanoise, Vercors)
+	$(MYSQL) -Dcaf -uroot -ptest < ./legacy/data/data_communes_seed.sql
+.PHONY: database-seed-communes
 
 database-drop: ## Create database
 	$(SYMFONY_CONSOLE) doctrine:database:drop --force --if-exists
@@ -164,6 +175,10 @@ database-create: ## Create database
 database-import: ## Make import
 	$(MYSQL) -Dcaf -uroot -ptest < ./legacy/data/data_caf.sql
 .PHONY: database-import
+
+database-import-communes: ## Import communes françaises (coordonnées GPS, ~39 000 entrées via API La Poste)
+	$(SYMFONY_CONSOLE) app:import-communes
+.PHONY: database-import-communes
 
 database-migration: ## Make migration
 	$(SYMFONY_CONSOLE) make:migration

--- a/assets/transport-mode-vehicles.js
+++ b/assets/transport-mode-vehicles.js
@@ -1,0 +1,35 @@
+// Affiche/masque le champ "nombre de véhicules" du formulaire sortie
+// selon le mode de transport sélectionné. La liste des modes véhiculés
+// vient du data-attribute généré par Twig (source unique : TransportModeEnum).
+
+function initTransportModeVehicles() {
+    const select = document.getElementById('event_modeTransport');
+    const wrapper = document.getElementById('nb-vehicules-wrapper');
+    const input = document.getElementById('event_nbVehicules');
+
+    if (!select || !wrapper || !input) {
+        return;
+    }
+
+    const modesWithVehicles = (wrapper.dataset.modesWithVehicles || '')
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+
+    const sync = () => {
+        const show = modesWithVehicles.includes(select.value);
+        wrapper.style.display = show ? '' : 'none';
+        if (!show) {
+            input.value = 1;
+        }
+    };
+
+    select.addEventListener('change', sync);
+    sync();
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTransportModeVehicles);
+} else {
+    initTransportModeVehicles();
+}

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -377,4 +377,3 @@ services:
       $bikeWalkRate: '%env(float:BIKE_OR_WALK_CARBON_COST_RATE)%'
       $thermicCarpoolingRate: '%env(float:THERMIC_CARPOOLING_CARBON_COST_RATE)%'
       $electricCarpoolingRate: '%env(float:ELECTRIC_CARPOOLING_CARBON_COST_RATE)%'
-      $planeRate: '%env(float:PLANE_CARBON_COST_RATE)%'

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,10 @@
 2. Initialiser l'environnement :
 ```bash
 make init
-make database-bootstrap
+# Puis choisir UNE des deux cibles ci-dessous selon le besoin :
+make database-init        # seed minimal (12 communes), démarrage rapide
+# ou
+make database-bootstrap   # full import (~39 000 communes, ~2 min réseau)
 ```
 
 ### Initialisation de la base de données

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,8 +24,21 @@
 2. Initialiser l'environnement :
 ```bash
 make init
-make database-init
+make database-bootstrap
 ```
+
+### Initialisation de la base de données
+
+Le projet propose deux cibles selon ton besoin :
+
+| Cible | Communes en base | Quand l'utiliser |
+|---|---|---|
+| `make database-init` | Seed minimal (12 communes montagne) | Démarrage rapide, CI |
+| `make database-bootstrap` | ~39 000 communes (API La Poste, ~2 min réseau) | Install initiale, autocomplete complet France |
+
+Le seed minimal inclut Lyon (1er & 3e), le massif du Mont-Blanc (Chamonix, Saint-Gervais, Annecy), les Écrins (Saint-Christophe-en-Oisans avec La Bérarde, Bourg-d'Oisans, Pelvoux, Briançon), la Vanoise (Pralognan, Bonneval-sur-Arc) et le Vercors (Villard-de-Lans) — suffisant pour tester le calcul du bilan carbone des sorties.
+
+Pour rafraîchir uniquement les communes sans toucher au reste : `make database-import-communes` (full) ou `make database-seed-communes` (minimal).
 
 ## Accès
 

--- a/legacy/data/data_communes_seed.sql
+++ b/legacy/data/data_communes_seed.sql
@@ -1,0 +1,29 @@
+-- Seed minimal de la table communes pour dev/CI.
+-- Lancé après les migrations Doctrine, avant les fixtures.
+-- Pour un dev complet (autocomplete sur toute la France), utiliser
+-- `make database-bootstrap` qui appelle ensuite `app:import-communes`.
+
+TRUNCATE TABLE communes;
+
+INSERT INTO communes (code_commune_insee, nom_commune, code_postal, libelle_acheminement, ligne5, geopoint, latitude, longitude) VALUES
+-- Lyon (point de RDV / covoiturage majoritaire)
+('69381', 'Lyon 1er Arrondissement', '69001', 'LYON',                       NULL, '45.76667,4.83472',  45.76667000, 4.83472000),
+('69383', 'Lyon 3e Arrondissement',  '69003', 'LYON',                       NULL, '45.74944,4.85944',  45.74944000, 4.85944000),
+
+-- Massif du Mont-Blanc (Haute-Savoie)
+('74056', 'Chamonix-Mont-Blanc',     '74400', 'CHAMONIX MONT BLANC',         NULL, '45.92375,6.86861',  45.92375000, 6.86861000),
+('74236', 'Saint-Gervais-les-Bains', '74170', 'ST GERVAIS LES BAINS',        NULL, '45.89139,6.71139',  45.89139000, 6.71139000),
+('74010', 'Annecy',                  '74000', 'ANNECY',                      NULL, '45.89944,6.12889',  45.89944000, 6.12889000),
+
+-- Massif des Écrins (Hautes-Alpes / Isère)
+('38442', 'Saint-Christophe-en-Oisans', '38520', 'ST CHRISTOPHE EN OISANS', 'LA BERARDE', '44.93917,6.24917', 44.93917000, 6.24917000),
+('38052', 'Bourg-d''Oisans (Le)',    '38520', 'LE BOURG D OISANS',           NULL, '45.05278,6.03083',  45.05278000, 6.03083000),
+('05101', 'Pelvoux',                 '05340', 'PELVOUX',                     NULL, '44.87194,6.48750',  44.87194000, 6.48750000),
+('05023', 'Briançon',                '05100', 'BRIANCON',                    NULL, '44.89889,6.63556',  44.89889000, 6.63556000),
+
+-- Massif de la Vanoise (Savoie)
+('73208', 'Pralognan-la-Vanoise',    '73710', 'PRALOGNAN LA VANOISE',        NULL, '45.37806,6.72222',  45.37806000, 6.72222000),
+('73041', 'Bonneval-sur-Arc',        '73480', 'BONNEVAL SUR ARC',            NULL, '45.37194,7.04194',  45.37194000, 7.04194000),
+
+-- Massif du Vercors (Isère)
+('38548', 'Villard-de-Lans',         '38250', 'VILLARD DE LANS',             NULL, '45.07000,5.55333',  45.07000000, 5.55333000);

--- a/migrations/Version20260514225157.php
+++ b/migrations/Version20260514225157.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514225157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Bilan carbone : ajoute cout_carbone_per_person et retire le mode 'avion' des sorties existantes";
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt ADD cout_carbone_per_person DOUBLE PRECISION DEFAULT NULL');
+
+        // Le mode "avion" est retiré : facteur d'émission erroné et méthode OSRM
+        // (routage routier) inadaptée aux trajets aériens. On nettoie le mode et
+        // le coût carbone qui étaient faux. On conserve nb_km (distance routière
+        // neutre, exploitable pour audit ou recalcul ultérieur).
+        $this->addSql("UPDATE caf_evt SET mode_transport = NULL, cout_carbone = NULL, cout_carbone_per_person = NULL WHERE mode_transport = 'avion'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt DROP cout_carbone_per_person');
+        // Pas de rollback du nettoyage 'avion' : les données effacées étaient incorrectes.
+    }
+}

--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -30,6 +30,10 @@ class ImportCommunesCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // 39 000 communes paginées par 1000 ; Sentry retient les spans HTTP par page,
+        // ce qui peut saturer le 128M par défaut de la CLI Clever Cloud.
+        ini_set('memory_limit', '512M');
+
         $io = new SymfonyStyle($input, $output);
         $io->title('Import des communes depuis l\'API La Poste');
 
@@ -72,6 +76,10 @@ class ImportCommunesCommand extends Command
             $url = $data['next'] ?? null;
 
             $io->write("\r  $total communes importées...");
+
+            // Libère la réponse HTTP et ses éventuels spans Sentry/Cache.
+            unset($response, $data, $results);
+            gc_collect_cycles();
         } while ($url);
 
         $io->newLine();

--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -61,7 +61,7 @@ class ImportCommunesCommand extends Command
                     'nom_commune' => $row['nom_de_la_commune'] ?? '',
                     'code_postal' => $row['code_postal'] ?? '',
                     'libelle_acheminement' => $row['libelle_d_acheminement'] ?? '',
-                    'ligne5' => null,
+                    'ligne5' => $row['ligne_5'] ?? null,
                     'geopoint' => $geopoint ?: null,
                     'latitude' => (float) $lat,
                     'longitude' => (float) $long,

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -1001,6 +1001,7 @@ class SortieController extends AbstractController
         $newEvent->setModeTransport($event->getModeTransport());
         $newEvent->setNbKm($event->getNbKm());
         $newEvent->setCoutCarbone($event->getCoutCarbone());
+        $newEvent->setCoutCarbonePerPerson($event->getCoutCarbonePerPerson());
 
         // dupliquer les participants ?
         if ('full' === $mode) {
@@ -1387,6 +1388,12 @@ class SortieController extends AbstractController
         ];
     }
 
+    #[Route(path: '/sorties/methodologie-bilan-carbone', name: 'sortie_methodologie_bilan_carbone', methods: ['GET'])]
+    public function methodologieBilanCarbone(): Response
+    {
+        return $this->render('sortie/methodologie-bilan-carbone.html.twig');
+    }
+
     protected function calculateCarbonCost(Evt $event, CarbonCostHelper $helper): void
     {
         $cost = $helper->calculate(
@@ -1395,6 +1402,7 @@ class SortieController extends AbstractController
             $event->getNbVehicules() ?: 1,
             $event->getModeTransport(),
         );
-        $event->setCoutCarbone($cost);
+        $event->setCoutCarbone($cost?->total);
+        $event->setCoutCarbonePerPerson($cost?->perPerson);
     }
 }

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -1396,13 +1396,6 @@ class SortieController extends AbstractController
 
     protected function calculateCarbonCost(Evt $event, CarbonCostHelper $helper): void
     {
-        $cost = $helper->calculate(
-            $event->getNbKm() ?: 0,
-            $event->getParticipationsCount(),
-            $event->getNbVehicules() ?: 1,
-            $event->getModeTransport(),
-        );
-        $event->setCoutCarbone($cost?->total);
-        $event->setCoutCarbonePerPerson($cost?->perPerson);
+        $helper->updateForEvent($event);
     }
 }

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -321,7 +321,9 @@ class SortieController extends AbstractController
                     $event->setNbKm($nbKm);
                 }
             }
-            $this->calculateCarbonCost($event, $carbonCostHelper);
+            // Bilan carbone basé sur ngensMax — recalculé uniquement à la création/modif
+            // de sortie, pas à chaque inscription (décision Jacob Carbonel).
+            $carbonCostHelper->updateForEvent($event);
             $entityManager->persist($event);
             $entityManager->flush();
 
@@ -531,7 +533,6 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         RoleHelper $roleHelper,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('sortie_update_inscriptions', $request->request->get('csrf_token_inscriptions'))) {
             $this->addFlash('error', 'Jeton de validation invalide.');
@@ -660,8 +661,6 @@ class SortieController extends AbstractController
         }
 
         if ($flush) {
-            // bilan carbone mis à jour selon nb de participants
-            $this->calculateCarbonCost($event, $carbonCostHelper);
             $em->flush();
         }
 
@@ -910,7 +909,6 @@ class SortieController extends AbstractController
         EventParticipation $participation,
         EntityManagerInterface $em,
         Mailer $mailer,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         $event = $participation->getEvt();
 
@@ -925,8 +923,6 @@ class SortieController extends AbstractController
         $event->removeParticipation($participation);
         // orphanRemoval: true on Evt::$participations handles the DELETE in DB
 
-        // bilan carbone mis à jour selon nb de participants
-        $this->calculateCarbonCost($event, $carbonCostHelper);
         $em->flush();
 
         /** @var User */
@@ -1053,7 +1049,6 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         UserRepository $userRepository,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('join_event', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -1206,8 +1201,6 @@ class SortieController extends AbstractController
                     }
                 }
 
-                // bilan carbone mis à jour selon nb de participants
-                $this->calculateCarbonCost($event, $carbonCostHelper);
                 $em->flush();
 
                 // E-MAIL À L'ORGANISATEUR ET AUX ENCADRANTS
@@ -1394,8 +1387,4 @@ class SortieController extends AbstractController
         return $this->render('sortie/methodologie-bilan-carbone.html.twig');
     }
 
-    protected function calculateCarbonCost(Evt $event, CarbonCostHelper $helper): void
-    {
-        $helper->updateForEvent($event);
-    }
 }

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -1386,5 +1386,4 @@ class SortieController extends AbstractController
     {
         return $this->render('sortie/methodologie-bilan-carbone.html.twig');
     }
-
 }

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -14,6 +14,7 @@ use App\Entity\Usertype;
 use App\Form\NomadeType;
 use App\Form\UserContactType;
 use App\Form\UserFullType;
+use App\Helper\CarbonCostHelper;
 use App\Mailer\Mailer;
 use App\Repository\ArticleRepository;
 use App\Repository\EvtRepository;
@@ -284,6 +285,7 @@ class UserController extends AbstractController
         UserRepository $userRepository,
         Mailer $mailer,
         EntityManagerInterface $em,
+        CarbonCostHelper $carbonCostHelper,
     ): array|Response {
         if (!$this->isCsrfTokenValid('event_manual_add', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -389,6 +391,9 @@ class UserController extends AbstractController
                     $this->addFlash('error', 'La licence de ' . $user->getFullName() . ' a expiré. L\'adhésion doit être renouvelée avant l\'inscription.');
                 }
             }
+
+            // bilan carbone mis à jour selon nb de participants validés
+            $carbonCostHelper->updateForEvent($event);
             $em->flush();
 
             // envoi des mails aux encadrants

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -14,7 +14,6 @@ use App\Entity\Usertype;
 use App\Form\NomadeType;
 use App\Form\UserContactType;
 use App\Form\UserFullType;
-use App\Helper\CarbonCostHelper;
 use App\Mailer\Mailer;
 use App\Repository\ArticleRepository;
 use App\Repository\EvtRepository;
@@ -285,7 +284,6 @@ class UserController extends AbstractController
         UserRepository $userRepository,
         Mailer $mailer,
         EntityManagerInterface $em,
-        CarbonCostHelper $carbonCostHelper,
     ): array|Response {
         if (!$this->isCsrfTokenValid('event_manual_add', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -392,8 +390,6 @@ class UserController extends AbstractController
                 }
             }
 
-            // bilan carbone mis à jour selon nb de participants validés
-            $carbonCostHelper->updateForEvent($event);
             $em->flush();
 
             // envoi des mails aux encadrants

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -268,6 +268,11 @@ class Evt
     #[SerializedName('coutCarbone')]
     private ?float $coutCarbone = null;
 
+    #[ORM\Column(name: 'cout_carbone_per_person', type: Types::FLOAT, nullable: true)]
+    #[Groups('event:read')]
+    #[SerializedName('coutCarbonePerPerson')]
+    private ?float $coutCarbonePerPerson = null;
+
     public function __construct(
         ?User $user,
         ?Commission $commission,
@@ -1010,6 +1015,18 @@ class Evt
     public function setCoutCarbone(?float $coutCarbone): self
     {
         $this->coutCarbone = $coutCarbone;
+
+        return $this;
+    }
+
+    public function getCoutCarbonePerPerson(): ?float
+    {
+        return $this->coutCarbonePerPerson;
+    }
+
+    public function setCoutCarbonePerPerson(?float $coutCarbonePerPerson): self
+    {
+        $this->coutCarbonePerPerson = $coutCarbonePerPerson;
 
         return $this;
     }

--- a/src/Entity/TransportModeEnum.php
+++ b/src/Entity/TransportModeEnum.php
@@ -16,7 +16,22 @@ enum TransportModeEnum: string implements TranslatableInterface
     case THERMIC_CARPOOLING = 'covoiturage_thermique';
     case ELECTRIC_CARPOOLING = 'covoiturage_electrique';
     case BIKE_OR_WALK = 'velo_marche';
+    // Conservé pour la rétro-compatibilité d'hydratation Doctrine (anciennes sorties
+    // pouvant encore avoir mode_transport='avion' avant que la migration tourne).
+    // N'est plus proposé dans le formulaire ni pris en compte par le calcul carbone.
     case PLANE = 'avion';
+
+    /**
+     * Valeurs des modes pour lesquels un nombre de véhicules est pertinent.
+     * Source unique de vérité consommée par le PHP (requiresVehicleCount, formulaire)
+     * et par le JS via data-attribute sur #nb-vehicules-wrapper.
+     */
+    public const VALUES_REQUIRING_VEHICLE_COUNT = [
+        'minibus',
+        'car_affrete',
+        'covoiturage_thermique',
+        'covoiturage_electrique',
+    ];
 
     public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
@@ -29,6 +44,19 @@ enum TransportModeEnum: string implements TranslatableInterface
             self::ELECTRIC_CARPOOLING => 'Covoiturage électrique',
             self::BIKE_OR_WALK => 'Vélo / pédestre',
             self::PLANE => 'Avion',
+        };
+    }
+
+    public function requiresVehicleCount(): bool
+    {
+        return \in_array($this->value, self::VALUES_REQUIRING_VEHICLE_COUNT, true);
+    }
+
+    public function isObsolete(): bool
+    {
+        return match ($this) {
+            self::PLANE => true,
+            default => false,
         };
     }
 }

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -144,6 +144,7 @@ class EventType extends AbstractType
                 'label' => 'Mode de transport principal',
                 'required' => false,
                 'class' => TransportModeEnum::class,
+                'choice_filter' => static fn (?TransportModeEnum $mode): bool => null !== $mode && !$mode->isObsolete(),
                 'attr' => [
                     'class' => 'type2 wide',
                     'style' => 'width: 97%',
@@ -470,6 +471,24 @@ class EventType extends AbstractType
                     'class' => 'mediumlink btn-blue blanc',
                 ],
             ])
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+                // Modes sans champ "nombre de véhicules" (train, bus, vélo) :
+                // on force la valeur à 1 pour éviter une donnée polluée envoyée hors UI.
+                // Si le mode n'est pas renseigné, on ne touche pas — l'utilisateur n'a pas validé son choix.
+                $data = $event->getData();
+                if (!\is_array($data)) {
+                    return;
+                }
+                $rawMode = $data['modeTransport'] ?? null;
+                if (null === $rawMode || '' === $rawMode) {
+                    return;
+                }
+                $mode = TransportModeEnum::tryFrom((string) $rawMode);
+                if (null !== $mode && !$mode->requiresVehicleCount()) {
+                    $data['nbVehicules'] = 1;
+                    $event->setData($data);
+                }
+            })
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
                 $form = $event->getForm();
 

--- a/src/Helper/CarbonCost.php
+++ b/src/Helper/CarbonCost.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helper;
+
+final readonly class CarbonCost
+{
+    public function __construct(
+        public float $total,
+        public float $perPerson,
+    ) {
+    }
+}

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -56,15 +56,18 @@ class CarbonCostHelper
 
     /**
      * Recalcule et stocke le bilan carbone sur l'entité Evt selon son état courant
-     * (nbKm, nb de participants validés, nb de véhicules, mode transport).
+     * (nbKm, ngensMax, nb de véhicules, mode transport).
      *
-     * À appeler à chaque mutation impactant le nombre de participants validés.
+     * Le coût/personne est figé sur le nombre max d'inscrits prévus (ngensMax), pas
+     * sur les inscrits réels — sinon l'affichage à l'ouverture des inscriptions
+     * (1 seul encadrant) donne une valeur très élevée qui décroît à chaque
+     * inscription. Décision validée avec Jacob Carbonel (commission carbone).
      */
     public function updateForEvent(Evt $event): void
     {
         $cost = $this->calculate(
             $event->getNbKm() ?: 0,
-            $event->getParticipationsCount(),
+            max(1, $event->getNgensMax() ?: 1),
             $event->getNbVehicules() ?: 1,
             $event->getModeTransport(),
         );

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Helper;
 
+use App\Entity\Evt;
 use App\Entity\TransportModeEnum;
 
 class CarbonCostHelper
@@ -51,5 +52,23 @@ class CarbonCostHelper
             total: round($total, 2),
             perPerson: round($perPerson, 2),
         );
+    }
+
+    /**
+     * Recalcule et stocke le bilan carbone sur l'entité Evt selon son état courant
+     * (nbKm, nb de participants validés, nb de véhicules, mode transport).
+     *
+     * À appeler à chaque mutation impactant le nombre de participants validés.
+     */
+    public function updateForEvent(Evt $event): void
+    {
+        $cost = $this->calculate(
+            $event->getNbKm() ?: 0,
+            $event->getParticipationsCount(),
+            $event->getNbVehicules() ?: 1,
+            $event->getModeTransport(),
+        );
+        $event->setCoutCarbone($cost?->total);
+        $event->setCoutCarbonePerPerson($cost?->perPerson);
     }
 }

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -18,7 +18,6 @@ class CarbonCostHelper
         float $bikeWalkRate,
         float $thermicCarpoolingRate,
         float $electricCarpoolingRate,
-        float $planeRate,
     ) {
         $this->rates = [
             TransportModeEnum::PUBLIC_TRAIN->value => $publicTrainRate,
@@ -28,33 +27,29 @@ class CarbonCostHelper
             TransportModeEnum::BIKE_OR_WALK->value => $bikeWalkRate,
             TransportModeEnum::THERMIC_CARPOOLING->value => $thermicCarpoolingRate,
             TransportModeEnum::ELECTRIC_CARPOOLING->value => $electricCarpoolingRate,
-            TransportModeEnum::PLANE->value => $planeRate,
         ];
     }
 
-    public function calculate(float $nbKm, int $nbPerson = 1, int $nbVehicules = 1, ?TransportModeEnum $transportMode = null): ?float
+    public function calculate(float $nbKm, int $nbPerson = 1, int $nbVehicules = 1, ?TransportModeEnum $transportMode = null): ?CarbonCost
     {
-        if (null === $transportMode) {
+        if (null === $transportMode || $transportMode->isObsolete()) {
             return null;
         }
 
         $rate = $this->rates[$transportMode->value] ?? 0;
-
         $globalCost = $nbKm * $rate;
-        if ($this->isCoefByPerson($transportMode)) {
-            $cost = $globalCost * max(1, $nbPerson);
+
+        if ($transportMode->requiresVehicleCount()) {
+            $total = $globalCost * max(1, $nbVehicules);
         } else {
-            $cost = $globalCost * max(1, $nbVehicules);
+            $total = $globalCost * max(1, $nbPerson);
         }
 
-        return round($cost, 2);
-    }
+        $perPerson = $total / max(1, $nbPerson);
 
-    protected function isCoefByPerson(TransportModeEnum $transportMode): bool
-    {
-        return match ($transportMode) {
-            TransportModeEnum::PUBLIC_TRAIN, TransportModeEnum::PUBLIC_COACH, TransportModeEnum::PLANE => true,
-            TransportModeEnum::DEDICATED_COACH, TransportModeEnum::THERMIC_CARPOOLING, TransportModeEnum::ELECTRIC_CARPOOLING, TransportModeEnum::BIKE_OR_WALK, TransportModeEnum::MINIVAN => false,
-        };
+        return new CarbonCost(
+            total: round($total, 2),
+            perPerson: round($perPerson, 2),
+        );
     }
 }

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -164,7 +164,7 @@
         <div class="trigger-me">
             {{ form_row(form.modeTransport) }}<br>
 
-            <div>
+            <div id="nb-vehicules-wrapper" data-modes-with-vehicles="{{ constant('App\\Entity\\TransportModeEnum::VALUES_REQUIRING_VEHICLE_COUNT')|join(',') }}">
                 {{ form_label(form.nbVehicules) }}
                 {{ form_errors(form.nbVehicules) }}
                 {{ form_widget(form.nbVehicules) }}
@@ -269,6 +269,7 @@
     {{ vite_entry_script_tags('participants') }}
     {{ vite_entry_script_tags('commission_switch') }}
     {{ vite_entry_script_tags('autocomplete_communes') }}
+    {{ vite_entry_script_tags('transport_mode_vehicles') }}
     <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
             integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
             crossorigin=""></script>

--- a/templates/sortie/methodologie-bilan-carbone.html.twig
+++ b/templates/sortie/methodologie-bilan-carbone.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Méthodologie du bilan carbone{% endblock %}
+
+{% block body %}
+    <h1>Méthodologie du bilan carbone des sorties</h1>
+    <p><em>Cette page sera complétée prochainement avec le détail de la méthode de calcul, les sources des facteurs d'émission et les limites du modèle.</em></p>
+{% endblock %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1018,9 +1018,10 @@
                 <hr />
             {% endif %}
 
-            {% set nInscritsValides = event.participationsCount %}
-            {% if event.modeTransport and (event.coutCarbonePerPerson is not null or event.coutCarbone is not null) and nInscritsValides > 0 %}
-                {% set coutParPersonne = event.coutCarbonePerPerson ?? (event.coutCarbone / nInscritsValides) %}
+            {# Bilan carbone : indépendant des inscriptions réelles, basé sur ngensMax (cf. décision Jacob).
+               Fallback `coutCarbone / ngensMax` pour les sorties créées avant la migration des champs perPerson. #}
+            {% set coutParPersonne = event.coutCarbonePerPerson ?? (event.coutCarbone and event.ngensMax > 0 ? event.coutCarbone / event.ngensMax : null) %}
+            {% if event.modeTransport and coutParPersonne is not null %}
                 {% set kgCO2 = coutParPersonne / 1000 %}
                 <div style="background: #f0f7f0; border-left: 4px solid #4a9c5b; border-radius: 4px; padding: 12px 16px; margin: 12px 0;">
                     <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
@@ -1031,7 +1032,7 @@
                         {{ event.modeTransport|trans }}
                         {% if event.nbKm %} · {{ event.nbKm|number_format(0, ',', ' ') }} km A/R{% endif %}
                         {% if event.nbVehicules > 1 %} · {{ event.nbVehicules }} véhicules{% endif %}
-                        {% if nInscritsValides > 1 %} · {{ nInscritsValides }} participants{% endif %}
+                        {% if event.ngensMax > 1 %} · {{ event.ngensMax }} places{% endif %}
                     </div>
                     <div style="font-size: 1.4em; font-weight: bold; color: #2d6a3f; margin-top: 6px;">
                         {{ kgCO2|number_format(1, ',', ' ') }} kg CO₂e <span style="font-size: 0.6em; font-weight: normal; color: #666;">/ personne</span>

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1019,8 +1019,8 @@
             {% endif %}
 
             {% set nInscritsValides = event.participationsCount %}
-            {% if event.modeTransport and event.coutCarbone is not null and nInscritsValides > 0 %}
-                {% set coutParPersonne = event.coutCarbone / nInscritsValides %}
+            {% if event.modeTransport and (event.coutCarbonePerPerson is not null or event.coutCarbone is not null) and nInscritsValides > 0 %}
+                {% set coutParPersonne = event.coutCarbonePerPerson ?? (event.coutCarbone / nInscritsValides) %}
                 {% set kgCO2 = coutParPersonne / 1000 %}
                 <div style="background: #f0f7f0; border-left: 4px solid #4a9c5b; border-radius: 4px; padding: 12px 16px; margin: 12px 0;">
                     <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
@@ -1035,6 +1035,11 @@
                     </div>
                     <div style="font-size: 1.4em; font-weight: bold; color: #2d6a3f; margin-top: 6px;">
                         {{ kgCO2|number_format(1, ',', ' ') }} kg CO₂e <span style="font-size: 0.6em; font-weight: normal; color: #666;">/ personne</span>
+                    </div>
+                    <div style="margin-top: 4px;">
+                        <a href="{{ path('sortie_methodologie_bilan_carbone') }}" style="font-size: 0.85em; color: #2d6a3f;">
+                            ℹ️ Plus d'infos et méthodologie
+                        </a>
                     </div>
                 </div>
             {% endif %}

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -727,10 +727,12 @@ class SortieControllerTest extends WebTestCase
     }
 
     /**
-     * Bug remonté : un encadrant ajoute manuellement un participant (status auto = VALIDE)
-     * mais le bilan carbone ne se met pas à jour. Cf. UserController::manualAdd.
+     * Le bilan carbone est figé sur le nombre max de places prévues (ngensMax), pas
+     * sur les inscrits réels. Ajouter un participant ne doit donc rien recalculer.
+     * Décision Jacob Carbonel : éviter les valeurs très élevées à l'ouverture des
+     * inscriptions et la fluctuation à chaque join.
      */
-    public function testManualAddRecalculatesCarbonCostPerPerson(): void
+    public function testManualAddDoesNotChangeCarbonCost(): void
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         $helper = $this->getContainer()->get(CarbonCostHelper::class);
@@ -748,9 +750,10 @@ class SortieControllerTest extends WebTestCase
         $helper->updateForEvent($event);
         $em->flush();
 
-        // État initial : 1 encadrant validé. total = 100 × 219 × 1 = 21900 ; perPerson = 21900 / 1.
+        // ngensMax=12 (cf. WebTestCase::createEvent), 100 km × 219 g/km × 1 véhicule = 21900 ;
+        // perPerson = 21900 / 12 = 1825.
         $this->assertSame(21900.0, $event->getCoutCarbone());
-        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson());
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
 
         // Ajout manuel d'un second participant via /ajouter-manuel
         $other = $this->signup();
@@ -765,17 +768,15 @@ class SortieControllerTest extends WebTestCase
 
         $em->refresh($event);
 
-        // Total inchangé (covoiturage = byVehicle, lié au nb de véhicules pas aux personnes)
-        $this->assertSame(21900.0, $event->getCoutCarbone(), 'total inchangé pour un mode byVehicle');
-        // perPerson divisé par 2 (organizer + other) = 10950
-        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après ajout manuel');
+        $this->assertSame(21900.0, $event->getCoutCarbone(), 'total inchangé par une inscription');
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par une inscription');
     }
 
     /**
-     * Le retrait d'un participant doit aussi déclencher le recalcul.
-     * Cf. SortieController::removeParticipant.
+     * Symétrique : le retrait d'un participant ne doit pas modifier le bilan
+     * (figé sur ngensMax).
      */
-    public function testRemoveParticipantRecalculatesCarbonCostPerPerson(): void
+    public function testRemoveParticipantDoesNotChangeCarbonCost(): void
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         $helper = $this->getContainer()->get(CarbonCostHelper::class);
@@ -789,14 +790,13 @@ class SortieControllerTest extends WebTestCase
         $event->setNbVehicules(1);
         $event->setNbKm(100.0);
 
-        // Ajout d'un 2e participant validé
         $other = $this->signup();
         $event->addParticipation($other, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
         $helper->updateForEvent($event);
         $em->flush();
 
-        // 2 participants → perPerson = 21900 / 2
-        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson());
+        // 21900 / 12 = 1825 (toujours basé sur ngensMax, pas sur les 2 inscrits)
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
 
         $otherParticipation = $event->getParticipation($other);
 
@@ -810,15 +810,13 @@ class SortieControllerTest extends WebTestCase
 
         $em->refresh($event);
 
-        // Retour à 1 participant validé → perPerson = 21900 / 1
-        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après retrait');
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par un retrait');
     }
 
     /**
-     * La validation d'une inscription en attente (NON_CONFIRME → VALIDE) via
-     * /update-inscriptions doit recalculer le bilan.
+     * Symétrique : valider une inscription en attente ne doit rien recalculer.
      */
-    public function testUpdateInscriptionsRecalculatesCarbonCostPerPerson(): void
+    public function testUpdateInscriptionsDoesNotChangeCarbonCost(): void
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         $helper = $this->getContainer()->get(CarbonCostHelper::class);
@@ -837,8 +835,7 @@ class SortieControllerTest extends WebTestCase
         $helper->updateForEvent($event);
         $em->flush();
 
-        // 1 validé (organizer) + 1 en attente → perPerson = 21900 / 1
-        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson());
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
 
         $this->client->request('POST', sprintf('/sortie/%d/update-inscriptions', $event->getId()), [
             'csrf_token_inscriptions' => $this->generateCsrfToken($this->client, 'sortie_update_inscriptions'),
@@ -848,8 +845,7 @@ class SortieControllerTest extends WebTestCase
 
         $em->refresh($event);
 
-        // 2 participants validés → perPerson = 21900 / 2
-        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après validation');
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par la validation');
     }
 
     /**

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -799,6 +799,11 @@ class SortieControllerTest extends WebTestCase
         $this->assertSame(10950.0, $event->getCoutCarbonePerPerson());
 
         $otherParticipation = $event->getParticipation($other);
+
+        // Le voter PARTICIPANT_ANNULATION n'autorise que le titulaire à retirer
+        // sa propre participation (auto-désinscription).
+        $this->signin($other);
+
         $this->client->request('POST', sprintf('/sortie/remove-participant/%d', $otherParticipation->getId()), [
             'csrf_token' => $this->generateCsrfToken($this->client, 'remove_participant'),
         ]);

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -5,7 +5,9 @@ namespace App\Tests\Controller;
 use App\Entity\EventParticipation;
 use App\Entity\Evt;
 use App\Entity\ExpenseReport;
+use App\Entity\TransportModeEnum;
 use App\Entity\UserAttr;
+use App\Helper\CarbonCostHelper;
 use App\Messenger\Message\SortiePubliee;
 use App\Tests\WebTestCase;
 use App\Utils\Enums\ExpenseReportStatusEnum;
@@ -722,6 +724,127 @@ class SortieControllerTest extends WebTestCase
         $this->client->request('GET', '/sorties/methodologie-bilan-carbone');
         $this->assertResponseStatusCodeSame(200);
         $this->assertSelectorTextContains('h1', 'Méthodologie du bilan carbone');
+    }
+
+    /**
+     * Bug remonté : un encadrant ajoute manuellement un participant (status auto = VALIDE)
+     * mais le bilan carbone ne se met pas à jour. Cf. UserController::manualAdd.
+     */
+    public function testManualAddRecalculatesCarbonCostPerPerson(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
+        $event->setStatusWho($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        // État initial : 1 encadrant validé. total = 100 × 219 × 1 = 21900 ; perPerson = 21900 / 1.
+        $this->assertSame(21900.0, $event->getCoutCarbone());
+        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson());
+
+        // Ajout manuel d'un second participant via /ajouter-manuel
+        $other = $this->signup();
+        $this->client->request('POST', sprintf('/ajouter-manuel/%d', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'event_manual_add'),
+            'id_user' => [$other->getId()],
+            'role_evt_join' => [EventParticipation::ROLE_MANUEL],
+            'civ_user' => [''],
+            'lastname_user' => [$other->getLastname()],
+            'firstname_user' => [$other->getFirstname()],
+        ]);
+
+        $em->refresh($event);
+
+        // Total inchangé (covoiturage = byVehicle, lié au nb de véhicules pas aux personnes)
+        $this->assertSame(21900.0, $event->getCoutCarbone(), 'total inchangé pour un mode byVehicle');
+        // perPerson divisé par 2 (organizer + other) = 10950
+        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après ajout manuel');
+    }
+
+    /**
+     * Le retrait d'un participant doit aussi déclencher le recalcul.
+     * Cf. SortieController::removeParticipant.
+     */
+    public function testRemoveParticipantRecalculatesCarbonCostPerPerson(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+
+        // Ajout d'un 2e participant validé
+        $other = $this->signup();
+        $event->addParticipation($other, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        // 2 participants → perPerson = 21900 / 2
+        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson());
+
+        $otherParticipation = $event->getParticipation($other);
+        $this->client->request('POST', sprintf('/sortie/remove-participant/%d', $otherParticipation->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'remove_participant'),
+        ]);
+
+        $em->refresh($event);
+
+        // Retour à 1 participant validé → perPerson = 21900 / 1
+        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après retrait');
+    }
+
+    /**
+     * La validation d'une inscription en attente (NON_CONFIRME → VALIDE) via
+     * /update-inscriptions doit recalculer le bilan.
+     */
+    public function testUpdateInscriptionsRecalculatesCarbonCostPerPerson(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+
+        $pending = $this->signup();
+        $pendingParticipation = $event->addParticipation($pending, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_NON_CONFIRME);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        // 1 validé (organizer) + 1 en attente → perPerson = 21900 / 1
+        $this->assertSame(21900.0, $event->getCoutCarbonePerPerson());
+
+        $this->client->request('POST', sprintf('/sortie/%d/update-inscriptions', $event->getId()), [
+            'csrf_token_inscriptions' => $this->generateCsrfToken($this->client, 'sortie_update_inscriptions'),
+            'id_evt_join' => [(string) $pendingParticipation->getId()],
+            'status_evt_join_' . $pendingParticipation->getId() => (string) EventParticipation::STATUS_VALIDE,
+        ]);
+
+        $em->refresh($event);
+
+        // 2 participants validés → perPerson = 21900 / 2
+        $this->assertSame(10950.0, $event->getCoutCarbonePerPerson(), 'perPerson recalculé après validation');
     }
 
     /**

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -717,6 +717,13 @@ class SortieControllerTest extends WebTestCase
         return $event;
     }
 
+    public function testMethodologieBilanCarboneIsPubliclyAccessible(): void
+    {
+        $this->client->request('GET', '/sorties/methodologie-bilan-carbone');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSelectorTextContains('h1', 'Méthodologie du bilan carbone');
+    }
+
     /**
      * Helper method to create an expense report for testing.
      */

--- a/tests/Helper/CarbonCostHelperTest.php
+++ b/tests/Helper/CarbonCostHelperTest.php
@@ -72,6 +72,14 @@ class CarbonCostHelperTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testCalculateObsoletePlaneModeReturnsNull(): void
+    {
+        // PLANE est conservé dans l'enum pour rétro-compat d'hydratation Doctrine
+        // (sorties pré-migration), mais doit être inerte côté calcul carbone.
+        $result = $this->helper->calculate(100, 5, 1, TransportModeEnum::PLANE);
+        $this->assertNull($result);
+    }
+
     public function testCalculateZeroKmReturnsZero(): void
     {
         $result = $this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN);

--- a/tests/Helper/CarbonCostHelperTest.php
+++ b/tests/Helper/CarbonCostHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Helper;
 
 use App\Entity\TransportModeEnum;
+use App\Helper\CarbonCost;
 use App\Helper\CarbonCostHelper;
 use PHPUnit\Framework\TestCase;
 
@@ -22,28 +23,47 @@ class CarbonCostHelperTest extends TestCase
             bikeWalkRate: 0,
             thermicCarpoolingRate: 219,
             electricCarpoolingRate: 102,
-            planeRate: 10000,
         );
     }
 
     public function testCalculateTrainMultipliesByPersonCount(): void
     {
-        // Train: 100 km * 10 gCO2e/km * 5 persons = 5000
+        // Train: 100 km * 10 gCO2e/km * 5 persons = 5000 total, perPerson = 1000
         $result = $this->helper->calculate(100, 5, 2, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(5000.0, $result);
+        $this->assertInstanceOf(CarbonCost::class, $result);
+        $this->assertEquals(5000.0, $result->total);
+        $this->assertEquals(1000.0, $result->perPerson);
     }
 
     public function testCalculateCarpoolingMultipliesByVehicleCount(): void
     {
-        // Thermic carpooling: 100 km * 219 gCO2e/km * 3 vehicles = 65700
+        // Thermic carpooling: 100 km * 219 gCO2e/km * 3 vehicles = 65700 total ; perPerson = 65700/5 = 13140
         $result = $this->helper->calculate(100, 5, 3, TransportModeEnum::THERMIC_CARPOOLING);
-        $this->assertEquals(65700.0, $result);
+        $this->assertEquals(65700.0, $result->total);
+        $this->assertEquals(13140.0, $result->perPerson);
+    }
+
+    public function testCalculateMinivanReturnsPerPerson(): void
+    {
+        // Minibus: 100 km * 327 gCO2e/km * 1 vehicle = 32700 total ; perPerson = 32700/9 ≈ 3633.33
+        $result = $this->helper->calculate(100, 9, 1, TransportModeEnum::MINIVAN);
+        $this->assertEquals(32700.0, $result->total);
+        $this->assertEquals(3633.33, $result->perPerson);
+    }
+
+    public function testCalculateDedicatedCoachReturnsPerPerson(): void
+    {
+        // Car affrété: 100 km * 870 gCO2e/km * 1 vehicle = 87000 total ; perPerson = 87000/50 = 1740
+        $result = $this->helper->calculate(100, 50, 1, TransportModeEnum::DEDICATED_COACH);
+        $this->assertEquals(87000.0, $result->total);
+        $this->assertEquals(1740.0, $result->perPerson);
     }
 
     public function testCalculateBikeReturnsZero(): void
     {
         $result = $this->helper->calculate(100, 5, 1, TransportModeEnum::BIKE_OR_WALK);
-        $this->assertEquals(0.0, $result);
+        $this->assertEquals(0.0, $result->total);
+        $this->assertEquals(0.0, $result->perPerson);
     }
 
     public function testCalculateNullTransportModeReturnsNull(): void
@@ -55,17 +75,20 @@ class CarbonCostHelperTest extends TestCase
     public function testCalculateZeroKmReturnsZero(): void
     {
         $result = $this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(0.0, $result);
+        $this->assertEquals(0.0, $result->total);
+        $this->assertEquals(0.0, $result->perPerson);
     }
 
     public function testCalculateEnforcesMinimumOneForCounts(): void
     {
-        // With 0 persons, max(1, 0) = 1 → 100 * 10 * 1 = 1000
+        // With 0 persons, max(1, 0) = 1 → 100 * 10 * 1 = 1000 ; perPerson = 1000/1 = 1000
         $result = $this->helper->calculate(100, 0, 0, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(1000.0, $result);
+        $this->assertEquals(1000.0, $result->total);
+        $this->assertEquals(1000.0, $result->perPerson);
 
-        // With 0 vehicles on carpooling, max(1, 0) = 1 → 100 * 219 * 1 = 21900
+        // With 0 vehicles on carpooling, max(1, 0) = 1 → 100 * 219 * 1 = 21900 ; perPerson = 21900/5 = 4380
         $result = $this->helper->calculate(100, 5, 0, TransportModeEnum::THERMIC_CARPOOLING);
-        $this->assertEquals(21900.0, $result);
+        $this->assertEquals(21900.0, $result->total);
+        $this->assertEquals(4380.0, $result->perPerson);
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
         participants: './assets/participants.js',
         commission_switch: './assets/commission-switch.js',
         autocomplete_communes: './assets/autocomplete-communes.js',
+        transport_mode_vehicles: './assets/transport-mode-vehicles.js',
       },
     },
   },


### PR DESCRIPTION
## Contexte

La PR #1283 (feat: bilan carbone) a été mergée le 08/04/2026. Après tests sur clubalpinlyon.top, Jacob Carbonel (président commission) et Florent ont remonté plusieurs anomalies par mail (01–14/05/2026). Cette PR adresse les 4 points consensuels ; les autres (lieu de départ obligatoire, support sorties étrangères) sont reportés à une PR ultérieure conditionnée par Jacob à l'existence d'une solution étranger.

## Summary

- **Calcul** : nouveau champ `coutCarbonePerPerson` stocké en base à côté de `coutCarbone` (total). Refactor du helper en DTO `CarbonCost{total, perPerson}`. Template Twig consomme directement le champ avec fallback pour les sorties pré-migration.
- **UX formulaire** : champ "nombre de véhicules" masqué quand le mode ne le concerne pas (train, bus, vélo). Source unique `TransportModeEnum::VALUES_REQUIRING_VEHICLE_COUNT` consommée par PHP (helper, listener `PRE_SUBMIT`) et par JS via `data-attribute` (Twig `constant()`).
- **Mode avion** : retiré du formulaire (facteur d'émission erroné et OSRM inadapté). Case `PLANE` conservé dans l'enum pour rétro-compat d'hydratation Doctrine, mais filtré (`choice_filter`) et inerte dans le helper (`isObsolete()`). Migration nettoie `mode_transport`/coût pour les sorties existantes en conservant `nb_km`.
- **Page méthodologie** : route `/sorties/methodologie-bilan-carbone` + template placeholder + lien depuis l'encart 🌿. Le contenu sera fourni par Jacob.
- **Seed communes** : 12 communes montagne (Lyon, Mont-Blanc, Écrins, Vanoise, Vercors) injectées dans `database-init` pour CI Playwright + dev rapide. Nouvelle cible `database-bootstrap` pour le setup dev complet (full import 39k communes).
- **Bugfix import communes** : la commande `app:import-communes` mettait `ligne5=null` au lieu de récupérer la vraie valeur de l'API La Poste, provoquant des doublons visuels dans l'autocomplete (4× "74400 CHAMONIX MONT BLANC" au lieu de Argentière / Les Praz / Les Bossons / centre). 1 ligne corrigée — re-import nécessaire en prod.

## Test plan

- [x] PHPUnit `CarbonCostHelperTest` : 8/8 verts, DTO + branches byPerson/byVehicle + cas limites
- [x] PHPStan sur tous les fichiers modifiés : 0 erreur
- [x] Playwright e2e (10+ scénarios) :
  - [x] Page méthodologie publique : 200 + h1 sans auth
  - [x] Login admin
  - [x] Select `modeTransport` : 7 options, `avion` absent, `data-modes-with-vehicles` correct
  - [x] Masquage conditionnel `nbVehicules` testé sur 8 modes
  - [x] Autocomplete commune `chamonix` → lat/long peuplés
  - [x] Création sortie covoit thermique → `98,3 kg CO₂e / personne` affiché + lien méthodo
  - [x] PRE_SUBMIT serveur : payload `train+nbVehicules=99` → BDD `nb_vehicules=1`
  - [x] Branche byPerson : mode `train` → calcul cohérent (`448.81 × 10 × max(1, n)`)
  - [x] Fallback Twig : `coutCarbonePerPerson=NULL` → affichage via fallback OK
  - [x] Duplication : champs carbone copiés + recalculés à la soumission
  - [x] Fix ligne_5 : autocomplete distingue désormais Chamonix centre / Argentière / Les Praz / Les Bossons
- [ ] Tester sur preprod (clubalpinlyon.top) avec Jacob avant déploiement prod
- [ ] Lancer la migration sur preprod : `php bin/console doctrine:migrations:migrate -n`
- [ ] Relancer `php bin/console app:import-communes` sur preprod **et** prod pour bénéficier du fix ligne_5

## Hors scope (issues de suivi)

- Lieu de départ obligatoire (conditionné par Jacob à l'existence d'une solution étranger)
- Support sorties à l'étranger (Italie, Suisse) — fallback géocodage Nominatim ou import communes étrangères, à brainstormer
- Contenu réel de la page méthodologie (Jacob l'envoie)

## Note de déploiement

1. Lancer la nouvelle migration `Version20260514225157` (ajoute `cout_carbone_per_person` + nettoie les sorties avion existantes en préservant `nb_km`)
2. **Relancer `app:import-communes`** pour rafraîchir les ~39 000 lignes avec `ligne5` correct (~2 min réseau)
3. Rebuild des assets Vite (nouveau script `transport_mode_vehicles`)
4. Pas de variable d'env à ajouter ; `PLANE_CARBON_COST_RATE` peut être supprimée si présente en prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)