### PR TITLE
fix: ne pas afficher « 0,0 kg CO₂e » quand nbKm n'a pas pu être calculé

### DIFF
--- a/.env
+++ b/.env
@@ -218,8 +218,8 @@ INFERIOR_RIGHTS_CLEAN=true
 
 ###> OSRM (calcul de distance) ###
 OSRM_API_URL='http://router.project-osrm.org/route/v1/driving/'
-# Timeout en secondes pour les appels OSRM
-OSRM_TIMEOUT=5
+# Timeout en secondes par tentative OSRM (le helper retente 2 fois en cas d'erreur transport/5xx)
+OSRM_TIMEOUT=2
 ###< OSRM (calcul de distance) ###
 
 ###> coefficients bilan carbone ###

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -307,14 +307,15 @@ class SortieController extends AbstractController
             }
             $event->setJoinMax($event->getNgensMax());
 
-            // bilan carbone : ne recalculer la distance que si les coordonnées ont changé
+            // bilan carbone : recalculer la distance si les coordonnées ont changé,
+            // ou si nbKm est vide (échec OSRM antérieur ou sortie d'avant la feature).
             $coordsChanged = !$isUpdate
                 || (float) $event->getLat() !== $originalEntityData['lat']
                 || (float) $event->getLong() !== $originalEntityData['long']
                 || (float) $event->getLatDepart() !== $originalEntityData['latDepart']
                 || (float) $event->getLongDepart() !== $originalEntityData['longDepart'];
 
