### PR TITLE
feat: webhook HelloAsso prod-ready (signature optionnelle + routage /webhook/notification)

### DIFF
--- a/src/Controller/HelloAssoWebhookController.php
+++ b/src/Controller/HelloAssoWebhookController.php
@@ -56,7 +56,7 @@ class HelloAssoWebhookController extends AbstractController
                     'payload' => $requestContent,
                 ]);
 
-                return new Response('Signature mismatch', Response::HTTP_OK);
+                return new Response('', Response::HTTP_FORBIDDEN);
             }
         }
 

--- a/src/Controller/HelloAssoWebhookController.php
+++ b/src/Controller/HelloAssoWebhookController.php
@@ -8,6 +8,7 @@ use App\Entity\Evt;
 use App\Entity\User;
 use App\Repository\EvtRepository;
 use App\Repository\UserRepository;
+use App\Service\LoxyaReservationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,6 +25,7 @@ class HelloAssoWebhookController extends AbstractController
         protected readonly EntityManagerInterface $entityManager,
         protected readonly EvtRepository $eventRepository,
         protected readonly UserRepository $userRepository,
+        protected readonly LoxyaReservationService $loxyaReservationService,
     ) {
     }
 
@@ -43,24 +45,26 @@ class HelloAssoWebhookController extends AbstractController
             return new Response('Invalid IP', Response::HTTP_BAD_REQUEST);
         }
 
-        // vérification signature
-        $requestHeader = $request->headers->all();
-        if (!\in_array('x-ha-signature', array_keys($requestHeader), true)) {
-            $this->logger->error('HelloAsso Webhook - Missing signature', [
-                $requestContent,
-            ]);
+        // vérification signature (optionnelle) : HelloAsso ne signe pas les notifications des comptes
+        // non-partenaires. On ne vérifie que si une clé est configurée ET qu'une signature est fournie
+        // (défense en profondeur) ; sinon l'authenticité repose sur l'allowlist d'IP ci-dessus.
+        $signature = $request->headers->get('x-ha-signature');
+        if ('' !== $this->helloAssoSignatureKey && null !== $signature) {
+            $calculatedSignature = hash_hmac('sha256', $request->getContent(), $this->helloAssoSignatureKey);
+            if (!hash_equals($signature, $calculatedSignature)) {
+                $this->logger->error('HelloAsso Webhook - Signature mismatch', [
+                    'payload' => $requestContent,
+                ]);
 
-            return new Response('Missing signature', Response::HTTP_BAD_REQUEST);
+                return new Response('Signature mismatch', Response::HTTP_OK);
+            }
         }
 
-        $signature = $requestHeader['x-ha-signature'][0];
-        $calculatedSignature = hash_hmac('sha256', $request->getContent(), $this->helloAssoSignatureKey);
-        if (!hash_equals($signature, $calculatedSignature)) {
-            $this->logger->error('HelloAsso Webhook - Signature mismatch', [
-                'payload' => $requestContent,
-            ]);
-
-            return new Response('Signature mismatch', Response::HTTP_OK);
+        // Paiement de location de matériel : identifié par metadata.reservation_id (injecté dans le
+        // checkout-intent par PaymentController::checkout). HelloAsso n'autorisant qu'une URL de notif
+        // par organisation, ces paiements arrivent sur la même URL que les inscriptions événements.
+        if (isset($requestContent['metadata']['reservation_id'])) {
+            return $this->handleMaterialReservationPayment($requestContent);
         }
 
         $requestData = $requestContent['data'] ?? [];
@@ -149,6 +153,52 @@ class HelloAssoWebhookController extends AbstractController
         ]);
 
         // on retourne une 200 même en cas d'erreur pour ne pas que HelloAsso renvoie plusieurs fois la notification
