### PR TITLE
feat: sorties en commun sur la fiche profil

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -80,10 +80,21 @@ class UserController extends AbstractController
         );
         $userEvents = $eventRepository->getUserEvents($user, 0, 3, [Evt::STATUS_PUBLISHED_VALIDE]);
 
+        // Sorties en commun avec l'utilisateur connecté (sauf sur son propre profil)
+        $loggedInUser = $this->getUser();
+        $commonEvents = [];
+        $nbCommonEvents = 0;
+        if ($loggedInUser instanceof User && $loggedInUser->getId() !== $user->getId()) {
+            $commonEvents = $eventRepository->getCommonEvents($user, $loggedInUser, 0, 3);
+            $nbCommonEvents = $eventRepository->getCommonEventsCount($user, $loggedInUser);
+        }
+
         return array_merge($userData, [
             'user' => $user,
             'user_articles' => $userArticles,
             'user_events' => $userEvents,
+            'common_events' => $commonEvents,
+            'nb_common_events' => $nbCommonEvents,
             'nb_events' => $eventRepository->getUserEventsCount($user, [Evt::STATUS_PUBLISHED_VALIDE]),
             'nb_articles' => $articleRepository->getUserArticlesCount($user),
         ]);

--- a/src/Repository/EvtRepository.php
+++ b/src/Repository/EvtRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Commission;
+use App\Entity\EventParticipation;
 use App\Entity\Evt;
 use App\Entity\ExpenseReport;
 use App\Entity\User;