-            if ($coordsChanged) {
+            if ($coordsChanged || !$event->getNbKm()) {
                 $nbKm = $distanceHelper->calculate($event);
                 // Conserver l'ancienne distance si l'appel OSRM échoue (retourne 0)
                 if ($nbKm > 0 || !$isUpdate) {

--- a/src/Helper/CarbonCostHelper.php
+++ b/src/Helper/CarbonCostHelper.php
@@ -37,6 +37,12 @@ class CarbonCostHelper
             return null;
         }
 
+        // nbKm non renseigné (échec OSRM, coords manquantes…) : pas de calcul plutôt
+        // que d'afficher un trompeur « 0,0 kg CO₂e ».
+        if ($nbKm <= 0) {
+            return null;
+        }
+
         $rate = $this->rates[$transportMode->value] ?? 0;
         $globalCost = $nbKm * $rate;
 

--- a/src/Helper/DistanceHelper.php
+++ b/src/Helper/DistanceHelper.php
@@ -6,16 +6,33 @@ namespace App\Helper;
 
 use App\Entity\Evt;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
+use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class DistanceHelper
 {
+    private readonly HttpClientInterface $retryableClient;
+
     public function __construct(
-        protected readonly HttpClientInterface $httpClient,
+        HttpClientInterface $httpClient,
         protected readonly LoggerInterface $logger,
         protected readonly string $osrmApiUrl = 'http://router.project-osrm.org/route/v1/driving/',
-        protected readonly int $timeout = 5,
+        protected readonly int $timeout = 2,
+        int $maxRetries = 2,
     ) {
+        // Backoff exponentiel : 100ms → 300ms (multiplier 3). Worst case avec
+        // timeout=2s et maxRetries=2 : ~6.4s (3 × 2s + délais + jitter).
+        // Statuts retentés = défauts de GenericRetryStrategy : exceptions transport
+        // (timeout, connexion refusée), 423/425/429 (rate-limit utile pour l'instance
+        // OSRM publique) et 5xx. Une 200 sans route n'est pas retentée — c'est une
+        // réponse légitime.
+        $this->retryableClient = new RetryableHttpClient(
+            $httpClient,
+            new GenericRetryStrategy(delayMs: 100, multiplier: 3.0, maxDelayMs: 300),
+            $maxRetries,
+            $logger,
+        );
     }
 
     /**
@@ -43,7 +60,7 @@ class DistanceHelper
         $url = $this->osrmApiUrl . $rdvCoords . ';' . $departureCoords . '?overview=false';
 
         try {
-            $response = $this->httpClient->request('GET', $url, [
+            $response = $this->retryableClient->request('GET', $url, [
                 'timeout' => $this->timeout,
             ]);
             $data = $response->toArray();

--- a/tests/Helper/CarbonCostHelperTest.php
+++ b/tests/Helper/CarbonCostHelperTest.php
@@ -80,11 +80,13 @@ class CarbonCostHelperTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testCalculateZeroKmReturnsZero(): void
+    public function testCalculateZeroKmReturnsNull(): void
     {
-        $result = $this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN);
-        $this->assertEquals(0.0, $result->total);
-        $this->assertEquals(0.0, $result->perPerson);
+        // nbKm=0 = donnée manquante (OSRM en échec, coords absentes…), pas un
+        // trajet valide à 0 km. On retourne null pour que le template masque le
+        // bloc plutôt que d'afficher un trompeur « 0,0 kg CO₂e ».
+        $this->assertNull($this->helper->calculate(0, 5, 1, TransportModeEnum::PUBLIC_TRAIN));
+        $this->assertNull($this->helper->calculate(0, 5, 1, TransportModeEnum::BIKE_OR_WALK));
     }
 
     public function testCalculateEnforcesMinimumOneForCounts(): void

--- a/tests/Helper/DistanceHelperTest.php
+++ b/tests/Helper/DistanceHelperTest.php
@@ -55,27 +55,68 @@ class DistanceHelperTest extends TestCase
         $this->assertEquals(0.0, $result);
     }
 
-    public function testCalculateReturnsZeroOnHttpException(): void
+    public function testCalculateReturnsZeroAfterAllRetriesFail(): void
     {
-        $mockClient = new MockHttpClient([new MockResponse('', ['http_code' => 500])]);
+        // 3 tentatives (initiale + 2 retries) toutes en 500 → retourne 0
+        $mockClient = new MockHttpClient([
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+        ]);
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error');
 
         $helper = new DistanceHelper($mockClient, $logger);
         $result = $helper->calculate($this->createEvent());
 
         $this->assertEquals(0.0, $result);
+        $this->assertSame(3, $mockClient->getRequestsCount(), 'doit avoir tenté 3 fois');
     }
 
     public function testCalculateLogsErrorOnFailure(): void
     {
-        $mockClient = new MockHttpClient([new MockResponse('', ['http_code' => 500])]);
+        $mockClient = new MockHttpClient([
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => 500]),
+        ]);
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('error')
             ->with($this->stringContains('OSRM distance calculation failed'));
 
         $helper = new DistanceHelper($mockClient, $logger);
         $helper->calculate($this->createEvent());
+    }
+
+    public function testCalculateRetriesOnTransientFailureThenSucceeds(): void
+    {
+        // 2 échecs 503 puis succès → le retry doit récupérer la distance
+        $successBody = json_encode(['routes' => [['distance' => 50000]]]);
+        $mockClient = new MockHttpClient([
+            new MockResponse('', ['http_code' => 503]),
+            new MockResponse('', ['http_code' => 503]),
+            new MockResponse($successBody),
+        ]);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('error');
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $result = $helper->calculate($this->createEvent());
+
+        $this->assertEquals(100.0, $result);
+        $this->assertSame(3, $mockClient->getRequestsCount());
+    }
+
+    public function testCalculateDoesNotRetryOnEmptyRoutes(): void
+    {
+        // 200 avec routes vides = réponse légitime → pas de retry
+        $responseBody = json_encode(['routes' => []]);
+        $mockClient = new MockHttpClient([new MockResponse($responseBody)]);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $helper = new DistanceHelper($mockClient, $logger);
+        $helper->calculate($this->createEvent());
+
+        $this->assertSame(1, $mockClient->getRequestsCount(), 'ne doit pas retenter sur 200 sans route');
     }
 
     public function testCalculateReturnsZeroOnZeroDepartureCoords(): void


### PR DESCRIPTION
## TL;DR

La sortie [Fête d'automne du club à Die (10298)](https://www.clubalpinlyon.fr/sortie/fete-d-automne-du-club-a-die-10298.html?commission=escalade) affiche « 0,0 kg CO₂e / personne ». Cause : OSRM a échoué silencieusement à la création, `nbKm` est resté à 0 en BDD, et le helper retournait `CarbonCost(0,0)` au lieu de `null`. Trois correctifs combinés.

## Cause racine

| Étape | Avant ce PR |
|---|---|
| 1. Création de la sortie | OSRM appelé une seule fois sans retry. Sur 5xx/timeout/réseau → retourne `0`. |
| 2. Persistance | `nbKm = 0` écrit en BDD car `!$isUpdate` force l'écriture même si `nbKm <= 0`. |
| 3. Éditions ultérieures | Recalcul OSRM tenté **uniquement si les coords ont changé** → la sortie reste bloquée à `nbKm=0`. |
| 4. Affichage | `CarbonCostHelper::calculate(0, …)` renvoie `CarbonCost(0.0, 0.0)`. Le template teste `is not null` → affiche « 0,0 kg CO₂e ». |

## Correctifs (3 commits)

| # | Fichier | Changement |
|---|---|---|
| 1 | `CarbonCostHelper.php` | Retourne `null` si `nbKm <= 0` (au lieu de `CarbonCost(0,0)`). Le template masque alors le bloc. |
| 2 | `SortieController.php` | Retente OSRM à l'édition si `nbKm` est vide (en plus du cas « coords modifiées »). |
| 3 | `DistanceHelper.php` | Décoré par `RetryableHttpClient` : 3 tentatives, backoff 100→300ms, retry uniquement sur transport/5xx. Timeout par tentative ramené à 2s. |

Bénéfice : moins de sorties bloquées dès la création (commit 3), et auto-réparation à l'édition pour celles déjà cassées (commit 2), avec un filet de sécurité côté affichage (commit 1) si tout échoue quand même.

## Config

`OSRM_TIMEOUT` passe de 5 à 2 secondes dans `.env`. Worst-case latence d'une sauvegarde de sortie avec OSRM injoignable : **~6,4s** (3 × 2s + backoff), au lieu de 5s avant — compromis assumé pour la robustesse. Aucune nouvelle variable d'env à provisionner.

## Effet sur les sorties existantes

Pas de migration de données. Les sorties déjà en BDD avec `cout_carbone_per_person = 0` continueront d'afficher « 0,0 kg CO₂e » **jusqu'à leur prochaine édition** — où OSRM sera retenté (avec le retry) et le calcul carbone refait.

Pour la sortie 10298 qui a déclenché le ticket : une édition manuelle suffira. Si on veut nettoyer tout le stock d'un coup, un suivi possible : commande `app:carbon:recompute` (proposée en follow-up, pas dans ce PR).

## Test plan

**Automatisé (passe localement)**
- [x] `CarbonCostHelperTest` — 9/9, 19 assertions
- [x] `DistanceHelperTest` — 8/8, 15 assertions (couvre succès 1er coup, retry réussi après 2× 503, échec après 3 tentatives, pas de retry sur 200 sans route)
- [x] `SortieControllerTest` (filtre `Carbon`) — 4/4, 11 assertions

**À vérifier en staging avant prod**
- [ ] Nouvelle sortie sans `modeTransport` ou coords invalides → bloc carbone non affiché
- [ ] Édition de la sortie Die 10298 → recalcul OSRM déclenché, valeur correcte affichée
- [ ] Sortie vélo/marche avec `nbKm` renseigné → continue d'afficher « 0,0 kg CO₂e » (positif voulu)
- [ ] Inspecter les logs OSRM (`warning` / `error`) pour mesurer le taux d'échec après retry

## Limites connues / follow-ups

- Pas de test fonctionnel pour la nouvelle branche `|| !\$event->getNbKm()` dans `SortieController` (les tests existants ne touchent pas ce chemin).
- Pas de backfill pour les sorties existantes (volontaire — chiffré en follow-up).
- Si OSRM est durablement HS, chaque édition d'une sortie cassée payera jusqu'à 6,4s avant `flush()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)