+        return new Response('OK', Response::HTTP_OK);
+    }
+
+    /**
+     * Marque la réservation Loxya comme payée à partir d'une notification de paiement matériel.
+     * Renvoie 503 si Loxya échoue, pour que HelloAsso retente (le PUT Loxya est idempotent).
+     */
+    private function handleMaterialReservationPayment(array $payload): Response
+    {
+        $eventType = $payload['eventType'] ?? null;
+        $state = $payload['data']['state'] ?? null;
+
+        if ('Payment' !== $eventType || 'Authorized' !== $state) {
+            $this->logger->info('HelloAsso Webhook - Loxya : notification ignorée', [
+                'eventType' => $eventType,
+                'state' => $state,
+            ]);
+
+            return new Response('OK', Response::HTTP_OK);
+        }
+
+        $reservationId = filter_var($payload['metadata']['reservation_id'] ?? null, FILTER_VALIDATE_INT, [
+            'options' => ['min_range' => 1],
+        ]);
+        $helloAssoPaymentId = $payload['data']['id'] ?? null;
+
+        if (false === $reservationId
+            || (!\is_string($helloAssoPaymentId) && !\is_int($helloAssoPaymentId))
+            || '' === (string) $helloAssoPaymentId
+        ) {
+            $this->logger->error('HelloAsso Webhook - Loxya : reservation_id ou payment id invalide');
+
+            return new Response('OK', Response::HTTP_OK);
+        }
+
+        try {
+            $this->loxyaReservationService->markReservationAsPaid($reservationId, (string) $helloAssoPaymentId);
+        } catch (\Exception $e) {
+            $this->logger->error('HelloAsso Webhook - Loxya update failed, HelloAsso will retry', [
+                'reservationId' => $reservationId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new Response('Loxya update failed', Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
         return new Response('OK', Response::HTTP_OK);
     }
 }

--- a/src/Controller/HelloAssoWebhookController.php
+++ b/src/Controller/HelloAssoWebhookController.php
@@ -45,9 +45,7 @@ class HelloAssoWebhookController extends AbstractController
             return new Response('Invalid IP', Response::HTTP_BAD_REQUEST);
         }
 
-        // vérification signature (optionnelle) : HelloAsso ne signe pas les notifications des comptes
-        // non-partenaires. On ne vérifie que si une clé est configurée ET qu'une signature est fournie
-        // (défense en profondeur) ; sinon l'authenticité repose sur l'allowlist d'IP ci-dessus.
+        // Signature vérifiée seulement si clé + header présents (HelloAsso ne signe pas les comptes non-partenaires).
         $signature = $request->headers->get('x-ha-signature');
         if ('' !== $this->helloAssoSignatureKey && null !== $signature) {
             $calculatedSignature = hash_hmac('sha256', $request->getContent(), $this->helloAssoSignatureKey);
@@ -60,9 +58,8 @@ class HelloAssoWebhookController extends AbstractController
             }
         }
 
-        // Paiement de location de matériel : identifié par metadata.reservation_id (injecté dans le
-        // checkout-intent par PaymentController::checkout). HelloAsso n'autorisant qu'une URL de notif
-        // par organisation, ces paiements arrivent sur la même URL que les inscriptions événements.
+        // Paiement matériel (metadata.reservation_id) : HelloAsso n'ayant qu'une URL de notif par orga,
+        // il arrive ici comme les inscriptions événements.
         if (isset($requestContent['metadata']['reservation_id'])) {
             return $this->handleMaterialReservationPayment($requestContent);
         }

--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -28,8 +28,11 @@ class PaymentController extends AbstractController
 
     private function isEnabled(): bool
     {
-        return '' !== $this->loxyaLinkSignatureKey
-            && '' !== $this->helloAssoSignatureKey;
+        // La clé de signature du lien (partagée avec Loxya) est le seul secret obligatoire :
+        // c'est elle qui authentifie l'entrée du tunnel (page /paiement). La signature du
+        // webhook HelloAsso est optionnelle (cf. webhook()) car HelloAsso ne signe pas les
+        // notifications des comptes non-partenaires — le webhook s'appuie alors sur l'IP.
+        return '' !== $this->loxyaLinkSignatureKey;
     }
 
     #[Route(path: '/paiement', name: 'payment_checkout', methods: ['GET'])]
@@ -101,8 +104,9 @@ class PaymentController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        // Ordre des vérifs : IP → signature → décodage JSON. Aucun payload non authentifié n'est loggé.
-        // Réponse générique (403 sans body) sur les vérifs auth pour ne pas guider un scan.
+        // Ordre des vérifs : IP → signature (optionnelle) → décodage JSON. Aucun payload non authentifié
+        // n'est loggé. Réponse générique (403 sans body) sur les vérifs auth pour ne pas guider un scan.
+        // L'IP HelloAsso est ici le garde principal (allowlist).
         if ($this->helloAssoServerIp !== $request->getClientIp()) {
             $this->logger->error('Payment webhook - Invalid IP', [
                 'ip' => $request->getClientIp(),
@@ -111,19 +115,19 @@ class PaymentController extends AbstractController
             return new Response('', Response::HTTP_FORBIDDEN);
         }
 
-        $signatureHeader = $request->headers->get('x-ha-signature');
-        if (null === $signatureHeader) {
-            $this->logger->error('Payment webhook - Missing signature');
-
-            return new Response('Missing signature', Response::HTTP_BAD_REQUEST);
-        }
-
         $rawContent = $request->getContent();
-        $calculatedSignature = hash_hmac('sha256', $rawContent, $this->helloAssoSignatureKey);
-        if (!hash_equals($calculatedSignature, $signatureHeader)) {
-            $this->logger->error('Payment webhook - Signature mismatch');
 
-            return new Response('Signature mismatch', Response::HTTP_FORBIDDEN);
+        // Signature optionnelle : HelloAsso ne signe pas les webhooks pour les comptes non-partenaires.
+        // Défense en profondeur : on ne vérifie la signature que si une clé est configurée ET qu'une
+        // signature est fournie. Sinon, l'authenticité repose sur l'allowlist d'IP vérifiée ci-dessus.
+        $signatureHeader = $request->headers->get('x-ha-signature');
+        if ('' !== $this->helloAssoSignatureKey && null !== $signatureHeader) {
+            $calculatedSignature = hash_hmac('sha256', $rawContent, $this->helloAssoSignatureKey);
+            if (!hash_equals($calculatedSignature, $signatureHeader)) {
+                $this->logger->error('Payment webhook - Signature mismatch');
+
+                return new Response('Signature mismatch', Response::HTTP_FORBIDDEN);
+            }
         }
 
         $payload = json_decode($rawContent, true);

--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -126,7 +126,7 @@ class PaymentController extends AbstractController
             if (!hash_equals($calculatedSignature, $signatureHeader)) {
                 $this->logger->error('Payment webhook - Signature mismatch');
 
-                return new Response('Signature mismatch', Response::HTTP_FORBIDDEN);
+                return new Response('', Response::HTTP_FORBIDDEN);
             }
         }
 

--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -28,10 +28,7 @@ class PaymentController extends AbstractController
 
     private function isEnabled(): bool
     {
-        // La clé de signature du lien (partagée avec Loxya) est le seul secret obligatoire :
-        // c'est elle qui authentifie l'entrée du tunnel (page /paiement). La signature du
-        // webhook HelloAsso est optionnelle (cf. webhook()) car HelloAsso ne signe pas les
-        // notifications des comptes non-partenaires — le webhook s'appuie alors sur l'IP.
+        // Seule la clé du lien (partagée avec Loxya) est requise ; la signature webhook est optionnelle (cf. webhook()).
         return '' !== $this->loxyaLinkSignatureKey;
     }
 
@@ -104,9 +101,7 @@ class PaymentController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        // Ordre des vérifs : IP → signature (optionnelle) → décodage JSON. Aucun payload non authentifié
-        // n'est loggé. Réponse générique (403 sans body) sur les vérifs auth pour ne pas guider un scan.
-        // L'IP HelloAsso est ici le garde principal (allowlist).
+        // Garde principal : allowlist d'IP HelloAsso. 403 sans body pour ne pas révéler le contrôle échoué.
         if ($this->helloAssoServerIp !== $request->getClientIp()) {
             $this->logger->error('Payment webhook - Invalid IP', [
                 'ip' => $request->getClientIp(),
@@ -117,9 +112,7 @@ class PaymentController extends AbstractController
 
         $rawContent = $request->getContent();
 
-        // Signature optionnelle : HelloAsso ne signe pas les webhooks pour les comptes non-partenaires.
-        // Défense en profondeur : on ne vérifie la signature que si une clé est configurée ET qu'une
-        // signature est fournie. Sinon, l'authenticité repose sur l'allowlist d'IP vérifiée ci-dessus.
+        // Signature vérifiée seulement si clé + header présents (HelloAsso ne signe pas les comptes non-partenaires).
         $signatureHeader = $request->headers->get('x-ha-signature');
         if ('' !== $this->helloAssoSignatureKey && null !== $signatureHeader) {
             $calculatedSignature = hash_hmac('sha256', $rawContent, $this->helloAssoSignatureKey);

--- a/tests/Controller/HelloAssoWebhookControllerTest.php
+++ b/tests/Controller/HelloAssoWebhookControllerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Service\LoxyaReservationService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class HelloAssoWebhookControllerTest extends WebTestCase
+{
+    private const SERVER_IP = '127.0.0.1';
+
+    private function postNotification($client, string $payload, string $ip = self::SERVER_IP): void
+    {
+        $client->request('POST', '/webhook/notification', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'REMOTE_ADDR' => $ip,
+        ], $payload);
+    }
+
+    public function testMaterialPaymentMarksReservationAsPaid(): void
+    {
+        // Pas de header de signature : HelloAsso n'en envoie pas (compte non-partenaire).
+        // L'IP valide suffit, et la metadata reservation_id déclenche le bridge Loxya.
+        $client = static::createClient();
+
+        $loxya = $this->createMock(LoxyaReservationService::class);
+        $loxya->expects($this->once())->method('markReservationAsPaid')->with(616, 'ha-pay-1');
+        $client->getContainer()->set(LoxyaReservationService::class, $loxya);
+
+        $this->postNotification($client, json_encode([
+            'eventType' => 'Payment',
+            'data' => ['id' => 'ha-pay-1', 'state' => 'Authorized'],
+            'metadata' => ['reservation_id' => 616],
+        ]));
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testMaterialPaymentReturns503OnLoxyaError(): void
+    {
+        $client = static::createClient();
+
+        $loxya = $this->createMock(LoxyaReservationService::class);
+        $loxya->method('markReservationAsPaid')->willThrowException(new \RuntimeException('Loxya down'));
+        $client->getContainer()->set(LoxyaReservationService::class, $loxya);
+
+        $this->postNotification($client, json_encode([
+            'eventType' => 'Payment',
+            'data' => ['id' => 'ha-pay-1', 'state' => 'Authorized'],
+            'metadata' => ['reservation_id' => 616],
+        ]));
+
+        $this->assertResponseStatusCodeSame(503);
+    }
+
+    public function testMaterialPaymentIgnoresNonAuthorizedState(): void
+    {
+        $client = static::createClient();
+
+        $loxya = $this->createMock(LoxyaReservationService::class);
+        $loxya->expects($this->never())->method('markReservationAsPaid');
+        $client->getContainer()->set(LoxyaReservationService::class, $loxya);
+
+        $this->postNotification($client, json_encode([
+            'eventType' => 'Payment',
+            'data' => ['id' => 'ha-pay-1', 'state' => 'Refused'],
+            'metadata' => ['reservation_id' => 616],
+        ]));
+
+        $this->assertResponseStatusCodeSame(200);
+    }
+
+    public function testRejectsInvalidIp(): void
+    {
+        $client = static::createClient();
+
+        $this->postNotification($client, json_encode([
+            'eventType' => 'Payment',
+            'data' => ['id' => 'ha-pay-1', 'state' => 'Authorized'],
+            'metadata' => ['reservation_id' => 616],
+        ]), ip: '10.0.0.1');
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+}

--- a/tests/Controller/PaymentControllerTest.php
+++ b/tests/Controller/PaymentControllerTest.php
@@ -218,17 +218,30 @@ class PaymentControllerTest extends WebTestCase
         $this->assertEmpty($client->getResponse()->getContent());
     }
 
-    public function testWebhookRejectsMissingSignature(): void
+    public function testWebhookAcceptsMissingSignatureWhenIpValid(): void
     {
+        // Signature optionnelle : sans header de signature mais avec une IP valide, le webhook
+        // est traité (HelloAsso ne signe pas les notifications des comptes non-partenaires).
         $client = static::createClient();
-        $payload = json_encode(['eventType' => 'Payment']);
+
+        $loxyaService = $this->createMock(LoxyaReservationService::class);
+        $loxyaService->expects($this->once())
+            ->method('markReservationAsPaid')
+            ->with(42, '99999');
+        $client->getContainer()->set(LoxyaReservationService::class, $loxyaService);
+
+        $payload = json_encode([
+            'eventType' => 'Payment',
+            'data' => ['id' => '99999', 'state' => 'Authorized'],
+            'metadata' => ['reservation_id' => 42],
+        ]);
 
         $client->request('POST', '/webhook/paiement', [], [], [
             'CONTENT_TYPE' => 'application/json',
             'REMOTE_ADDR' => self::WEBHOOK_SERVER_IP,
         ], $payload);
 
-        $this->assertResponseStatusCodeSame(400);
+        $this->assertResponseStatusCodeSame(200);
     }
 
     public function testWebhookRejectsInvalidSignature(): void


### PR DESCRIPTION
## Contexte
Suite aux tests staging : le compte HelloAsso du club n'est pas « partenaire » → **pas de SignatureKey**, webhooks **non signés**. De plus, HelloAsso n'autorise qu'**une seule URL de notification par organisation**, déjà occupée par `/webhook/notification` (inscriptions événements).

## Changements
1. **Signature optionnelle** (`PaymentController::webhook` + `HelloAssoWebhookController::notification`) : la signature `x-ha-signature` n'est vérifiée que si une clé **et** une signature sont présentes (défense en profondeur sandbox/partenaire). Sinon, l'authenticité repose sur l'**allowlist d'IP HelloAsso**.
2. **Routage** : les paiements matériel sont désormais traités par le webhook existant **`/webhook/notification`** (URL unique de l'orga), distingués des inscriptions via `metadata.reservation_id` → délégués à `LoxyaReservationService` (PUT idempotent, `503` si Loxya échoue pour rejeu HelloAsso). `/webhook/paiement` reste dispo (sandbox / URL dédiée).
3. **`isEnabled()`** ne dépend plus que de `LOXYA_LINK_SIGNATURE_KEY`.
4. Tests : `PaymentControllerTest` adapté + nouveau `HelloAssoWebhookControllerTest` (branche matériel, 503, IP, état non autorisé).

## Déploiement
- Prod : **garder l'URL de notif HelloAsso sur `/webhook/notification`** (ne pas la remplacer). `HELLO_ASSO_WEBHOOK_SIGNATURE_KEY` peut rester vide.
- `HELLO_ASSO_SERVER_IP` = `51.138.206.200` (prod) / `4.233.135.234` (sandbox), + `TRUSTED_PROXIES` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)