@@ -270,6 +271,42 @@ class EvtRepository extends ServiceEntityRepository
             ->select('count(e)')
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    /**
+     * Sorties auxquelles $user ET $otherUser participent tous deux (participation validée).
+     *
+     * Pas de filtre de date : on reste cohérent avec « Dernières sorties »
+     * (getUserEvents), qui liste aussi bien les sorties passées que futures.
+     *
+     * @return Evt[]
+     */
+    public function getCommonEvents(User $user, User $otherUser, int $first, int $perPage): array
+    {
+        return $this->getPaginatedResults($this->getCommonEventsDql($user, $otherUser), $first, $perPage);
+    }
+
+    /**
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function getCommonEventsCount(User $user, User $otherUser): int
+    {
+        return (int) $this
+            ->getCommonEventsDql($user, $otherUser)
+            ->select('count(DISTINCT e)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function getCommonEventsDql(User $user, User $otherUser): QueryBuilder
+    {
+        return $this->getEventsByUserDql($user, [Evt::STATUS_PUBLISHED_VALIDE], [EventParticipation::STATUS_VALIDE])
+            ->innerJoin('e.participations', 'p2', 'WITH', 'p2.user = :otherUser AND p2.status = :validStatus')
+            ->setParameter('otherUser', $otherUser)
+            ->setParameter('validStatus', EventParticipation::STATUS_VALIDE)
+            ->orderBy('e.startDate', 'desc')
+        ;
     }
 
     public function getRecentPastEvents(?Commission $commission = null): array

--- a/templates/macros/user-content.html.twig
+++ b/templates/macros/user-content.html.twig
@@ -1,4 +1,4 @@
-{% macro user_content(user, nb_articles, user_articles, nb_events, user_events, type = 'full') %}
+{% macro user_content(user, nb_articles, user_articles, nb_events, user_events, type = 'full', common_events = [], nb_common_events = 0) %}
     {% import 'macros/article-link.html.twig' as article_macro %}
     {% import 'macros/event-line.html.twig' as event_macro %}
 
@@ -19,6 +19,20 @@
     </div>
     <br style="clear:both" />
     <hr  />
+
+    {% if type is same as ('reduced') and app.user is not same as (user) %}
+        <h2 id="user-sorties-communes">Sorties en commun :</h2>
+        <p class="mini">{{ nb_common_events }} sortie(s) en commun</p>
+        <div class="profile-block">
+            <table id="agenda">
+                {% for event in common_events %}
+                    {{ event_macro.event_line(event, user, '', false) }}
+                {% endfor %}
+            </table>
+        </div>
+        <br style="clear:both" />
+        <hr  />
+    {% endif %}
 
     <h2 id="user-articles">
         {% if type is same as ('reduced') %}

--- a/templates/user/profile.html.twig
+++ b/templates/user/profile.html.twig
@@ -53,7 +53,7 @@
                 {% if allowed('user_read_private') or app.user is same as (user) %}
                     {{ taux_macro.taux_presence(user, fiabilite, nb_absences, total_sorties) }}
 
-                    {{ content_macro.user_content(user, nb_articles, user_articles, nb_events, user_events, 'reduced') }}
+                    {{ content_macro.user_content(user, nb_articles, user_articles, nb_events, user_events, 'reduced', common_events, nb_common_events) }}
                 {% endif %}
             </div>
         </div>

--- a/tests/Repository/EvtRepositoryCommonEventsTest.php
+++ b/tests/Repository/EvtRepositoryCommonEventsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\EventParticipation;
+use App\Entity\Evt;
+use App\Entity\User;
+use App\Repository\EvtRepository;
+use App\Tests\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+class EvtRepositoryCommonEventsTest extends WebTestCase
+{
+    private function em(): EntityManagerInterface
+    {
+        return $this->getContainer()->get(EntityManagerInterface::class);
+    }
+
+    private function repo(): EvtRepository
+    {
+        return $this->getContainer()->get(EvtRepository::class);
+    }
+
+    /**
+     * Crée une sortie passée, publiée et validée, dont $owner est encadrant validé.
+     */
+    private function createPastValidatedEvent(User $owner): Evt
+    {
+        // createEvent() crée une sortie future avec $owner comme participant validé
+        $event = $this->createEvent($owner);
+        $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
+        $event->setStartDate(new \DateTimeImmutable('-8 days'));
+        $event->setEndDate(new \DateTimeImmutable('-7 days'));
+        $this->em()->flush();
+
+        return $event;
+    }
+
+    public function testReturnsSharedPastValidatedEvent(): void
+    {
+        $userA = $this->signup();
+        $userB = $this->signup();
+
+        $event = $this->createPastValidatedEvent($userA);
+        $event->addParticipation($userB, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
+        $this->em()->flush();
+
+        $common = $this->repo()->getCommonEvents($userA, $userB, 0, 10);
+
+        $this->assertCount(1, $common);
+        $this->assertSame($event->getId(), $common[0]->getId());
+        $this->assertSame(1, $this->repo()->getCommonEventsCount($userA, $userB));
+
+        // L'intersection est symétrique
+        $this->assertSame(1, $this->repo()->getCommonEventsCount($userB, $userA));
+    }
+
+    public function testIncludesFutureSharedEvent(): void
+    {
+        $userA = $this->signup();
+        $userB = $this->signup();
+
+        // Sortie future (createEvent => +7/+8 jours), publiée et validée, deux participants validés.
+        // Comme « Dernières sorties », on ne filtre pas sur la date : elle doit être incluse.
+        $event = $this->createEvent($userA);
+        $event->setStatus(Evt::STATUS_PUBLISHED_VALIDE);
+        $event->addParticipation($userB, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
+        $this->em()->flush();
+
+        $common = $this->repo()->getCommonEvents($userA, $userB, 0, 10);
+
+        $this->assertCount(1, $common);
+        $this->assertSame($event->getId(), $common[0]->getId());
+        $this->assertSame(1, $this->repo()->getCommonEventsCount($userA, $userB));
+    }
+
+    public function testExcludesWhenOtherUserNotValidated(): void
+    {
+        $userA = $this->signup();
+        $userB = $this->signup();
+
+        $event = $this->createPastValidatedEvent($userA);
+        // B seulement pré-inscrit (non confirmé) => ne compte pas
+        $event->addParticipation($userB, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_NON_CONFIRME);
+        $this->em()->flush();
+
+        $this->assertEmpty($this->repo()->getCommonEvents($userA, $userB, 0, 10));
+        $this->assertSame(0, $this->repo()->getCommonEventsCount($userA, $userB));
+    }
+
+    public function testExcludesEventNotSharedWithOtherUser(): void
+    {
+        $userA = $this->signup();
+        $userB = $this->signup();
+        $userC = $this->signup();
+
+        // Sortie passée validée partagée par A et C, mais pas B
+        $event = $this->createPastValidatedEvent($userA);
+        $event->addParticipation($userC, EventParticipation::ROLE_INSCRIT, EventParticipation::STATUS_VALIDE);
+        $this->em()->flush();
+
+        $this->assertEmpty($this->repo()->getCommonEvents($userA, $userB, 0, 10));
+        $this->assertCount(1, $this->repo()->getCommonEvents($userA, $userC, 0, 10));
+    }
+}


### PR DESCRIPTION
Ajoute une section « Sorties en commun » sur la fiche profil (la popup ouverte
en cliquant sur le nom d'un adhérent depuis une sortie). Elle liste les sorties,
passées comme futures, auxquelles l'adhérent consulté **et** l'utilisateur
connecté ont tous deux une participation **validée**.

La section est affichée et traitée exactement comme « Dernières sorties » (même
emplacement, même mise en forme, même condition de visibilité), simplement
filtrée sur les sorties partagées entre les deux personnes.

### Comportement

- **Pas de filtre de date** : cohérent avec « Dernières sorties », on liste le
  passé comme le futur (les sorties futures apparaissent en tête).
- **Participation validée des deux côtés** : une inscription refusée ou non
  confirmée ne compte pas comme une sortie en commun.
- **Masquée sur son propre profil** (la notion n'a pas de sens sur soi-même).
- **Aucune sortie en commun** : le tableau reste affiché, mais vide
  (« 0 sortie(s) en commun »).
- Même visibilité que « Dernières sorties » : aucune nouvelle donnée n'est
  exposée à des personnes qui n'y avaient pas déjà accès.

### Captures d'écran

**Plusieurs sorties en commun**

<img width="1004" height="1434" alt="sorties_communes_1" src="https://github.com/user-attachments/assets/e7427f00-debb-4146-936d-8b82b212fb89" />

**Aucune sortie en commun (tableau vide)**

<img width="992" height="1438" alt="sorties_communes_2" src="https://github.com/user-attachments/assets/be5071de-dac1-4146-a12c-4034e04419ce" />

**Son propre profil (section absente)**

<img width="1002" height="1438" alt="sorties_communes_3" src="https://github.com/user-attachments/assets/591583fe-3a66-469b-bf9d-60d12683c576" />

### Tests

- `make tests path=tests/Repository/EvtRepositoryCommonEventsTest.php` : OK
  (4 tests, 11 assertions) — sortie partagée passée, sortie partagée future
  (incluse), exclusion si la participation de l'autre n'est pas validée,
  exclusion si non partagée, symétrie de l'intersection
- `make php-cs` : OK
- `make phpstan` : OK

### Notes techniques

- Aucune migration / changement de schéma : uniquement de la requête et de
  l'affichage.
