### PR TITLE
MEP 2026-05-21 : bilan carbone + corrections diverses

### DIFF
--- a/.env
+++ b/.env
@@ -215,3 +215,23 @@ METABASE_SECRET_KEY=
 ###< Metabase ###
 
 INFERIOR_RIGHTS_CLEAN=true
+
+###> OSRM (calcul de distance) ###
+OSRM_API_URL='http://router.project-osrm.org/route/v1/driving/'
+# Timeout en secondes pour les appels OSRM
+OSRM_TIMEOUT=5
+###< OSRM (calcul de distance) ###
+
+###> coefficients bilan carbone ###
+# Taux en gCO2e/km. Le coût total stocké en BDD = taux × distance × nombre (personnes ou véhicules).
+# Train/bus/avion : multiplié par le nombre de participants (coût individuel par personne)
+# Covoiturage/minibus/car affrété : multiplié par le nombre de véhicules (coût par véhicule)
+PUBLIC_TRAIN_CARBON_COST_RATE=10
+PUBLIC_COACH_CARBON_COST_RATE=122
+DEDICATED_COACH_CARBON_COST_RATE=870
+MINIVAN_CARBON_COST_RATE=327
+BIKE_OR_WALK_CARBON_COST_RATE=0
+THERMIC_CARPOOLING_CARBON_COST_RATE=219
+ELECTRIC_CARPOOLING_CARBON_COST_RATE=102
+PLANE_CARBON_COST_RATE=10000
+###< coefficients bilan carbone ###

--- a/.env
+++ b/.env
@@ -224,7 +224,7 @@ OSRM_TIMEOUT=5
 
 ###> coefficients bilan carbone ###
 # Taux en gCO2e/km. Le coût total stocké en BDD = taux × distance × nombre (personnes ou véhicules).
-# Train/bus/avion : multiplié par le nombre de participants (coût individuel par personne)
+# Train/bus : multiplié par le nombre de participants (coût individuel par personne)
 # Covoiturage/minibus/car affrété : multiplié par le nombre de véhicules (coût par véhicule)
 PUBLIC_TRAIN_CARBON_COST_RATE=10
 PUBLIC_COACH_CARBON_COST_RATE=122
@@ -233,5 +233,4 @@ MINIVAN_CARBON_COST_RATE=327
 BIKE_OR_WALK_CARBON_COST_RATE=0
 THERMIC_CARPOOLING_CARBON_COST_RATE=219
 ELECTRIC_CARPOOLING_CARBON_COST_RATE=102
-PLANE_CARBON_COST_RATE=10000
 ###< coefficients bilan carbone ###

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public/dev.txt
 /bin/tools
 
 /.php-cs-fixer.cache
+/.phpstan-tmp/
 
 ###> symfony/framework-bundle ###
 /.env.local
@@ -33,6 +34,7 @@ public/dev.txt
 /playwright/.cache/
 /e2e/.auth/
 .env.test
+/.playwright-mcp/
 ###< playwright ###
 
 ###> lexik/jwt-authentication-bundle ###

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ database-init-test: ## Init database for test
 	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/schema_caf.sql
 	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/data_caf.sql
 	$(SYMFONY_CONSOLE) doctrine:migrations:migrate --no-interaction --env=test
+	$(MYSQL) -Dcaf_test -uroot -ptest < ./legacy/data/data_communes_seed.sql
 	$(MAKE) args="--env=test --no-interaction" database-fixtures-load
 .PHONY: database-init-test
 
@@ -142,13 +143,23 @@ npm-watch: ## Watch the frontend files
 .PHONY: npm-watch
 
 ## —— 📊 Database ——
-database-init: ## Init database
+database-init: ## Init database (seed minimal de communes — CI rapide)
 	$(MAKE) database-drop
 	$(MAKE) database-create
 	$(MAKE) database-import
 	$(MAKE) database-migrate
+	$(MAKE) database-seed-communes
 	$(MAKE) args="--env=dev --no-interaction" database-fixtures-load
 .PHONY: database-init
+
+database-bootstrap: ## Setup dev complet : database-init + import des ~39 000 communes (~2 min réseau)
+	$(MAKE) database-init
+	$(MAKE) database-import-communes
+.PHONY: database-bootstrap
+
+database-seed-communes: ## Seed minimal de communes montagne (Lyon, Mont-Blanc, Écrins, Vanoise, Vercors)
+	$(MYSQL) -Dcaf -uroot -ptest < ./legacy/data/data_communes_seed.sql
+.PHONY: database-seed-communes
 
 database-drop: ## Create database
 	$(SYMFONY_CONSOLE) doctrine:database:drop --force --if-exists
@@ -164,6 +175,10 @@ database-create: ## Create database
 database-import: ## Make import
 	$(MYSQL) -Dcaf -uroot -ptest < ./legacy/data/data_caf.sql
 .PHONY: database-import
+
+database-import-communes: ## Import communes françaises (coordonnées GPS, ~39 000 entrées via API La Poste)
+	$(SYMFONY_CONSOLE) app:import-communes
+.PHONY: database-import-communes
 
 database-migration: ## Make migration
 	$(SYMFONY_CONSOLE) make:migration

--- a/assets/autocomplete-communes.js
+++ b/assets/autocomplete-communes.js
@@ -1,6 +1,7 @@
 function searchCommunes(context) {
     const field = document.getElementById('event_place');
     const list = document.getElementById("place_suggestions");
+    const container = field ? field.closest('[data-start-lat-field][data-start-long-field]') || field.parentElement : null;
     let timer;
 
     field.addEventListener('keyup', (e) => {
@@ -24,7 +25,7 @@ function searchCommunes(context) {
                         list.innerHTML = "";
                         data.forEach(item => {
                             let liContentText = item. codePostal + ' ' + item.nomCommune;
-                            if ('' !== item.ligne5) {
+                            if (item.ligne5) {
                                 liContentText += ' (' + item.ligne5 + ')';
                             }
                             const li = document.createElement("li");
@@ -34,6 +35,18 @@ function searchCommunes(context) {
                             li.onclick = () => {
                                 field.value = liContentText;
                                 list.innerHTML = '';
+
+                                // Remplir les champs cachés latDepart et longDepart
+                                const startLatSelector = container ? container.getAttribute('data-start-lat-field') : null;
+                                const startLongSelector = container ? container.getAttribute('data-start-long-field') : null;
+                                const startLatField = startLatSelector ? document.getElementById(startLatSelector) : document.getElementById('event_latDepart');
+                                const startLongField = startLongSelector ? document.getElementById(startLongSelector) : document.getElementById('event_longDepart');
+                                if (startLatField && item.latitude) {
+                                    startLatField.value = item.latitude;
+                                }
+                                if (startLongField && item.longitude) {
+                                    startLongField.value = item.longitude;
+                                }
                             };
                             list.appendChild(li);
                         });

--- a/assets/transport-mode-vehicles.js
+++ b/assets/transport-mode-vehicles.js
@@ -1,0 +1,35 @@
+// Affiche/masque le champ "nombre de véhicules" du formulaire sortie
+// selon le mode de transport sélectionné. La liste des modes véhiculés
+// vient du data-attribute généré par Twig (source unique : TransportModeEnum).
+
+function initTransportModeVehicles() {
+    const select = document.getElementById('event_modeTransport');
+    const wrapper = document.getElementById('nb-vehicules-wrapper');
+    const input = document.getElementById('event_nbVehicules');
+
+    if (!select || !wrapper || !input) {
+        return;
+    }
+
+    const modesWithVehicles = (wrapper.dataset.modesWithVehicles || '')
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
+
+    const sync = () => {
+        const show = modesWithVehicles.includes(select.value);
+        wrapper.style.display = show ? '' : 'none';
+        if (!show) {
+            input.value = 1;
+        }
+    };
+
+    select.addEventListener('change', sync);
+    sync();
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTransportModeVehicles);
+} else {
+    initTransportModeVehicles();
+}

--- a/composer.lock
+++ b/composer.lock
@@ -5904,16 +5904,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "3.10.1",
+            "version": "3.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "e013633c2907d13a6906d9e95dca09748eb1523c"
+                "reference": "13f709c73e417c3c8cadc87ac88f809fd8d1fa45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/e013633c2907d13a6906d9e95dca09748eb1523c",
-                "reference": "e013633c2907d13a6906d9e95dca09748eb1523c",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/13f709c73e417c3c8cadc87ac88f809fd8d1fa45",
+                "reference": "13f709c73e417c3c8cadc87ac88f809fd8d1fa45",
                 "shasum": ""
             },
             "require": {
@@ -5935,15 +5935,13 @@
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
                 "php": "^8.1",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
                 "dompdf/dompdf": "^2.0 || ^3.0",
                 "friendsofphp/php-cs-fixer": "^3.2",
-                "mitoteam/jpgraph": "^10.3",
+                "mitoteam/jpgraph": "^10.5",
                 "mpdf/mpdf": "^8.1.1",
                 "phpcompatibility/php-compatibility": "^9.3",
                 "phpstan/phpstan": "^1.1",
@@ -5954,7 +5952,7 @@
             },
             "suggest": {
                 "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
-                "ext-intl": "PHP Internationalization Functions",
+                "ext-intl": "PHP Internationalization Functions, required for NumberFormatter Wizard",
                 "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
                 "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
                 "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
@@ -5987,6 +5985,9 @@
                 },
                 {
                     "name": "Adrien Crivelli"
+                },
+                {
+                    "name": "Owen Leibman"
                 }
             ],
             "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
@@ -6003,9 +6004,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/3.10.1"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/3.10.5"
             },
-            "time": "2025-09-01T18:47:22+00:00"
+            "time": "2026-04-19T05:54:30+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -14381,5 +14382,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -362,3 +362,19 @@ services:
     arguments:
       $cleanInferiorRights: '%inferior_rights_clean%'
     tags: ['controller.service_arguments']
+
+  App\Helper\DistanceHelper:
+    arguments:
+      $osrmApiUrl: '%env(OSRM_API_URL)%'
+      $timeout: '%env(int:OSRM_TIMEOUT)%'
+
+  App\Helper\CarbonCostHelper:
+    arguments:
+      $publicTrainRate: '%env(float:PUBLIC_TRAIN_CARBON_COST_RATE)%'
+      $publicCoachRate: '%env(float:PUBLIC_COACH_CARBON_COST_RATE)%'
+      $dedicatedCoachRate: '%env(float:DEDICATED_COACH_CARBON_COST_RATE)%'
+      $minivanRate: '%env(float:MINIVAN_CARBON_COST_RATE)%'
+      $bikeWalkRate: '%env(float:BIKE_OR_WALK_CARBON_COST_RATE)%'
+      $thermicCarpoolingRate: '%env(float:THERMIC_CARPOOLING_CARBON_COST_RATE)%'
+      $electricCarpoolingRate: '%env(float:ELECTRIC_CARPOOLING_CARBON_COST_RATE)%'
+      $planeRate: '%env(float:PLANE_CARBON_COST_RATE)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -377,4 +377,3 @@ services:
       $bikeWalkRate: '%env(float:BIKE_OR_WALK_CARBON_COST_RATE)%'
       $thermicCarpoolingRate: '%env(float:THERMIC_CARPOOLING_CARBON_COST_RATE)%'
       $electricCarpoolingRate: '%env(float:ELECTRIC_CARPOOLING_CARBON_COST_RATE)%'
-      $planeRate: '%env(float:PLANE_CARBON_COST_RATE)%'

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,8 +24,24 @@
 2. Initialiser l'environnement :
 ```bash
 make init
-make database-init
+# Puis choisir UNE des deux cibles ci-dessous selon le besoin :
+make database-init        # seed minimal (12 communes), démarrage rapide
+# ou
+make database-bootstrap   # full import (~39 000 communes, ~2 min réseau)
 ```
+
+### Initialisation de la base de données
+
+Le projet propose deux cibles selon ton besoin :
+
+| Cible | Communes en base | Quand l'utiliser |
+|---|---|---|
+| `make database-init` | Seed minimal (12 communes montagne) | Démarrage rapide, CI |
+| `make database-bootstrap` | ~39 000 communes (API La Poste, ~2 min réseau) | Install initiale, autocomplete complet France |
+
+Le seed minimal inclut Lyon (1er & 3e), le massif du Mont-Blanc (Chamonix, Saint-Gervais, Annecy), les Écrins (Saint-Christophe-en-Oisans avec La Bérarde, Bourg-d'Oisans, Pelvoux, Briançon), la Vanoise (Pralognan, Bonneval-sur-Arc) et le Vercors (Villard-de-Lans) — suffisant pour tester le calcul du bilan carbone des sorties.
+
+Pour rafraîchir uniquement les communes sans toucher au reste : `make database-import-communes` (full) ou `make database-seed-communes` (minimal).
 
 ## Accès
 

--- a/docs/validation-sorties.md
+++ b/docs/validation-sorties.md
@@ -1,0 +1,24 @@
+# Validation des sorties
+
+## Cycle de validation
+
+Une sortie passe par deux étapes de validation indépendantes :
+
+1. **Validation publication** (`evt_validate`) — un responsable de commission (généralement, rôle à choisir dans la matrice des droits) approuve la sortie pour qu'elle soit visible publiquement (`STATUS_PUBLISHED_VALIDE`).
+2. **Validation légale** (`evt_legal_accept` / `evt_legal_refuse`) — une personne habilitée confirme que la sortie est conforme pour être reconnue comme sortie officielle du CAF.
+
+Ces deux étapes sont indépendantes : une sortie peut être publiée sans être validée légalement.
+
+## Matrice des droits
+
+Les droits `evt_validate`, `evt_legal_accept` et `evt_legal_refuse` s'administrent dans la matrice des droits (`/admin/`). Chaque droit peut être assigné à un ou plusieurs rôles, avec ou sans restriction par commission.
+
+La page de validation légale (`/validation-des-sorties.html`) n'est accessible qu'aux utilisateurs dont au moins un rôle possède `evt_legal_accept` ou `evt_legal_refuse`.
+
+## Comportement si aucun rôle n'a `evt_legal_accept`
+
+Si aucun rôle n'est configuré avec le droit `evt_legal_accept` dans la matrice, les sorties sont **automatiquement validées légalement** au moment de leur publication, sans envoi d'email à l'organisateur.
+
+Ce cas se produit typiquement lorsque le club ne souhaite pas de circuit de validation légale distinct et considère que publication vaut validation. La responsabilité légale est déléguée au rôle associé à la publication.
+
+La vérification porte sur la configuration de la matrice (table `caf_usertype_attr`), pas sur l'existence d'utilisateurs affectés à un rôle.

--- a/legacy/data/data_communes_seed.sql
+++ b/legacy/data/data_communes_seed.sql
@@ -1,0 +1,29 @@
+-- Seed minimal de la table communes pour dev/CI.
+-- Lancé après les migrations Doctrine, avant les fixtures.
+-- Pour un dev complet (autocomplete sur toute la France), utiliser
+-- `make database-bootstrap` qui appelle ensuite `app:import-communes`.
+
+TRUNCATE TABLE communes;
+
+INSERT INTO communes (code_commune_insee, nom_commune, code_postal, libelle_acheminement, ligne5, geopoint, latitude, longitude) VALUES
+-- Lyon (point de RDV / covoiturage majoritaire)
+('69381', 'Lyon 1er Arrondissement', '69001', 'LYON',                       NULL, '45.76667,4.83472',  45.76667000, 4.83472000),
+('69383', 'Lyon 3e Arrondissement',  '69003', 'LYON',                       NULL, '45.74944,4.85944',  45.74944000, 4.85944000),
+
+-- Massif du Mont-Blanc (Haute-Savoie)
+('74056', 'Chamonix-Mont-Blanc',     '74400', 'CHAMONIX MONT BLANC',         NULL, '45.92375,6.86861',  45.92375000, 6.86861000),
+('74236', 'Saint-Gervais-les-Bains', '74170', 'ST GERVAIS LES BAINS',        NULL, '45.89139,6.71139',  45.89139000, 6.71139000),
+('74010', 'Annecy',                  '74000', 'ANNECY',                      NULL, '45.89944,6.12889',  45.89944000, 6.12889000),
+
+-- Massif des Écrins (Hautes-Alpes / Isère)
+('38442', 'Saint-Christophe-en-Oisans', '38520', 'ST CHRISTOPHE EN OISANS', 'LA BERARDE', '44.93917,6.24917', 44.93917000, 6.24917000),
+('38052', 'Bourg-d''Oisans (Le)',    '38520', 'LE BOURG D OISANS',           NULL, '45.05278,6.03083',  45.05278000, 6.03083000),
+('05101', 'Pelvoux',                 '05340', 'PELVOUX',                     NULL, '44.87194,6.48750',  44.87194000, 6.48750000),
+('05023', 'Briançon',                '05100', 'BRIANCON',                    NULL, '44.89889,6.63556',  44.89889000, 6.63556000),
+
+-- Massif de la Vanoise (Savoie)
+('73208', 'Pralognan-la-Vanoise',    '73710', 'PRALOGNAN LA VANOISE',        NULL, '45.37806,6.72222',  45.37806000, 6.72222000),
+('73041', 'Bonneval-sur-Arc',        '73480', 'BONNEVAL SUR ARC',            NULL, '45.37194,7.04194',  45.37194000, 7.04194000),
+
+-- Massif du Vercors (Isère)
+('38548', 'Villard-de-Lans',         '38250', 'VILLARD DE LANS',             NULL, '45.07000,5.55333',  45.07000000, 5.55333000);

--- a/migrations/Version20250911073424.php
+++ b/migrations/Version20250911073424.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250911073424 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds new field for carbon cost calculation to caf_evt table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt ADD mode_transport VARCHAR(50) DEFAULT NULL, ADD nb_km DOUBLE PRECISION DEFAULT NULL, ADD cout_carbone DOUBLE PRECISION DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt DROP mode_transport, DROP nb_km, DROP cout_carbone');
+    }
+}

--- a/migrations/Version20251128133218.php
+++ b/migrations/Version20251128133218.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20251128133218 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds new fields to store gps coordinates';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Step 1: add columns as nullable
+        $this->addSql('ALTER TABLE communes ADD geopoint VARCHAR(255) DEFAULT NULL, ADD latitude NUMERIC(11, 8) DEFAULT NULL, ADD longitude NUMERIC(11, 8) DEFAULT NULL');
+
+        // Step 2: populate existing rows
+        $this->addSql('UPDATE communes SET geopoint = \'\', latitude = 0, longitude = 0 WHERE latitude IS NULL');
+
+        // Step 3: set NOT NULL on latitude and longitude (geopoint stays nullable)
+        $this->addSql('ALTER TABLE communes CHANGE latitude latitude NUMERIC(11, 8) NOT NULL, CHANGE longitude longitude NUMERIC(11, 8) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE communes DROP geopoint, DROP latitude, DROP longitude');
+    }
+}

