### PR TITLE
fix: descend "HelloAsso Webhook - Unknown form" en info

### DIFF
--- a/src/Controller/HelloAssoWebhookController.php
+++ b/src/Controller/HelloAssoWebhookController.php
@@ -102,7 +102,8 @@ class HelloAssoWebhookController extends AbstractController
         $event = $this->eventRepository->findOneBy(['helloAssoFormSlug' => $eventSlug]);
 
         if (!$event instanceof Evt) {
-            $this->logger->error('HelloAsso Webhook - Unknown form', [
+            // formulaire non géré par la plateforme (cas attendu, cf. les logs info ci-dessus)
+            $this->logger->info('HelloAsso Webhook - Unknown form', [
                 'eventSlug' => $eventSlug,
             ]);
 


### PR DESCRIPTION
## Contexte

L'issue Sentry [`CLUBALPINLYONFR-17K`](https://club-alpin-lyon.sentry.io/issues/6965212515/) remonte ~1700 erreurs **"HelloAsso Webhook - Unknown form"** depuis octobre 2025 et reste en permanence *unresolved*.

## Cause racine (pas un bug code)

HelloAsso n'expose **qu'une seule URL de webhook pour toute l'organisation** : *tous* les paiements y transitent. Quand aucun `Evt` n'a de `helloAssoFormSlug` correspondant, on logge en `error` (`HelloAssoWebhookController.php:105`).

Or, en échantillonnant 100 événements (21 slugs distincts), **aucun** ne suit le format de titre généré par la plateforme (`[YYYY-MM-DD] Commission - Nom - Lieu`, cf. `HelloAssoService:44`). Ce sont tous des formulaires **créés à la main** dans HelloAsso :
- non-sorties : `carte-decouverte`, `double-adhesion`, `location-materiel-*`, `remboursement-minibus`…
- sorties/camps organisés hors du flux plateforme : `le-long-week-end-de-trarn-…` (32 occ.), `camp-de-base-alpinisme-*`, `we-rando-massif-du-devoluy-…`…

La plateforme ne peut pas réconcilier des formulaires qu'elle n'a pas créés : c'est un cas **structurellement attendu**, pas une erreur.

## Correctif

Passage de `error` à `info`, par cohérence avec les cas voisins "not handled" déjà descendus en `info` (#1417).

Le handler Monolog→Sentry capture à partir de `ERROR` (`config/packages/prod/monolog.yaml:27`) : l'événement **sort donc de Sentry** tout en restant dans les logs stdout (handler `file`, niveau debug).

## Sûreté

Une sortie créée via la plateforme **ne peut pas** tomber dans ce cas : son `helloAssoFormSlug` est enregistré à la validation (`SortieController.php:501`), et un échec de création de formulaire est déjà loggé séparément (`SortieController.php:507`).

## Suivi (hors périmètre)

Le volume montre que des camps/sorties payants réels (ex. 32 paiements pour un week-end) passent par des formulaires HelloAsso manuels et ne sont jamais réconciliés sur la plateforme. Si cette réconciliation est souhaitée, ce serait un sujet produit à part (lier un formulaire HelloAsso existant à une `Evt`).

## Après merge / déploiement

Marquer l'issue Sentry `CLUBALPINLYONFR-17K` comme *resolved*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)