### PR TITLE
fix: évite l'OOM de l'import des communes (champs sélectionnés)

### DIFF
--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -20,6 +20,9 @@ class ImportCommunesCommand extends Command
 {
     private const API_URL = 'https://datanova.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/lines';
     private const PAGE_SIZE = 1000;
+    // On ne demande que les champs utiles : le dataset expose aussi `_contours_commune.geometry`
+    // (MultiPolygon de plusieurs Ko/ligne) qui, sur 39 000 communes, sature la mémoire (OOM).
+    private const SELECT_FIELDS = 'code_commune_insee,nom_de_la_commune,code_postal,libelle_d_acheminement,ligne_5,_geopoint';
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -41,7 +44,7 @@ class ImportCommunesCommand extends Command
         $io->comment('Table communes vidée.');
 
         $total = 0;
-        $url = self::API_URL . '?size=' . self::PAGE_SIZE;
+        $url = self::API_URL . '?size=' . self::PAGE_SIZE . '&select=' . self::SELECT_FIELDS;
 
         do {
             $response = $this->httpClient->request('GET', $url);


### PR DESCRIPTION
## Problème

`php bin/console app:import-communes` plante en **OutOfMemory** (même avec le plafond à 512M défini dans la commande) :

```
Fatal error: Allowed memory size of 536870912 bytes exhausted
... json_decode( ..."_contours_commune.geometry":"{\"type\":\"MultiPolygon\"...
```

Le dataset La Poste `laposte-hexasmal` expose désormais un champ **`_contours_commune.geometry`** — des `MultiPolygon` de plusieurs Ko par commune. La commande téléchargeait tous les champs ; sur ~39 000 communes paginées par 1000, ces contours géographiques saturent la mémoire.

## Correctif

On restreint la requête API aux **6 champs réellement utilisés** via le paramètre `select` :

```
code_commune_insee, nom_de_la_commune, code_postal, libelle_d_acheminement, ligne_5, _geopoint
```

- Charge mémoire divisée par ~50 (le `geometry` disparaît de la réponse).
- `ligne_5` (hameaux) toujours récupéré — vérifié sur Chamonix (Argentière, Les Bossons, Les Praz).
- La pagination (`next`) conserve le `select`, donc **toutes** les pages restent légères.

## Test

```bash
php bin/console app:import-communes
# → ~39 000 communes importées sans OOM
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)