--- a/migrations/Version20260202143015.php
+++ b/migrations/Version20260202143015.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260202143015 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds new fields to store carbon cost informations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // nb_vehicules has a DEFAULT, can be added directly as NOT NULL
+        $this->addSql('ALTER TABLE caf_evt ADD nb_vehicules INT DEFAULT 1 NOT NULL');
+
+        // Step 1: add columns as nullable
+        $this->addSql('ALTER TABLE caf_evt ADD lat_depart NUMERIC(11, 8) DEFAULT NULL, ADD long_depart NUMERIC(11, 8) DEFAULT NULL');
+
+        // Step 2: populate existing rows
+        $this->addSql('UPDATE caf_evt SET lat_depart = 0, long_depart = 0 WHERE lat_depart IS NULL');
+
+        // Step 3: set NOT NULL
+        $this->addSql('ALTER TABLE caf_evt CHANGE lat_depart lat_depart NUMERIC(11, 8) NOT NULL, CHANGE long_depart long_depart NUMERIC(11, 8) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt DROP lat_depart, DROP long_depart');
+        $this->addSql('ALTER TABLE caf_evt DROP nb_vehicules');
+    }
+}

--- a/migrations/Version20260514225157.php
+++ b/migrations/Version20260514225157.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514225157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Bilan carbone : ajoute cout_carbone_per_person et retire le mode 'avion' des sorties existantes";
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt ADD cout_carbone_per_person DOUBLE PRECISION DEFAULT NULL');
+
+        // Le mode "avion" est retiré : facteur d'émission erroné et méthode OSRM
+        // (routage routier) inadaptée aux trajets aériens. On nettoie le mode et
+        // le coût carbone qui étaient faux. On conserve nb_km (distance routière
+        // neutre, exploitable pour audit ou recalcul ultérieur).
+        $this->addSql("UPDATE caf_evt SET mode_transport = NULL, cout_carbone = NULL, cout_carbone_per_person = NULL WHERE mode_transport = 'avion'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt DROP cout_carbone_per_person');
+        // Pas de rollback du nettoyage 'avion' : les données effacées étaient incorrectes.
+    }
+}

--- a/src/Command/GoogleGroupsSync.php
+++ b/src/Command/GoogleGroupsSync.php
@@ -146,7 +146,7 @@ class GoogleGroupsSync extends Command
         }
 
         foreach ($this->userAttrRepository->listAllResponsables() as $commissionMember) {
-            $type = 'MEMBER';
+            $type = 'OWNER';
             $email = $this->getUserEmail($commissionMember->getUser());
 
             if (!$email) {
@@ -203,7 +203,7 @@ class GoogleGroupsSync extends Command
         }
 
         foreach ($this->userAttrRepository->listAllEncadrants($commission) as $commissionMember) {
-            $type = 'MEMBER';
+            $type = UserAttr::RESPONSABLE_COMMISSION === $commissionMember->getCode() ? 'OWNER' : 'MEMBER';
             $email = $this->getUserEmail($commissionMember->getUser());
 
             if (!$email) {

--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsCommand(
+    name: 'app:import-communes',
+    description: 'Import des communes françaises depuis l\'API La Poste (codes postaux + coordonnées GPS)',
+)]
+class ImportCommunesCommand extends Command
+{
+    private const API_URL = 'https://datanova.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/lines';
+    private const PAGE_SIZE = 1000;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly Connection $connection,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Import des communes depuis l\'API La Poste');
+
+        $this->connection->executeStatement('DELETE FROM communes');
+        $io->comment('Table communes vidée.');
+
+        $total = 0;
+        $url = self::API_URL . '?size=' . self::PAGE_SIZE;
+
+        do {
+            $response = $this->httpClient->request('GET', $url);
+            $data = $response->toArray();
+            $results = $data['results'] ?? [];
+
+            if (empty($results)) {
+                break;
+            }
+
+            foreach ($results as $row) {
+                $lat = 0;
+                $long = 0;
+                $geopoint = $row['_geopoint'] ?? '';
+                if ($geopoint && str_contains($geopoint, ',')) {
+                    [$lat, $long] = explode(',', $geopoint);
+                }
+
+                $this->connection->insert('communes', [
+                    'code_commune_insee' => $row['code_commune_insee'] ?? '',
+                    'nom_commune' => $row['nom_de_la_commune'] ?? '',
+                    'code_postal' => $row['code_postal'] ?? '',
+                    'libelle_acheminement' => $row['libelle_d_acheminement'] ?? '',
+                    'ligne5' => null,
+                    'geopoint' => $geopoint ?: null,
+                    'latitude' => (float) $lat,
+                    'longitude' => (float) $long,
+                ]);
+            }
+
+            $total += \count($results);
+            $url = $data['next'] ?? null;
+
+            $io->write("\r  $total communes importées...");
+        } while ($url);
+
+        $io->newLine();
+        $io->success("$total communes importées avec succès.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -30,6 +30,10 @@ class ImportCommunesCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // 39 000 communes paginées par 1000 ; Sentry retient les spans HTTP par page,
+        // ce qui peut saturer le 128M par défaut de la CLI Clever Cloud.
+        ini_set('memory_limit', '512M');
+
         $io = new SymfonyStyle($input, $output);
         $io->title('Import des communes depuis l\'API La Poste');
 
@@ -61,7 +65,7 @@ class ImportCommunesCommand extends Command
                     'nom_commune' => $row['nom_de_la_commune'] ?? '',
                     'code_postal' => $row['code_postal'] ?? '',
                     'libelle_acheminement' => $row['libelle_d_acheminement'] ?? '',
-                    'ligne5' => null,
+                    'ligne5' => $row['ligne_5'] ?? null,
                     'geopoint' => $geopoint ?: null,
                     'latitude' => (float) $lat,
                     'longitude' => (float) $long,
@@ -72,6 +76,10 @@ class ImportCommunesCommand extends Command
             $url = $data['next'] ?? null;
 
             $io->write("\r  $total communes importées...");
+
+            // Libère la réponse HTTP et ses éventuels spans Sentry/Cache.
+            unset($response, $data, $results);
+            gc_collect_cycles();
         } while ($url);
 
         $io->newLine();

--- a/src/Controller/AgendaController.php
+++ b/src/Controller/AgendaController.php
@@ -29,7 +29,7 @@ class AgendaController extends AbstractController
         $year = (int) ($request->query->get('year') ?: date('Y'));
         $month = (int) ($request->query->get('month') ?: date('m'));
 
-        if ($year <= 2000) {
+        if ($year <= 2000 || $year > (int) date('Y') + 2) {
             $year = (int) date('Y');
         }
         if ($month < 1 || $month > 12) {

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -10,6 +10,8 @@ use App\Entity\FormationValidationNiveauPratique;
 use App\Entity\User;
 use App\Entity\UserAttr;
 use App\Form\EventType;
+use App\Helper\CarbonCostHelper;
+use App\Helper\DistanceHelper;
 use App\Helper\RoleHelper;
 use App\Helper\SlugHelper;
 use App\Legacy\LegacyContainer;
@@ -74,6 +76,8 @@ class SortieController extends AbstractController
         ManagerRegistry $doctrine,
         CommissionRepository $commissionRepository,
         Mailer $mailer,
+        CarbonCostHelper $carbonCostHelper,
+        DistanceHelper $distanceHelper,
         ?Evt $event = null,
         ?string $mode = null,
     ): array|RedirectResponse {
@@ -145,6 +149,10 @@ class SortieController extends AbstractController
             $currentBenevoles = $event->getEncadrants([EventParticipation::ROLE_BENEVOLE]);
             $originalEntityData['hasPaymentForm'] = $event->hasPaymentForm();
             $originalEntityData['paymentAmount'] = $event->getPaymentAmount();
+            $originalEntityData['lat'] = (float) $event->getLat();
+            $originalEntityData['long'] = (float) $event->getLong();
+            $originalEntityData['latDepart'] = (float) $event->getLatDepart();
+            $originalEntityData['longDepart'] = (float) $event->getLongDepart();
         }
 
         $form = $this->createForm(EventType::class, $event, ['is_edit' => $isUpdate, 'editoLineLink' => $this->editoLineLink, 'imageRightLink' => $this->imageRightLink, 'user' => $user]);
@@ -279,6 +287,21 @@ class SortieController extends AbstractController
             }
             $event->setJoinMax($event->getNgensMax());
 
+            // bilan carbone : ne recalculer la distance que si les coordonnées ont changé
+            $coordsChanged = !$isUpdate
+                || (float) $event->getLat() !== $originalEntityData['lat']
+                || (float) $event->getLong() !== $originalEntityData['long']
+                || (float) $event->getLatDepart() !== $originalEntityData['latDepart']
+                || (float) $event->getLongDepart() !== $originalEntityData['longDepart'];
+
+            if ($coordsChanged) {
+                $nbKm = $distanceHelper->calculate($event);
+                // Conserver l'ancienne distance si l'appel OSRM échoue (retourne 0)
+                if ($nbKm > 0 || !$isUpdate) {
+                    $event->setNbKm($nbKm);
+                }
+            }
+            $this->calculateCarbonCost($event, $carbonCostHelper);
             $entityManager->persist($event);
             $entityManager->flush();
 
@@ -485,6 +508,7 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         RoleHelper $roleHelper,
+        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('sortie_update_inscriptions', $request->request->get('csrf_token_inscriptions'))) {
             $this->addFlash('error', 'Jeton de validation invalide.');
@@ -523,7 +547,7 @@ class SortieController extends AbstractController
             }
 
             if ($status < 0) {
-                $em->remove($participation);
+                $event->removeParticipation($participation);
 
                 continue;
             }
@@ -613,6 +637,8 @@ class SortieController extends AbstractController
         }
 
         if ($flush) {
+            // bilan carbone mis à jour selon nb de participants
+            $this->calculateCarbonCost($event, $carbonCostHelper);
             $em->flush();
         }
 
