### PR TITLE
fix: corrige l'OOM de l'import des communes en limitant les champs récupérés

### DIFF
--- a/src/Command/ImportCommunesCommand.php
+++ b/src/Command/ImportCommunesCommand.php
@@ -21,6 +21,11 @@ class ImportCommunesCommand extends Command
     private const API_URL = 'https://datanova.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/lines';
     private const PAGE_SIZE = 1000;
 
+    // On ne récupère que les champs utilisés : le dataset expose aussi
+    // `_contours_commune.geometry` (polygones complets, ~98 % du poids d'une page),
+    // qui faisait exploser la mémoire pendant l'import des ~39 000 communes.
+    private const SELECT_FIELDS = 'code_commune_insee,nom_de_la_commune,code_postal,libelle_d_acheminement,ligne_5,_geopoint';
+
     public function __construct(
         private readonly HttpClientInterface $httpClient,
         private readonly Connection $connection,
@@ -41,7 +46,7 @@ class ImportCommunesCommand extends Command
         $io->comment('Table communes vidée.');
 
         $total = 0;
-        $url = self::API_URL . '?size=' . self::PAGE_SIZE;
+        $url = self::API_URL . '?size=' . self::PAGE_SIZE . '&select=' . self::SELECT_FIELDS;
 
         do {
             $response = $this->httpClient->request('GET', $url);


### PR DESCRIPTION
En lançant `make database-bootstrap`, l'import des communes (`app:import-communes`)
échoue avec une erreur de mémoire (`Allowed memory size ... exhausted`).

La requête à l'API La Poste récupère **tous** les champs du dataset, dont
`_contours_commune.geometry` (les polygones complets de chaque commune, ~98 % du
poids de la réponse) — alors que la commande n'en a pas besoin.

J'ai ajouté un paramètre `select` à l'URL pour ne demander que les champs
réellement utilisés. Plus d'erreur mémoire : `make database-bootstrap` va
désormais au bout (39 192 communes importées).

### Tests

- `make database-bootstrap` : OK
- `make php-cs` : OK
- `make phpstan` : OK