@@ -856,8 +882,13 @@ class SortieController extends AbstractController
     }
 
     #[Route(path: '/sortie/remove-participant/{id}', name: 'sortie_remove_participant', requirements: ['id' => '\d+'], methods: ['POST'], priority: '10')]
-    public function removeParticipant(Request $request, EventParticipation $participation, EntityManagerInterface $em, Mailer $mailer): RedirectResponse
-    {
+    public function removeParticipant(
+        Request $request,
+        EventParticipation $participation,
+        EntityManagerInterface $em,
+        Mailer $mailer,
+        CarbonCostHelper $carbonCostHelper,
+    ): RedirectResponse {
         $event = $participation->getEvt();
 
         if (!$this->isCsrfTokenValid('remove_participant', $request->request->get('csrf_token'))) {
@@ -868,7 +899,11 @@ class SortieController extends AbstractController
             throw new AccessDeniedHttpException('Vous n\'êtes pas autorisé à cela.');
         }
 
-        $em->remove($participation);
+        $event->removeParticipation($participation);
+        // orphanRemoval: true on Evt::$participations handles the DELETE in DB
+
+        // bilan carbone mis à jour selon nb de participants
+        $this->calculateCarbonCost($event, $carbonCostHelper);
         $em->flush();
 
         /** @var User */
@@ -937,6 +972,12 @@ class SortieController extends AbstractController
         $newEvent->setJoinStartDate(new \DateTimeImmutable());
         $newEvent->setAutoAccept($event->isAutoAccept());
         $newEvent->setIsDraft(true);
+        $newEvent->setLatDepart($event->getLatDepart());
+        $newEvent->setLongDepart($event->getLongDepart());
+        $newEvent->setNbVehicules($event->getNbVehicules());
+        $newEvent->setModeTransport($event->getModeTransport());
+        $newEvent->setNbKm($event->getNbKm());
+        $newEvent->setCoutCarbone($event->getCoutCarbone());
 
         // dupliquer les participants ?
         if ('full' === $mode) {
@@ -988,6 +1029,7 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         UserRepository $userRepository,
+        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('join_event', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -1139,6 +1181,9 @@ class SortieController extends AbstractController
                         }
                     }
                 }
+
+                // bilan carbone mis à jour selon nb de participants
+                $this->calculateCarbonCost($event, $carbonCostHelper);
                 $em->flush();
 
                 // E-MAIL À L'ORGANISATEUR ET AUX ENCADRANTS
@@ -1317,5 +1362,16 @@ class SortieController extends AbstractController
             'hideBlankLines' => ('y' === $request->query->get('hide_blank')),
             'pdf' => $isPdf,
         ];
+    }
+
+    protected function calculateCarbonCost(Evt $event, CarbonCostHelper $helper): void
+    {
+        $cost = $helper->calculate(
+            $event->getNbKm() ?: 0,
+            $event->getParticipationsCount(),
+            $event->getNbVehicules() ?: 1,
+            $event->getModeTransport(),
+        );
+        $event->setCoutCarbone($cost);
     }
 }

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,7 +26,6 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
-use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;
@@ -395,11 +394,9 @@ class SortieController extends AbstractController
             }
         }
 
-        // Date cutoff: September 30 of current year if after Dec 1, otherwise September 30 of previous year
-        $currentMonth = date('m');
-        $currentYear = date('Y');
-        $cutoffYear = $currentMonth >= 12 ? $currentYear : $currentYear - 1;
-        $cutoffDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $cutoffYear . '-' . UserLicenseHelper::LICENSE_TOLERANCY_PERIOD_END);
+        // Date cutoff: December 31 of the previous year
+        $cutoffYear = (int) date('Y') - 1;
+        $cutoffDate = new \DateTimeImmutable($cutoffYear . '-12-31 23:59:59');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -88,6 +88,7 @@ class SortieController extends AbstractController
         $isDuplicate = false;
         $hasErrors = false;
         $commission = $event?->getCommission();
+        $sourceEventId = null;
 
         if (!$event instanceof Evt) {
             $commission = $commissionRepository->findOneBy(['code' => $request->query->get('commission')]);
@@ -110,6 +111,7 @@ class SortieController extends AbstractController
             $event->setJoinStartDate(new \DateTimeImmutable());
             $isUpdate = false;
         } elseif (!empty($mode)) {
+            $sourceEventId = 'full' === $mode ? $event->getId() : null;
             $event = $this->duplicate($request, $event, $mode);
             $commission = $event->getCommission();
             $isUpdate = false;
@@ -197,6 +199,24 @@ class SortieController extends AbstractController
                             ;
                         } else {
                             $event->addParticipation($participant, $role, EventParticipation::STATUS_VALIDE);
+                        }
+                    }
+                }
+            }
+
+            // participants depuis duplication "avec le groupe"
+            $sourceEventIdFromRequest = (int) $request->request->get('source_event_id');
+            if (!$isUpdate && $sourceEventIdFromRequest > 0) {
+                $sourceEvent = $entityManager->getRepository(Evt::class)->find($sourceEventIdFromRequest);
+                if ($sourceEvent && $this->isGranted('SORTIE_DUPLICATE', $sourceEvent)) {
+                    $rolesImportedOutsideForm = [
+                        EventParticipation::ROLE_INSCRIT,
+                        EventParticipation::ROLE_MANUEL,
+                        EventParticipation::BENEVOLE,
+                    ];
+                    foreach ($sourceEvent->getParticipations($rolesImportedOutsideForm, EventParticipation::STATUS_VALIDE) as $participation) {
+                        if (!$event->getParticipation($participation->getUser())) {
+                            $event->addParticipation($participation->getUser(), $participation->getRole(), EventParticipation::STATUS_VALIDE);
                         }
                     }
                 }
@@ -310,6 +330,7 @@ class SortieController extends AbstractController
         }
         if ($form->isSubmitted() && !$form->isValid()) {
             $hasErrors = true;
+            $sourceEventId = (int) $request->request->get('source_event_id') ?: null;
         }
 
         return [
@@ -322,6 +343,7 @@ class SortieController extends AbstractController
             'form_action' => $isUpdate ? $this->generateUrl('modifier_sortie', ['event' => $event->getId()]) : $this->generateUrl('creer_sortie'),
             'is_duplicate' => $isDuplicate,
             'has_errors' => $hasErrors,
+            'source_event_id' => $sourceEventId,
         ];
     }
 

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -185,7 +185,7 @@ class SortieController extends AbstractController
                 EventParticipation::ROLE_COENCADRANT => 'coencadrants',
                 EventParticipation::ROLE_BENEVOLE => 'benevoles',
             ];
-            $newEncadrants = [];
+            $newEncadrants = array_fill_keys(array_values($rolesMap), []);
             foreach ($rolesMap as $role => $roleName) {
                 if (!empty($formData[$roleName])) {
                     foreach ($formData[$roleName] as $participantId) {

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -583,7 +583,7 @@ class SortieController extends AbstractController
                 continue;
             }
 
-            if ($event->isFinished() && !\in_array($status, [EventParticipation::STATUS_ABSENT], true)) {
+            if ($event->isStarted() && !\in_array($status, [EventParticipation::STATUS_ABSENT], true)) {
                 continue;
             }
 

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,6 +26,7 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
+use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -26,7 +26,6 @@ use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
 use App\Service\HelloAssoService;
-use App\Service\UserLicenseHelper;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
 use App\Utils\ExcelExport;

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -56,6 +56,8 @@ use Twig\Error\SyntaxError;
 
 class SortieController extends AbstractController
 {
+    public const EXPENSE_REPORT_DEADLINE_DAYS = 120;
+
     public function __construct(
         protected SlugHelper $slugHelper,
         protected float $defaultLat,
@@ -394,9 +396,8 @@ class SortieController extends AbstractController
             }
         }
 
-        // Date cutoff: December 31 of the previous year
-        $cutoffYear = (int) date('Y') - 1;
-        $cutoffDate = new \DateTimeImmutable($cutoffYear . '-12-31 23:59:59');
+        // Notes de frais must be submitted within EXPENSE_REPORT_DEADLINE_DAYS of the event's end date
+        $expenseReportDeadline = $event->getEndDate()->modify('+' . self::EXPENSE_REPORT_DEADLINE_DAYS . ' days');
 
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;
@@ -423,8 +424,8 @@ class SortieController extends AbstractController
             'current_user_has_paid' => $currentUserHasPaid,
             'current_user_accepted' => $currentUserAccepted,
             'accepted_participations' => $participationRepository->getSortedParticipations($event),
-            'is_event_after_cutoff' => $event->getEndDate() >= $cutoffDate,
-            'cutoff_year' => $cutoffYear,
+            'is_within_expense_report_deadline' => new \DateTimeImmutable() <= $expenseReportDeadline,
+            'expense_report_deadline_days' => self::EXPENSE_REPORT_DEADLINE_DAYS,
             'has_viewable_expense_report' => $hasViewableExpenseReport,
             'groupes_competences' => $groupesCompRefs,
             'niveaux' => $nivRefs,

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -321,7 +321,9 @@ class SortieController extends AbstractController
                     $event->setNbKm($nbKm);
                 }
             }
-            $this->calculateCarbonCost($event, $carbonCostHelper);
+            // Bilan carbone basé sur ngensMax — recalculé uniquement à la création/modif
+            // de sortie, pas à chaque inscription (décision Jacob Carbonel).
+            $carbonCostHelper->updateForEvent($event);
             $entityManager->persist($event);
             $entityManager->flush();
 
@@ -531,7 +533,6 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         RoleHelper $roleHelper,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('sortie_update_inscriptions', $request->request->get('csrf_token_inscriptions'))) {
             $this->addFlash('error', 'Jeton de validation invalide.');
@@ -660,8 +661,6 @@ class SortieController extends AbstractController
         }
 
         if ($flush) {
-            // bilan carbone mis à jour selon nb de participants
-            $this->calculateCarbonCost($event, $carbonCostHelper);
             $em->flush();
         }
 
@@ -910,7 +909,6 @@ class SortieController extends AbstractController
         EventParticipation $participation,
         EntityManagerInterface $em,
         Mailer $mailer,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         $event = $participation->getEvt();
 
@@ -925,8 +923,6 @@ class SortieController extends AbstractController
         $event->removeParticipation($participation);
         // orphanRemoval: true on Evt::$participations handles the DELETE in DB
 
-        // bilan carbone mis à jour selon nb de participants
-        $this->calculateCarbonCost($event, $carbonCostHelper);
         $em->flush();
 
         /** @var User */
@@ -1001,6 +997,7 @@ class SortieController extends AbstractController
         $newEvent->setModeTransport($event->getModeTransport());
         $newEvent->setNbKm($event->getNbKm());
         $newEvent->setCoutCarbone($event->getCoutCarbone());
+        $newEvent->setCoutCarbonePerPerson($event->getCoutCarbonePerPerson());
 
         // dupliquer les participants ?
         if ('full' === $mode) {
@@ -1052,7 +1049,6 @@ class SortieController extends AbstractController
         EntityManagerInterface $em,
         Mailer $mailer,
         UserRepository $userRepository,
-        CarbonCostHelper $carbonCostHelper,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('join_event', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -1205,8 +1201,6 @@ class SortieController extends AbstractController
                     }
                 }
 
-                // bilan carbone mis à jour selon nb de participants
-                $this->calculateCarbonCost($event, $carbonCostHelper);
                 $em->flush();
 
                 // E-MAIL À L'ORGANISATEUR ET AUX ENCADRANTS
@@ -1387,14 +1381,9 @@ class SortieController extends AbstractController
         ];
     }
 
-    protected function calculateCarbonCost(Evt $event, CarbonCostHelper $helper): void
+    #[Route(path: '/sorties/methodologie-bilan-carbone', name: 'sortie_methodologie_bilan_carbone', methods: ['GET'])]
+    public function methodologieBilanCarbone(): Response
     {
-        $cost = $helper->calculate(
-            $event->getNbKm() ?: 0,
-            $event->getParticipationsCount(),
-            $event->getNbVehicules() ?: 1,
-            $event->getModeTransport(),
-        );
-        $event->setCoutCarbone($cost);
+        return $this->render('sortie/methodologie-bilan-carbone.html.twig');
     }
 }

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -56,8 +56,6 @@ use Twig\Error\SyntaxError;
 
 class SortieController extends AbstractController
 {
-    public const EXPENSE_REPORT_DEADLINE_DAYS = 120;
-
     public function __construct(
         protected SlugHelper $slugHelper,
         protected float $defaultLat,
@@ -418,9 +416,6 @@ class SortieController extends AbstractController
             }
         }
 
-        // Notes de frais must be submitted within EXPENSE_REPORT_DEADLINE_DAYS of the event's end date
-        $expenseReportDeadline = $event->getEndDate()->modify('+' . self::EXPENSE_REPORT_DEADLINE_DAYS . ' days');
-
         // Check if user has a viewable expense report (submitted, approved, or accounted)
         $hasViewableExpenseReport = false;
         if ($user) {
@@ -446,8 +441,8 @@ class SortieController extends AbstractController
             'current_user_has_paid' => $currentUserHasPaid,
             'current_user_accepted' => $currentUserAccepted,
             'accepted_participations' => $participationRepository->getSortedParticipations($event),
-            'is_within_expense_report_deadline' => new \DateTimeImmutable() <= $expenseReportDeadline,
-            'expense_report_deadline_days' => self::EXPENSE_REPORT_DEADLINE_DAYS,
+            'is_within_expense_report_deadline' => $event->isExpenseReportOpen(),
+            'expense_report_deadline_days' => Evt::EXPENSE_REPORT_DEADLINE_DAYS,
             'has_viewable_expense_report' => $hasViewableExpenseReport,
             'groupes_competences' => $groupesCompRefs,
             'niveaux' => $nivRefs,

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -25,6 +25,7 @@ use App\Repository\FormationValidationGroupeCompetenceRepository;
 use App\Repository\FormationValidationNiveauPratiqueRepository;
 use App\Repository\UserAttrRepository;
 use App\Repository\UserRepository;
+use App\Repository\UserRightRepository;
 use App\Service\HelloAssoService;
 use App\Twig\JavascriptGlobalsExtension;
 use App\Utils\Enums\ExpenseReportStatusEnum;
@@ -472,6 +473,7 @@ class SortieController extends AbstractController
         Mailer $mailer,
         MessageBusInterface $messageBus,
         LoggerInterface $logger,
+        UserRightRepository $userRightRepository,
     ): RedirectResponse {
         if (!$this->isCsrfTokenValid('sortie_validate', $request->request->get('csrf_token'))) {
             throw new BadRequestException('Jeton de validation invalide.');
@@ -482,6 +484,12 @@ class SortieController extends AbstractController
         }
 
         $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE)->setStatusWho($this->getUser());
+
+        if (!$userRightRepository->hasAnyRoleWithRight('evt_legal_accept')) {
+            $event->setStatusLegal(Evt::STATUS_LEGAL_VALIDE)
+                ->setStatusLegalWho(null)
+                ->setLegalStatusChangeDate(new \DateTimeImmutable());
+        }
 
         // créer la campagne hello asso si nécessaire
         if ($event->hasPaymentForm() && !$event->getHelloAssoFormSlug()) {

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -389,6 +389,7 @@ class UserController extends AbstractController
                     $this->addFlash('error', 'La licence de ' . $user->getFullName() . ' a expiré. L\'adhésion doit être renouvelée avant l\'inscription.');
                 }
             }
+
             $em->flush();
 
             // envoi des mails aux encadrants

--- a/src/Entity/Commune.php
+++ b/src/Entity/Commune.php
@@ -31,6 +31,15 @@ class Commune
     #[ORM\Column(name: 'ligne5', type: Types::STRING, nullable: true)]
     private string $ligne5;
 
+    #[ORM\Column(name: 'geopoint', type: Types::STRING, nullable: true)]
+    private ?string $geopoint = null;
+
+    #[ORM\Column(name: 'latitude', type: Types::DECIMAL, precision: 11, scale: 8, nullable: false)]
+    private string|float $latitude = 0;
+
+    #[ORM\Column(name: 'longitude', type: Types::DECIMAL, precision: 11, scale: 8, nullable: false)]
+    private string|float $longitude = 0;
+
     public function __toString(): string
     {
         return $this->getNomCommune();
@@ -97,6 +106,42 @@ class Commune
     public function setLigne5(string $ligne5): self
     {
         $this->ligne5 = $ligne5;
+
+        return $this;
+    }
+
+    public function getGeopoint(): ?string
+    {
+        return $this->geopoint;
+    }
+
+    public function setGeopoint(?string $geopoint): self
+    {
+        $this->geopoint = $geopoint;
+
+        return $this;
+    }
+
+    public function getLatitude(): string|float
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude(string|float $latitude): self
+    {
+        $this->latitude = $latitude;
+
+        return $this;
+    }
+
+    public function getLongitude(): string|float
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude(string|float $longitude): self
+    {
+        $this->longitude = $longitude;
 
         return $this;
     }

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -140,12 +140,22 @@ class Evt
     #[ORM\Column(name: 'lat_evt', type: 'decimal', precision: 11, scale: 8, nullable: false)]
     #[Groups('event:details')]
     #[SerializedName('latitude')]
-    private string|float|null $lat;
+    private string|float $lat;
 
     #[ORM\Column(name: 'long_evt', type: 'decimal', precision: 11, scale: 8, nullable: false)]
     #[Groups('event:details')]
     #[SerializedName('longitude')]
-    private string|float|null $long;
+    private string|float $long;
+
+    #[ORM\Column(name: 'lat_depart', type: 'decimal', precision: 11, scale: 8, nullable: false)]
+    #[Groups('event:details')]
+    #[SerializedName('latitudeDepart')]
+    private string|float $latDepart;
+
+    #[ORM\Column(name: 'long_depart', type: 'decimal', precision: 11, scale: 8, nullable: false)]
+    #[Groups('event:details')]
+    #[SerializedName('longitudeDepart')]
+    private string|float $longDepart;
 
     #[ORM\Column(name: 'matos_evt', type: 'text', nullable: true)]
     #[Groups('event:details')]
@@ -236,6 +246,26 @@ class Evt
     #[SerializedName('waitingSeat')]
     private ?int $waitingSeat = null;
 
+    #[ORM\Column(name: 'mode_transport', type: Types::STRING, length: 50, nullable: true, enumType: TransportModeEnum::class)]
+    #[Groups('event:read')]
+    #[SerializedName('modeTransport')]
+    private ?TransportModeEnum $modeTransport = null;
+
+    #[ORM\Column(name: 'nb_vehicules', type: Types::INTEGER, nullable: false, options: ['default' => 1])]
+    #[Groups('event:read')]
+    #[SerializedName('nbVehicules')]
+    private int $nbVehicules;
+
+    #[ORM\Column(name: 'nb_km', type: Types::FLOAT, nullable: true)]
+    #[Groups('event:read')]
+    #[SerializedName('nbKm')]
+    private ?float $nbKm = null;
+
+    #[ORM\Column(name: 'cout_carbone', type: Types::FLOAT, nullable: true)]
+    #[Groups('event:read')]
+    #[SerializedName('coutCarbone')]
+    private ?float $coutCarbone = null;
+
     public function __construct(
         ?User $user,
         ?Commission $commission,
@@ -258,6 +288,9 @@ class Evt
         $this->rdv = $rdv;
         $this->lat = $rdvLat;
         $this->long = $rdvLong;
+        $this->latDepart = 0.0;
+        $this->longDepart = 0.0;
+        $this->nbVehicules = 1;
         $this->description = $description;
         $this->joinMax = $maxInscriptions;
         $this->ngensMax = $maxParticipants;
@@ -685,24 +718,24 @@ class Evt
         return $this;
     }
 
-    public function getLat(): string|float|null
+    public function getLat(): string|float
     {
         return $this->lat;
     }
 
-    public function setLat(string|float|null $lat): self
+    public function setLat(string|float $lat): self
     {
         $this->lat = $lat;
 
         return $this;
     }
 
-    public function getLong(): string|float|null
+    public function getLong(): string|float
     {
         return $this->long;
     }
 
-    public function setLong(string|float|null $long): self
+    public function setLong(string|float $long): self
     {
         $this->long = $long;
 
@@ -913,6 +946,54 @@ class Evt
         return $this;
     }
 
+    public function getModeTransport(): ?TransportModeEnum
+    {
+        return $this->modeTransport;
+    }
+
+    public function setModeTransport(?TransportModeEnum $modeTransport): self
+    {
+        $this->modeTransport = $modeTransport;
+
+        return $this;
+    }
+
+    public function getNbVehicules(): int
+    {
+        return $this->nbVehicules;
+    }
+
+    public function setNbVehicules(int $nbVehicules): self
+    {
+        $this->nbVehicules = $nbVehicules;
+
+        return $this;
+    }
+
+    public function getNbKm(): ?float
+    {
+        return $this->nbKm;
+    }
+
+    public function setNbKm(?float $nbKm): self
+    {
+        $this->nbKm = $nbKm;
+
+        return $this;
+    }
+
+    public function getCoutCarbone(): ?float
+    {
+        return $this->coutCarbone;
+    }
+
+    public function setCoutCarbone(?float $coutCarbone): self
+    {
+        $this->coutCarbone = $coutCarbone;
+
+        return $this;
+    }
+
     public function hasPaymentForm(): bool
     {
         return $this->hasPaymentForm;
@@ -1010,6 +1091,30 @@ class Evt
     public function setWaitingSeat(?int $waitingSeat): self
     {
         $this->waitingSeat = $waitingSeat;
+
+        return $this;
+    }
+
+    public function getLatDepart(): float|string
+    {
+        return $this->latDepart;
+    }
+
+    public function setLatDepart(float|string $latDepart): self
+    {
+        $this->latDepart = $latDepart;
+
+        return $this;
+    }
+
+    public function getLongDepart(): float|string
+    {
+        return $this->longDepart;
+    }
+
+    public function setLongDepart(float|string $longDepart): self
+    {
+        $this->longDepart = $longDepart;
 
         return $this;
     }

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -610,6 +610,15 @@ class Evt
         return $this->endDate < new \DateTimeImmutable();
     }
 
+    public function isStarted(): bool
+    {
+        if (null === $this->startDate) {
+            return false;
+        }
+
+        return $this->startDate <= new \DateTimeImmutable();
+    }
+
     public function getPlace(): ?string
     {
         return $this->place;

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -46,6 +46,8 @@ class Evt
     public const int STATUS_LEGAL_VALIDE = 1;
     public const int STATUS_LEGAL_REFUSE = 2;
 
+    public const int EXPENSE_REPORT_DEADLINE_DAYS = 120;
+
     #[ORM\Column(name: 'id_evt', type: 'integer', nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
@@ -608,6 +610,15 @@ class Evt
         }
 
         return $this->endDate < new \DateTimeImmutable();
+    }
+
+    public function isExpenseReportOpen(): bool
+    {
+        if (null === $this->endDate) {
+            return false;
+        }
+
+        return new \DateTimeImmutable() <= $this->endDate->modify(sprintf('+%d days', self::EXPENSE_REPORT_DEADLINE_DAYS));
     }
 
     public function isStarted(): bool

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -395,7 +395,7 @@ class Evt
         return $this->statusLegalWho;
     }
 
-    public function setStatusLegalWho(User $statusLegalWho): self
+    public function setStatusLegalWho(?User $statusLegalWho): self
     {
         $this->statusLegalWho = $statusLegalWho;
 

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -268,6 +268,11 @@ class Evt
     #[SerializedName('coutCarbone')]
     private ?float $coutCarbone = null;
 
+    #[ORM\Column(name: 'cout_carbone_per_person', type: Types::FLOAT, nullable: true)]
+    #[Groups('event:read')]
+    #[SerializedName('coutCarbonePerPerson')]
+    private ?float $coutCarbonePerPerson = null;
+
     public function __construct(
         ?User $user,
         ?Commission $commission,
@@ -1010,6 +1015,18 @@ class Evt
     public function setCoutCarbone(?float $coutCarbone): self
     {
         $this->coutCarbone = $coutCarbone;
+
+        return $this;
+    }
+
+    public function getCoutCarbonePerPerson(): ?float
+    {
+        return $this->coutCarbonePerPerson;
+    }
+
+    public function setCoutCarbonePerPerson(?float $coutCarbonePerPerson): self
+    {
+        $this->coutCarbonePerPerson = $coutCarbonePerPerson;
 
         return $this;
     }

--- a/src/Entity/TransportModeEnum.php
+++ b/src/Entity/TransportModeEnum.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TransportModeEnum: string implements TranslatableInterface
+{
+    case PUBLIC_TRAIN = 'train';
+    case PUBLIC_COACH = 'car_ligne';
+    case DEDICATED_COACH = 'car_affrete';
+    case MINIVAN = 'minibus';
+    case THERMIC_CARPOOLING = 'covoiturage_thermique';
+    case ELECTRIC_CARPOOLING = 'covoiturage_electrique';
+    case BIKE_OR_WALK = 'velo_marche';
+    case PLANE = 'avion';
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return match ($this) {
+            self::PUBLIC_TRAIN => 'Transports en commun ferroviaire',
+            self::PUBLIC_COACH => 'Transports en commun routier',
+            self::DEDICATED_COACH => 'Car affrété',
+            self::MINIVAN => 'Minibus',
+            self::THERMIC_CARPOOLING => 'Covoiturage thermique',
+            self::ELECTRIC_CARPOOLING => 'Covoiturage électrique',
+            self::BIKE_OR_WALK => 'Vélo / pédestre',
+            self::PLANE => 'Avion',
+        };
+    }
+}

--- a/src/Entity/TransportModeEnum.php
+++ b/src/Entity/TransportModeEnum.php
@@ -16,7 +16,22 @@ enum TransportModeEnum: string implements TranslatableInterface
     case THERMIC_CARPOOLING = 'covoiturage_thermique';
     case ELECTRIC_CARPOOLING = 'covoiturage_electrique';
     case BIKE_OR_WALK = 'velo_marche';
+    // Conservé pour la rétro-compatibilité d'hydratation Doctrine (anciennes sorties
+    // pouvant encore avoir mode_transport='avion' avant que la migration tourne).
+    // N'est plus proposé dans le formulaire ni pris en compte par le calcul carbone.
     case PLANE = 'avion';
+
+    /**
+     * Valeurs des modes pour lesquels un nombre de véhicules est pertinent.
+     * Source unique de vérité consommée par le PHP (requiresVehicleCount, formulaire)
+     * et par le JS via data-attribute sur #nb-vehicules-wrapper.
+     */
+    public const VALUES_REQUIRING_VEHICLE_COUNT = [
+        'minibus',
+        'car_affrete',
+        'covoiturage_thermique',
+        'covoiturage_electrique',
+    ];
 
     public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
@@ -29,6 +44,19 @@ enum TransportModeEnum: string implements TranslatableInterface
             self::ELECTRIC_CARPOOLING => 'Covoiturage électrique',
             self::BIKE_OR_WALK => 'Vélo / pédestre',
             self::PLANE => 'Avion',
+        };
+    }
+
+    public function requiresVehicleCount(): bool
+    {
+        return \in_array($this->value, self::VALUES_REQUIRING_VEHICLE_COUNT, true);
+    }
+
+    public function isObsolete(): bool
+    {
+        return match ($this) {
+            self::PLANE => true,
+            default => false,
         };
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -613,6 +613,27 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
         // $this->plainPassword = null;
     }
 
+    public function __serialize(): array
+    {
+        return [
+            'id' => isset($this->id) ? $this->id : null,
+            'email' => $this->email,
+            'mdp' => $this->mdp,
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        // Support both new format (from __serialize) and legacy native PHP
+        // serialization format where private property keys are mangled as
+        // "\0ClassName\0propertyName" and bigint $id is stored as string.
+        $p = "\0" . self::class . "\0";
+        $id = $data['id'] ?? $data[$p . 'id'] ?? null;
+        $this->id = null !== $id ? (int) $id : null;
+        $this->email = $data['email'] ?? $data[$p . 'email'] ?? null;
+        $this->mdp = $data['mdp'] ?? $data[$p . 'mdp'] ?? null;
+    }
+
     /**
      * A visual identifier that represents this user.
      *

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\Commission;
 use App\Entity\Evt;
+use App\Entity\TransportModeEnum;
 use App\Entity\User;
 use App\Helper\EventFormHelper;
 use App\Repository\CommissionRepository;
@@ -14,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -28,6 +30,7 @@ use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Type;
 
 class EventType extends AbstractType
@@ -74,6 +77,11 @@ class EventType extends AbstractType
         $appointment = $event->getRdv();
         $lat = $event->getLat();
         $long = $event->getLong();
+
+        // bilan carbone
+        $latDepart = $event->getLatDepart();
+        $longDepart = $event->getLongDepart();
+        $nbVehicules = $event->getNbVehicules();
 
         $builder
             ->add('commission', EntityType::class, [
@@ -132,6 +140,40 @@ class EventType extends AbstractType
                     ]),
                 ],
             ])
+            ->add('modeTransport', EnumType::class, [
+                'label' => 'Mode de transport principal',
+                'required' => false,
+                'class' => TransportModeEnum::class,
+                'attr' => [
+                    'class' => 'type2 wide',
+                    'style' => 'width: 97%',
+                ],
+                'placeholder' => 'Choisissez un mode de transport principal',
+                'help' => 'Permet d\'aider au calcul du bilan carbone.',
+                'help_attr' => [
+                    'class' => 'mini',
+                ],
+            ])
+            ->add('nbVehicules', NumberType::class, [
+                'label' => 'Nombre de véhicules',
+                'required' => true,
+                'html5' => true,
+                'attr' => [
+                    'placeholder' => 'ex : 2',
+                    'class' => 'type2',
+                    'min' => 1,
+                ],
+                'data' => $nbVehicules,
+                'scale' => 0,
+                'constraints' => [
+                    new Type(['type' => 'numeric', 'message' => 'Veuillez saisir un nombre valide.']),
+                    new GreaterThanOrEqual(1),
+                ],
+                'help' => 'Permet d\'aider au calcul du bilan carbone.',
+                'help_attr' => [
+                    'class' => 'mini',
+                ],
+            ])
             ->add('rdv', TextType::class, [
                 'label' => 'Lieu de rendez-vous covoiturage',
                 'help' => 'Ville et adresse du lieu de RDV pour vous rendre à la sortie. Ce champ permet de placer le marqueur sur la carte.',
@@ -160,7 +202,6 @@ class EventType extends AbstractType
                 'constraints' => [
                     new NotBlank(null, 'La latitude est obligatoire. Avez-vous bien cliqué sur le bouton pour placer le marqueur ?'),
                     new Type(['type' => 'numeric', 'message' => 'La latitude doit être un nombre valide.']),
-                    new GreaterThan(0),
                 ],
             ])
             ->add('long', HiddenType::class, [
@@ -170,7 +211,6 @@ class EventType extends AbstractType
                 'constraints' => [
                     new NotBlank(null, 'La longitude est obligatoire. Avez-vous bien cliqué sur le bouton pour placer le marqueur ?'),
                     new Type(['type' => 'numeric', 'message' => 'La longitude doit être un nombre valide.']),
-                    new GreaterThan(0),
                 ],
             ])
             ->add('startDate', DateTimeType::class, [
@@ -356,6 +396,24 @@ class EventType extends AbstractType
                     'class' => 'mini',
                 ],
                 'help_html' => true,
+            ])
+            ->add('latDepart', HiddenType::class, [
+                'label' => false,
+                'required' => false,
+                'data' => $latDepart,
+                'constraints' => [
+                    new Type(['type' => 'numeric', 'message' => 'La latitude de départ doit être un nombre valide.']),
+                    new Range(min: -90, max: 90, notInRangeMessage: 'La latitude doit être comprise entre -90 et 90.'),
+                ],
+            ])
+            ->add('longDepart', HiddenType::class, [
+                'label' => false,
+                'required' => false,
+                'data' => $longDepart,
+                'constraints' => [
+                    new Type(['type' => 'numeric', 'message' => 'La longitude de départ doit être un nombre valide.']),
+                    new Range(min: -180, max: 180, notInRangeMessage: 'La longitude doit être comprise entre -180 et 180.'),
+                ],
             ])
         ;
         if ($displayHelloAssoFields && $isUserAuthorizeToUseHelloAsso) {

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -144,6 +144,7 @@ class EventType extends AbstractType
                 'label' => 'Mode de transport principal',
                 'required' => false,
                 'class' => TransportModeEnum::class,
+                'choice_filter' => static fn (?TransportModeEnum $mode): bool => null !== $mode && !$mode->isObsolete(),
                 'attr' => [
                     'class' => 'type2 wide',
                     'style' => 'width: 97%',
@@ -470,6 +471,24 @@ class EventType extends AbstractType
                     'class' => 'mediumlink btn-blue blanc',
                 ],
             ])
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+                // Modes sans champ "nombre de véhicules" (train, bus, vélo) :
+                // on force la valeur à 1 pour éviter une donnée polluée envoyée hors UI.
+                // Si le mode n'est pas renseigné, on ne touche pas — l'utilisateur n'a pas validé son choix.
+                $data = $event->getData();
+                if (!\is_array($data)) {
+                    return;
+                }
+                $rawMode = $data['modeTransport'] ?? null;
+                if (null === $rawMode || '' === $rawMode) {
+                    return;
+                }
+                $mode = TransportModeEnum::tryFrom((string) $rawMode);
+                if (null !== $mode && !$mode->requiresVehicleCount()) {
+                    $data['nbVehicules'] = 1;
+                    $event->setData($data);
+                }
+            })
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
                 $form = $event->getForm();
 

--- a/src/Helper/CarbonCost.php
+++ b/src/Helper/CarbonCost.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helper;
+
+final readonly class CarbonCost
+{
+    public function __construct(
+        public float $total,
+        public float $perPerson,
+    ) {
+    }
+}

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helper;
+
+use App\Entity\TransportModeEnum;
+
+class CarbonCostHelper
+{
+    protected array $rates = [];
+
+    public function __construct(
+        float $publicTrainRate,
+        float $publicCoachRate,
+        float $dedicatedCoachRate,
+        float $minivanRate,
+        float $bikeWalkRate,
+        float $thermicCarpoolingRate,
+        float $electricCarpoolingRate,
+        float $planeRate,
+    ) {
+        $this->rates = [
+            TransportModeEnum::PUBLIC_TRAIN->value => $publicTrainRate,
+            TransportModeEnum::PUBLIC_COACH->value => $publicCoachRate,
+            TransportModeEnum::DEDICATED_COACH->value => $dedicatedCoachRate,
+            TransportModeEnum::MINIVAN->value => $minivanRate,
+            TransportModeEnum::BIKE_OR_WALK->value => $bikeWalkRate,
+            TransportModeEnum::THERMIC_CARPOOLING->value => $thermicCarpoolingRate,
+            TransportModeEnum::ELECTRIC_CARPOOLING->value => $electricCarpoolingRate,
+            TransportModeEnum::PLANE->value => $planeRate,
+        ];
+    }
+
+    public function calculate(float $nbKm, int $nbPerson = 1, int $nbVehicules = 1, ?TransportModeEnum $transportMode = null): ?float
+    {
+        if (null === $transportMode) {
+            return null;
+        }
+
+        $rate = $this->rates[$transportMode->value] ?? 0;
+
+        $globalCost = $nbKm * $rate;
+        if ($this->isCoefByPerson($transportMode)) {
+            $cost = $globalCost * max(1, $nbPerson);
+        } else {
+            $cost = $globalCost * max(1, $nbVehicules);
+        }
+
+        return round($cost, 2);
+    }
+
+    protected function isCoefByPerson(TransportModeEnum $transportMode): bool
+    {
+        return match ($transportMode) {
+            TransportModeEnum::PUBLIC_TRAIN, TransportModeEnum::PUBLIC_COACH, TransportModeEnum::PLANE => true,
+            TransportModeEnum::DEDICATED_COACH, TransportModeEnum::THERMIC_CARPOOLING, TransportModeEnum::ELECTRIC_CARPOOLING, TransportModeEnum::BIKE_OR_WALK, TransportModeEnum::MINIVAN => false,
+        };
+    }
+}

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Helper;
 
+use App\Entity\Evt;
 use App\Entity\TransportModeEnum;
 
 class CarbonCostHelper
@@ -18,7 +19,6 @@ class CarbonCostHelper
         float $bikeWalkRate,
         float $thermicCarpoolingRate,
         float $electricCarpoolingRate,
-        float $planeRate,
     ) {
         $this->rates = [
             TransportModeEnum::PUBLIC_TRAIN->value => $publicTrainRate,
@@ -28,33 +28,50 @@ class CarbonCostHelper
             TransportModeEnum::BIKE_OR_WALK->value => $bikeWalkRate,
             TransportModeEnum::THERMIC_CARPOOLING->value => $thermicCarpoolingRate,
             TransportModeEnum::ELECTRIC_CARPOOLING->value => $electricCarpoolingRate,
-            TransportModeEnum::PLANE->value => $planeRate,
         ];
     }
 
-    public function calculate(float $nbKm, int $nbPerson = 1, int $nbVehicules = 1, ?TransportModeEnum $transportMode = null): ?float
+    public function calculate(float $nbKm, int $nbPerson = 1, int $nbVehicules = 1, ?TransportModeEnum $transportMode = null): ?CarbonCost
     {
-        if (null === $transportMode) {
+        if (null === $transportMode || $transportMode->isObsolete()) {
             return null;
         }
 
         $rate = $this->rates[$transportMode->value] ?? 0;
-
         $globalCost = $nbKm * $rate;
-        if ($this->isCoefByPerson($transportMode)) {
-            $cost = $globalCost * max(1, $nbPerson);
+
+        if ($transportMode->requiresVehicleCount()) {
+            $total = $globalCost * max(1, $nbVehicules);
         } else {
-            $cost = $globalCost * max(1, $nbVehicules);
+            $total = $globalCost * max(1, $nbPerson);
         }
 
-        return round($cost, 2);
+        $perPerson = $total / max(1, $nbPerson);
+
+        return new CarbonCost(
+            total: round($total, 2),
+            perPerson: round($perPerson, 2),
+        );
     }
 
-    protected function isCoefByPerson(TransportModeEnum $transportMode): bool
+    /**
+     * Recalcule et stocke le bilan carbone sur l'entité Evt selon son état courant
+     * (nbKm, ngensMax, nb de véhicules, mode transport).
+     *
+     * Le coût/personne est figé sur le nombre max d'inscrits prévus (ngensMax), pas
+     * sur les inscrits réels — sinon l'affichage à l'ouverture des inscriptions
+     * (1 seul encadrant) donne une valeur très élevée qui décroît à chaque
+     * inscription. Décision validée avec Jacob Carbonel (commission carbone).
+     */
+    public function updateForEvent(Evt $event): void
     {
-        return match ($transportMode) {
-            TransportModeEnum::PUBLIC_TRAIN, TransportModeEnum::PUBLIC_COACH, TransportModeEnum::PLANE => true,
-            TransportModeEnum::DEDICATED_COACH, TransportModeEnum::THERMIC_CARPOOLING, TransportModeEnum::ELECTRIC_CARPOOLING, TransportModeEnum::BIKE_OR_WALK, TransportModeEnum::MINIVAN => false,
-        };
+        $cost = $this->calculate(
+            $event->getNbKm() ?: 0,
+            max(1, $event->getNgensMax() ?: 1),
+            $event->getNbVehicules() ?: 1,
+            $event->getModeTransport(),
+        );
+        $event->setCoutCarbone($cost?->total);
+        $event->setCoutCarbonePerPerson($cost?->perPerson);
     }
 }

--- a/src/Helper/DistanceHelper.php
+++ b/src/Helper/DistanceHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helper;
+
+use App\Entity\Evt;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class DistanceHelper
+{
+    public function __construct(
+        protected readonly HttpClientInterface $httpClient,
+        protected readonly LoggerInterface $logger,
+        protected readonly string $osrmApiUrl = 'http://router.project-osrm.org/route/v1/driving/',
+        protected readonly int $timeout = 5,
+    ) {
+    }
+
+    /**
+     * Calculate round-trip distance in km between the RDV point and the departure point.
+     *
+     * @param Evt $event the event with RDV coordinates (lat/long) and departure coordinates (latDepart/longDepart)
+     *
+     * @return float round-trip distance in km, 0 on failure
+     */
+    public function calculate(Evt $event): float
+    {
+        // Coordonnées non renseignées (valeur par défaut 0,0) → pas d'appel OSRM
+        if (0.0 === (float) $event->getLatDepart() && 0.0 === (float) $event->getLongDepart()) {
+            return 0;
+        }
+        if (0.0 === (float) $event->getLat() && 0.0 === (float) $event->getLong()) {
+            return 0;
+        }
+
+        $distance = 0;
+        // OSRM expects "longitude,latitude" format
+        $rdvCoords = $event->getLong() . ',' . $event->getLat();
+        $departureCoords = $event->getLongDepart() . ',' . $event->getLatDepart();
+
+        $url = $this->osrmApiUrl . $rdvCoords . ';' . $departureCoords . '?overview=false';
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'timeout' => $this->timeout,
+            ]);
+            $data = $response->toArray();
+
+            if (isset($data['routes'][0]['distance'])) {
+                $distance = $data['routes'][0]['distance'] / 1000; // distance is in meters in the response
+            } else {
+                $this->logger->warning('OSRM returned no route', [
+                    'url' => $url,
+                    'response' => $data,
+                ]);
+            }
+        } catch (\Exception $exception) {
+            $this->logger->error('OSRM distance calculation failed: ' . $exception->getMessage());
+        }
+
+        return $distance * 2;
+    }
+}

--- a/src/Repository/UserRightRepository.php
+++ b/src/Repository/UserRightRepository.php
@@ -38,6 +38,21 @@ class UserRightRepository extends ServiceEntityRepository
         return $this->processRightsResults($results);
     }
 
+    public function hasAnyRoleWithRight(string $rightCode): bool
+    {
+        $sql = '
+            SELECT COUNT(*) AS cnt
+            FROM caf_userright ur
+            INNER JOIN caf_usertype_attr uta ON ur.id_userright = uta.right_usertype_attr
+            WHERE ur.code_userright = :rightCode
+        ';
+
+        $statement = $this->getEntityManager()->getConnection()->prepare($sql);
+        $statement->bindValue('rightCode', $rightCode);
+
+        return (int) $statement->executeQuery()->fetchOne() > 0;
+    }
+
     public function getRightsByUserType(string $userType): array
     {
         $sql = '

--- a/src/Service/HelloAssoService.php
+++ b/src/Service/HelloAssoService.php
@@ -69,6 +69,8 @@ class HelloAssoService
                 [
                     'label' => 'Frais d\'inscription',
                     'price' => (int) ($event->getPaymentAmount() * 100),        // prix en centimes
+                    // maxPayers volontairement absent : le formulaire HelloAsso est illimité,
+                    // la gestion des places est assurée par ngensMax côté plateforme.
                 ],
             ],
         ];

--- a/templates/macros/event-line.html.twig
+++ b/templates/macros/event-line.html.twig
@@ -150,7 +150,7 @@
                         {% if participation and display_notes_de_frais and include_name is same as ('profil-sorties-prev')
                             and event.finished and not event.cancelled and event.statusLegal
                             and (participation.role in constant('App\\Entity\\EventParticipation::ROLES_ENCADREMENT')) %}
-                            {% if exp_status and exp_status.value == constant('App\\Entity\\ExpenseReport::STATUS_DRAFT') %}
+                            {% if exp_status and exp_status.value == constant('App\\Entity\\ExpenseReport::STATUS_DRAFT') and event.expenseReportOpen %}
                                 <span class="text-din tw-inline-flex tw-items-center tw-text-right tw-gap-1 tw-text-xs tw-font-medium tw-text-orange-600 tw-whitespace-nowrap">
                                     🧾 ✍
                                     NdF brouillon
@@ -175,7 +175,7 @@
                                     🧾 ❌
                                     NdF refusée
                                 </span>
-                            {% else %}
+                            {% elseif not exp_status and event.expenseReportOpen %}
                                 <span class="text-din tw-inline-flex tw-items-center tw-text-right tw-gap-1 tw-text-xs tw-font-medium tw-text-gray-600 tw-whitespace-nowrap">
                                     🧾❓
                                     NdF possible

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -78,8 +78,12 @@
             </div>
             <br style="clear:both" />
 
-            {{ form_row(form.place) }}
+            <div data-start-lat-field="{{ form.latDepart.vars.id }}" data-start-long-field="{{ form.longDepart.vars.id }}">
+                {{ form_row(form.place) }}
+            </div>
             <ul id="place_suggestions"></ul>
+            {{ form_row(form.latDepart) }}
+            {{ form_row(form.longDepart) }}
         </div>
 
         <h2 class="trigger-h2">Tarif :</h2>
@@ -150,6 +154,19 @@
                 {{ form_widget(form.waitingSeat) }}<br />
                 {{ form_help(form.waitingSeat) }}
             </div><br />
+        </div>
+
+        <h2 class="trigger-h2">Mode de transport :</h2>
+        <div class="trigger-me">
+            {{ form_row(form.modeTransport) }}<br>
+
+            <div>
+                {{ form_label(form.nbVehicules) }}
+                {{ form_errors(form.nbVehicules) }}
+                {{ form_widget(form.nbVehicules) }}
+                <br>
+                {{ form_help(form.nbVehicules) }}
+            </div>
         </div>
 
         <h2 class="trigger-h2">Difficulté / matériel :</h2>

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -14,6 +14,10 @@
             attr: {class: 'padded-form', 'id': 'event_form'}
         }) }}
 
+        {% if source_event_id is defined and source_event_id %}
+            <input type="hidden" name="source_event_id" value="{{ source_event_id }}">
+        {% endif %}
+
         <p class="italic">
             Les champs marqués d'un <span class="required">*</span> sont obligatoires.
             <br>Les champs marqués d'un <span class="revalidation">*</span> demanderont une réapprobation de la sortie par un responsable de commission si vous les modifiez.

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -164,7 +164,7 @@
         <div class="trigger-me">
             {{ form_row(form.modeTransport) }}<br>
 
-            <div>
+            <div id="nb-vehicules-wrapper" data-modes-with-vehicles="{{ constant('App\\Entity\\TransportModeEnum::VALUES_REQUIRING_VEHICLE_COUNT')|join(',') }}">
                 {{ form_label(form.nbVehicules) }}
                 {{ form_errors(form.nbVehicules) }}
                 {{ form_widget(form.nbVehicules) }}
@@ -269,6 +269,7 @@
     {{ vite_entry_script_tags('participants') }}
     {{ vite_entry_script_tags('commission_switch') }}
     {{ vite_entry_script_tags('autocomplete_communes') }}
+    {{ vite_entry_script_tags('transport_mode_vehicles') }}
     <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"
             integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=="
             crossorigin=""></script>

--- a/templates/sortie/methodologie-bilan-carbone.html.twig
+++ b/templates/sortie/methodologie-bilan-carbone.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Méthodologie du bilan carbone{% endblock %}
+
+{% block body %}
+    <h1>Méthodologie du bilan carbone des sorties</h1>
+    <p><em>Cette page sera complétée prochainement avec le détail de la méthode de calcul, les sources des facteurs d'émission et les limites du modèle.</em></p>
+{% endblock %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -375,12 +375,12 @@
                         {% if has_viewable_expense_report %}
                             {# User already has a submitted/approved/accounted expense report, always show it #}
                             {% include 'vuejs/expense-report-form.twig' %}
-                        {% elseif not is_event_after_cutoff %}
+                        {% elseif not is_within_expense_report_deadline %}
                             <div class="alerte info-container" style="margin-bottom:2rem !important">
                                 <img src="/img/base/cross.png" alt="" title=""/>
                                 <div class="text-container">
                                     <b>Note de frais non disponible :</b><br />
-                                    Il n'est plus possible de déposer une note de frais pour cette sortie car les comptes du Club pour l'année {{ cutoff_year }} ont été clôturés.<br />
+                                    Il n'est plus possible de déposer une note de frais pour cette sortie car le délai de {{ expense_report_deadline_days }} jours après la fin de la sortie est dépassé.<br />
                                     En cas de question, contactez la comptabilité.<br />&nbsp;
                                 </div>
                             </div>

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1018,6 +1018,27 @@
                 <hr />
             {% endif %}
 
+            {% set nInscritsValides = event.participationsCount %}
+            {% if event.modeTransport and event.coutCarbone is not null and nInscritsValides > 0 %}
+                {% set coutParPersonne = event.coutCarbone / nInscritsValides %}
+                {% set kgCO2 = coutParPersonne / 1000 %}
+                <div style="background: #f0f7f0; border-left: 4px solid #4a9c5b; border-radius: 4px; padding: 12px 16px; margin: 12px 0;">
+                    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
+                        <span style="font-size: 1.3em;">🌿</span>
+                        <b style="color: #2d6a3f;">Empreinte carbone transport</b>
+                    </div>
+                    <div style="color: #444; font-size: 0.95em;">
+                        {{ event.modeTransport|trans }}
+                        {% if event.nbKm %} · {{ event.nbKm|number_format(0, ',', ' ') }} km A/R{% endif %}
+                        {% if event.nbVehicules > 1 %} · {{ event.nbVehicules }} véhicules{% endif %}
+                        {% if nInscritsValides > 1 %} · {{ nInscritsValides }} participants{% endif %}
+                    </div>
+                    <div style="font-size: 1.4em; font-weight: bold; color: #2d6a3f; margin-top: 6px;">
+                        {{ kgCO2|number_format(1, ',', ' ') }} kg CO₂e <span style="font-size: 0.6em; font-weight: normal; color: #666;">/ personne</span>
+                    </div>
+                </div>
+            {% endif %}
+
             <ul class="nice-list">
                 <li class="wide">
                     <b>DÉPART :</b> Le {{ event.startDate | intldate('cccc d MMMM') }} {% if allowed('user_read_limited') %}{{ event.startDate|date('H:i') }}{% endif %}

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1018,9 +1018,10 @@
                 <hr />
             {% endif %}
 
-            {% set nInscritsValides = event.participationsCount %}
-            {% if event.modeTransport and event.coutCarbone is not null and nInscritsValides > 0 %}
-                {% set coutParPersonne = event.coutCarbone / nInscritsValides %}
+            {# Bilan carbone : indépendant des inscriptions réelles, basé sur ngensMax (cf. décision Jacob).
+               Fallback `coutCarbone / ngensMax` pour les sorties créées avant la migration des champs perPerson. #}
+            {% set coutParPersonne = event.coutCarbonePerPerson ?? (event.coutCarbone and event.ngensMax > 0 ? event.coutCarbone / event.ngensMax : null) %}
+            {% if event.modeTransport and coutParPersonne is not null %}
                 {% set kgCO2 = coutParPersonne / 1000 %}
                 <div style="background: #f0f7f0; border-left: 4px solid #4a9c5b; border-radius: 4px; padding: 12px 16px; margin: 12px 0;">
                     <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
@@ -1031,10 +1032,15 @@
                         {{ event.modeTransport|trans }}
                         {% if event.nbKm %} · {{ event.nbKm|number_format(0, ',', ' ') }} km A/R{% endif %}
                         {% if event.nbVehicules > 1 %} · {{ event.nbVehicules }} véhicules{% endif %}
-                        {% if nInscritsValides > 1 %} · {{ nInscritsValides }} participants{% endif %}
+                        {% if event.ngensMax > 1 %} · {{ event.ngensMax }} places{% endif %}
                     </div>
                     <div style="font-size: 1.4em; font-weight: bold; color: #2d6a3f; margin-top: 6px;">
                         {{ kgCO2|number_format(1, ',', ' ') }} kg CO₂e <span style="font-size: 0.6em; font-weight: normal; color: #666;">/ personne</span>
+                    </div>
+                    <div style="margin-top: 4px;">
+                        <a href="{{ path('sortie_methodologie_bilan_carbone') }}" style="font-size: 0.85em; color: #2d6a3f;">
+                            ℹ️ Plus d'infos et méthodologie
+                        </a>
                     </div>
                 </div>
             {% endif %}

--- a/tests/Controller/AgendaControllerTest.php
+++ b/tests/Controller/AgendaControllerTest.php
@@ -55,4 +55,11 @@ class AgendaControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
     }
+
+    public function testAgendaWithInvalidYearDoesNotCrash(): void
+    {
+        $this->client->request('GET', '/agenda.html?year=20250&month=9');
+
+        $this->assertResponseIsSuccessful();
+    }
 }

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -564,9 +564,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a submitted expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormVisibleForSubmittedReportPastCutoff()
+    public function testExpenseReportFormVisibleForSubmittedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -584,9 +584,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an approved expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormVisibleForApprovedReportPastCutoff()
+    public function testExpenseReportFormVisibleForApprovedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -604,9 +604,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with an accounted expense report can see the form
-     * even if the event is past the cutoff date.
+     * even if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormVisibleForAccountedReportPastCutoff()
+    public function testExpenseReportFormVisibleForAccountedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -624,9 +624,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a draft expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormNotVisibleForDraftReportPastCutoff()
+    public function testExpenseReportFormNotVisibleForDraftReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -644,9 +644,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user with a rejected expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormNotVisibleForRejectedReportPastCutoff()
+    public function testExpenseReportFormNotVisibleForRejectedReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -664,9 +664,9 @@ class SortieControllerTest extends WebTestCase
 
     /**
      * Test that a user without any expense report cannot see the form
-     * if the event is past the cutoff date.
+     * if the event is past the 120-day deadline.
      */
-    public function testExpenseReportFormNotVisibleWithoutReportPastCutoff()
+    public function testExpenseReportFormNotVisibleWithoutReportPastDeadline()
     {
         $user = $this->signup();
         $this->signin($user);
@@ -683,14 +683,14 @@ class SortieControllerTest extends WebTestCase
     }
 
     /**
-     * Helper method to create a past event (before cutoff date).
+     * Helper method to create a past event (ended more than 120 days ago).
      */
     protected function createPastEvent($user): Evt
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         $commission = $this->createCommission();
 
-        // Create an event that ended 2 years ago (definitely past any cutoff)
+        // Create an event that ended 2 years ago (definitely past the 120-day deadline)
         $event = new Evt(
             $user,
             $commission,

--- a/tests/Controller/SortieControllerTest.php
+++ b/tests/Controller/SortieControllerTest.php
@@ -5,7 +5,9 @@ namespace App\Tests\Controller;
 use App\Entity\EventParticipation;
 use App\Entity\Evt;
 use App\Entity\ExpenseReport;
+use App\Entity\TransportModeEnum;
 use App\Entity\UserAttr;
+use App\Helper\CarbonCostHelper;
 use App\Messenger\Message\SortiePubliee;
 use App\Tests\WebTestCase;
 use App\Utils\Enums\ExpenseReportStatusEnum;
@@ -715,6 +717,135 @@ class SortieControllerTest extends WebTestCase
         $em->flush();
 
         return $event;
+    }
+
+    public function testMethodologieBilanCarboneIsPubliclyAccessible(): void
+    {
+        $this->client->request('GET', '/sorties/methodologie-bilan-carbone');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSelectorTextContains('h1', 'Méthodologie du bilan carbone');
+    }
+
+    /**
+     * Le bilan carbone est figé sur le nombre max de places prévues (ngensMax), pas
+     * sur les inscrits réels. Ajouter un participant ne doit donc rien recalculer.
+     * Décision Jacob Carbonel : éviter les valeurs très élevées à l'ouverture des
+     * inscriptions et la fluctuation à chaque join.
+     */
+    public function testManualAddDoesNotChangeCarbonCost(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
+        $event->setStatusWho($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        // ngensMax=12 (cf. WebTestCase::createEvent), 100 km × 219 g/km × 1 véhicule = 21900 ;
+        // perPerson = 21900 / 12 = 1825.
+        $this->assertSame(21900.0, $event->getCoutCarbone());
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
+
+        // Ajout manuel d'un second participant via /ajouter-manuel
+        $other = $this->signup();
+        $this->client->request('POST', sprintf('/ajouter-manuel/%d', $event->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'event_manual_add'),
+            'id_user' => [$other->getId()],
+            'role_evt_join' => [EventParticipation::ROLE_MANUEL],
+            'civ_user' => [''],
+            'lastname_user' => [$other->getLastname()],
+            'firstname_user' => [$other->getFirstname()],
+        ]);
+
+        $em->refresh($event);
+
+        $this->assertSame(21900.0, $event->getCoutCarbone(), 'total inchangé par une inscription');
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par une inscription');
+    }
+
+    /**
+     * Symétrique : le retrait d'un participant ne doit pas modifier le bilan
+     * (figé sur ngensMax).
+     */
+    public function testRemoveParticipantDoesNotChangeCarbonCost(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+
+        $other = $this->signup();
+        $event->addParticipation($other, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        // 21900 / 12 = 1825 (toujours basé sur ngensMax, pas sur les 2 inscrits)
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
+
+        $otherParticipation = $event->getParticipation($other);
+
+        // Le voter PARTICIPANT_ANNULATION n'autorise que le titulaire à retirer
+        // sa propre participation (auto-désinscription).
+        $this->signin($other);
+
+        $this->client->request('POST', sprintf('/sortie/remove-participant/%d', $otherParticipation->getId()), [
+            'csrf_token' => $this->generateCsrfToken($this->client, 'remove_participant'),
+        ]);
+
+        $em->refresh($event);
+
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par un retrait');
+    }
+
+    /**
+     * Symétrique : valider une inscription en attente ne doit rien recalculer.
+     */
+    public function testUpdateInscriptionsDoesNotChangeCarbonCost(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $helper = $this->getContainer()->get(CarbonCostHelper::class);
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->addAttribute($organizer, UserAttr::ENCADRANT, 'commission:*');
+
+        $event = $this->createEvent($organizer);
+        $event->setModeTransport(TransportModeEnum::THERMIC_CARPOOLING);
+        $event->setNbVehicules(1);
+        $event->setNbKm(100.0);
+
+        $pending = $this->signup();
+        $pendingParticipation = $event->addParticipation($pending, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_NON_CONFIRME);
+        $helper->updateForEvent($event);
+        $em->flush();
+
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson());
+
+        $this->client->request('POST', sprintf('/sortie/%d/update-inscriptions', $event->getId()), [
+            'csrf_token_inscriptions' => $this->generateCsrfToken($this->client, 'sortie_update_inscriptions'),
+            'id_evt_join' => [(string) $pendingParticipation->getId()],
+            'status_evt_join_' . $pendingParticipation->getId() => (string) EventParticipation::STATUS_VALIDE,
+        ]);
+
+        $em->refresh($event);
+
+        $this->assertSame(1825.0, $event->getCoutCarbonePerPerson(), 'perPerson inchangé par la validation');
     }
 
     /**

--- a/tests/Entity/UserSerializationTest.php
+++ b/tests/Entity/UserSerializationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class UserSerializationTest extends TestCase
+{
+    public function testSerializeAndUnserialize(): void
+    {
+        $user = new User(42);
+        $user->setEmail('test@example.com');
+        $user->setMdp('hashed_password');
+
+        $serialized = serialize($user);
+        $restored = unserialize($serialized);
+
+        $this->assertSame(42, $restored->getId());
+        $this->assertSame('test@example.com', $restored->getEmail());
+        $this->assertSame('hashed_password', $restored->getMdp());
+    }
+
+    public function testUnserializeLegacyFormat(): void
+    {
+        // Simulate native PHP serialization format where $id is a string
+        // (bigint returned by Doctrine) and keys are mangled with class name.
+        $prefix = "\0" . User::class . "\0";
+        $legacyData = [
+            $prefix . 'id' => '12345',
+            $prefix . 'email' => 'legacy@example.com',
+            $prefix . 'mdp' => 'old_hash',
+        ];
+
+        $user = (new \ReflectionClass(User::class))->newInstanceWithoutConstructor();
+        $user->__unserialize($legacyData);
+
+        $this->assertSame(12345, $user->getId());
+        $this->assertSame('legacy@example.com', $user->getEmail());
+        $this->assertSame('old_hash', $user->getMdp());
+    }
+
+    public function testUnserializeWithNullId(): void
+    {
+        $user = new User();
+        $user->setEmail('noid@example.com');
+        $user->setMdp('pwd');
+
+        $serialized = serialize($user);
+        $restored = unserialize($serialized);
+
+        $this->assertNull($restored->getId());
+        $this->assertSame('noid@example.com', $restored->getEmail());
+    }
+}

--- a/tests/Helper/CarbonCostHelperTest.php
+++ b/tests/Helper/CarbonCostHelperTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Helper;
+
+use App\Entity\TransportModeEnum;
+use App\Helper\CarbonCostHelper;
+use PHPUnit\Framework\TestCase;
+
+class CarbonCostHelperTest extends TestCase
+{
+    private CarbonCostHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new CarbonCostHelper(
+            publicTrainRate: 10,
+            publicCoachRate: 122,
+            dedicatedCoachRate: 870,
+            minivanRate: 327,
+            bikeWalkRate: 0,
+            thermicCarpoolingRate: 219,
+            electricCarpoolingRate: 102,
+            planeRate: 10000,
+        );
+    }
+
+    public function testCalculateTrainMultipliesByPersonCount(): void
+    {
+        // Train: 100 km * 10 gCO2e/km * 5 persons = 5000
+        $result = $this->helper->calculate(100, 5, 2, TransportModeEnum::PUBLIC_TRAIN);
+        $this->assertEquals(5000.0, $result);
+    }
+
+    public function testCalculateCarpoolingMultipliesByVehicleCount(): void
+    {
+        // Thermic carpooling: 100 km * 219 gCO2e/km * 3 vehicles = 65700
+        $result = $this->helper->calculate(100, 5, 3, TransportModeEnum::THERMIC_CARPOOLING);
+        $this->assertEquals(65700.0, $result);
+    }
+
+    public function testCalculateBikeReturnsZero(): void
+    {
+        $result = $this->helper->calculate(100, 5, 1, TransportModeEnum::BIKE_OR_WALK);
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function testCalculateNullTransportModeReturnsNull(): void
+    {
+        $result = $this->helper->calculate(100, 5, 1, null);
+        $this->assertNull($result);
+    }
+
+    public function testCalculateZeroKmReturnsZero(): void
+    {
+        $result = $this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN);
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function testCalculateEnforcesMinimumOneForCounts(): void
+    {
+        // With 0 persons, max(1, 0) = 1 → 100 * 10 * 1 = 1000
+        $result = $this->helper->calculate(100, 0, 0, TransportModeEnum::PUBLIC_TRAIN);
+        $this->assertEquals(1000.0, $result);
+
+        // With 0 vehicles on carpooling, max(1, 0) = 1 → 100 * 219 * 1 = 21900
+        $result = $this->helper->calculate(100, 5, 0, TransportModeEnum::THERMIC_CARPOOLING);
+        $this->assertEquals(21900.0, $result);
+    }
+}

--- a/tests/Helper/CarbonCostHelperTest.php
+++ b/tests/Helper/CarbonCostHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Helper;
 
 use App\Entity\TransportModeEnum;
+use App\Helper\CarbonCost;
 use App\Helper\CarbonCostHelper;
 use PHPUnit\Framework\TestCase;
 
@@ -22,28 +23,47 @@ class CarbonCostHelperTest extends TestCase
             bikeWalkRate: 0,
             thermicCarpoolingRate: 219,
             electricCarpoolingRate: 102,
-            planeRate: 10000,
         );
     }
 
     public function testCalculateTrainMultipliesByPersonCount(): void
     {
-        // Train: 100 km * 10 gCO2e/km * 5 persons = 5000
+        // Train: 100 km * 10 gCO2e/km * 5 persons = 5000 total, perPerson = 1000
         $result = $this->helper->calculate(100, 5, 2, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(5000.0, $result);
+        $this->assertInstanceOf(CarbonCost::class, $result);
+        $this->assertEquals(5000.0, $result->total);
+        $this->assertEquals(1000.0, $result->perPerson);
     }
 
     public function testCalculateCarpoolingMultipliesByVehicleCount(): void
     {
-        // Thermic carpooling: 100 km * 219 gCO2e/km * 3 vehicles = 65700
+        // Thermic carpooling: 100 km * 219 gCO2e/km * 3 vehicles = 65700 total ; perPerson = 65700/5 = 13140
         $result = $this->helper->calculate(100, 5, 3, TransportModeEnum::THERMIC_CARPOOLING);
-        $this->assertEquals(65700.0, $result);
+        $this->assertEquals(65700.0, $result->total);
+        $this->assertEquals(13140.0, $result->perPerson);
+    }
+
+    public function testCalculateMinivanReturnsPerPerson(): void
+    {
+        // Minibus: 100 km * 327 gCO2e/km * 1 vehicle = 32700 total ; perPerson = 32700/9 ≈ 3633.33
+        $result = $this->helper->calculate(100, 9, 1, TransportModeEnum::MINIVAN);
+        $this->assertEquals(32700.0, $result->total);
+        $this->assertEquals(3633.33, $result->perPerson);
+    }
+
+    public function testCalculateDedicatedCoachReturnsPerPerson(): void
+    {
+        // Car affrété: 100 km * 870 gCO2e/km * 1 vehicle = 87000 total ; perPerson = 87000/50 = 1740
+        $result = $this->helper->calculate(100, 50, 1, TransportModeEnum::DEDICATED_COACH);
+        $this->assertEquals(87000.0, $result->total);
+        $this->assertEquals(1740.0, $result->perPerson);
     }
 
     public function testCalculateBikeReturnsZero(): void
     {
         $result = $this->helper->calculate(100, 5, 1, TransportModeEnum::BIKE_OR_WALK);
-        $this->assertEquals(0.0, $result);
+        $this->assertEquals(0.0, $result->total);
+        $this->assertEquals(0.0, $result->perPerson);
     }
 
     public function testCalculateNullTransportModeReturnsNull(): void
@@ -52,20 +72,31 @@ class CarbonCostHelperTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testCalculateObsoletePlaneModeReturnsNull(): void
+    {
+        // PLANE est conservé dans l'enum pour rétro-compat d'hydratation Doctrine
+        // (sorties pré-migration), mais doit être inerte côté calcul carbone.
+        $result = $this->helper->calculate(100, 5, 1, TransportModeEnum::PLANE);
+        $this->assertNull($result);
+    }
+
     public function testCalculateZeroKmReturnsZero(): void
     {
         $result = $this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(0.0, $result);
+        $this->assertEquals(0.0, $result->total);
+        $this->assertEquals(0.0, $result->perPerson);
     }
 
     public function testCalculateEnforcesMinimumOneForCounts(): void
     {
-        // With 0 persons, max(1, 0) = 1 → 100 * 10 * 1 = 1000
+        // With 0 persons, max(1, 0) = 1 → 100 * 10 * 1 = 1000 ; perPerson = 1000/1 = 1000
         $result = $this->helper->calculate(100, 0, 0, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(1000.0, $result);
+        $this->assertEquals(1000.0, $result->total);
+        $this->assertEquals(1000.0, $result->perPerson);
 
-        // With 0 vehicles on carpooling, max(1, 0) = 1 → 100 * 219 * 1 = 21900
+        // With 0 vehicles on carpooling, max(1, 0) = 1 → 100 * 219 * 1 = 21900 ; perPerson = 21900/5 = 4380
         $result = $this->helper->calculate(100, 5, 0, TransportModeEnum::THERMIC_CARPOOLING);
-        $this->assertEquals(21900.0, $result);
+        $this->assertEquals(21900.0, $result->total);
+        $this->assertEquals(4380.0, $result->perPerson);
     }
 }

--- a/tests/Helper/DistanceHelperTest.php
+++ b/tests/Helper/DistanceHelperTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Helper;
+
+use App\Entity\Evt;
+use App\Helper\DistanceHelper;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class DistanceHelperTest extends TestCase
+{
+    private function createEvent(float $lat = 45.76, float $long = 4.83, float $latDepart = 45.19, float $longDepart = 5.72): Evt
+    {
+        $event = $this->createMock(Evt::class);
+        $event->method('getLat')->willReturn($lat);
+        $event->method('getLong')->willReturn($long);
+        $event->method('getLatDepart')->willReturn($latDepart);
+        $event->method('getLongDepart')->willReturn($longDepart);
+
+        return $event;
+    }
+
+    public function testCalculateReturnsRoundTripDistanceInKm(): void
+    {
+        $responseBody = json_encode([
+            'routes' => [
+                ['distance' => 50000], // 50 km one-way
+            ],
+        ]);
+        $mockClient = new MockHttpClient([new MockResponse($responseBody)]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent());
+
+        // 50000m / 1000 = 50km * 2 (round-trip) = 100km
+        $this->assertEquals(100.0, $result);
+    }
+
+    public function testCalculateReturnsZeroOnEmptyRoutes(): void
+    {
+        $responseBody = json_encode(['routes' => []]);
+        $mockClient = new MockHttpClient([new MockResponse($responseBody)]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent());
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function testCalculateReturnsZeroOnHttpException(): void
+    {
+        $mockClient = new MockHttpClient([new MockResponse('', ['http_code' => 500])]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent());
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function testCalculateLogsErrorOnFailure(): void
+    {
+        $mockClient = new MockHttpClient([new MockResponse('', ['http_code' => 500])]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error')
+            ->with($this->stringContains('OSRM distance calculation failed'));
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $helper->calculate($this->createEvent());
+    }
+
+    public function testCalculateReturnsZeroOnZeroDepartureCoords(): void
+    {
+        // Coordonnées de départ à 0,0 (valeur par défaut) → pas d'appel OSRM
+        $mockClient = new MockHttpClient([]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+        $logger->expects($this->never())->method('warning');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent(latDepart: 0.0, longDepart: 0.0));
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function testCalculateReturnsZeroOnZeroRdvCoords(): void
+    {
+        // Coordonnées RDV à 0,0 → pas d'appel OSRM
+        $mockClient = new MockHttpClient([]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent(lat: 0.0, long: 0.0));
+
+        $this->assertEquals(0.0, $result);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
         participants: './assets/participants.js',
         commission_switch: './assets/commission-switch.js',
         autocomplete_communes: './assets/autocomplete-communes.js',
+        transport_mode_vehicles: './assets/transport-mode-vehicles.js',
       },
     },
   },


### PR DESCRIPTION
## Contenu de la MEP

Merge de `main` dans `production` avec résolution des conflits.

### Résolution des conflits

4 hotfix avaient été appliqués directement sur `production` (délai NdF 90→120j + refactor en constante locale au controller) :
- `0c692ed6` feat: bloquer les NdF après 90 jours
- `82e0ba08` feat: passer le délai à 120 jours
- `34b66d88` fix: corriger le commentaire createPastEvent
- `48ac45fe` refactor: extraire le délai en constante

Ces commits sont **superseded par #1723** sur `main`, qui réimplémente la même feature plus proprement :
- Constante `EXPENSE_REPORT_DEADLINE_DAYS = 120` déplacée dans `Evt`
- Logique encapsulée dans `Evt::isExpenseReportOpen()`
- Tests identiques (à 2 lignes près)

→ Résolution : version `main` acceptée pour `SortieController.php`, `sortie.html.twig`, `SortieControllerTest.php`.

### Feature majeure
- **#1283** feat: bilan carbone
- **#1736** fix: corrections bilan carbone suite retours bénévoles

### Features
- **#1730** feat: formulaire HelloAsso sans limite de places (maxPayers absent)
- **#1710** feat: responsables de commission en tant que OWNER du groupe Google
- **#1723** feat: bloquer les notes de frais après 120 jours (remplace les hotfix prod)

### Fixes
- **#1727** fix: valider automatiquement le statut légal si aucun rôle n'a evt_legal_accept
- **#1733** fix: masquer NdF possible et brouillon après expiration du délai
- **#1712** fix: initialiser toutes les clés de newEncadrants
- **#1711** fix: copier tous les participants lors de la duplication d'une sortie avec le groupe
- **#1726** fix: permettre le marquage "absent" dès le début de la sortie
- **#1729** fix: retirer l'import inutilisé UserLicenseHelper
- **#1703** fix: validate year upper bound in agenda
- **#1705** fix: add User serialization methods to prevent TypeError on session restore

## Test plan
- [ ] Vérifier sur staging que le bilan carbone s'affiche correctement
- [ ] Vérifier les ajouts/retraits de participants sur une sortie (impact bilan carbone)
- [ ] Vérifier la création d'une note de frais (limite 120 jours)
- [ ] Vérifier l'inscription via HelloAsso (sans maxPayers)
- [ ] Vérifier la duplication d'une sortie avec groupe

## Merge

Merge classique (pas fast-forward) — la branche contient le commit de merge avec résolution des conflits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)