### PR TITLE
fix: évite le 500 à la création de sortie sans marqueur placé

### DIFF
--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -199,9 +199,12 @@ class EventType extends AbstractType
                     ]),
                 ],
             ])
+            // non mappés : une saisie vide planterait le setter non-nullable (cf. Sentry 1E6) ;
+            // recopiés dans l'entité en POST_SUBMIT si valides.
             ->add('lat', HiddenType::class, [
                 'label' => false,
                 'required' => true,
+                'mapped' => false,
                 'data' => $lat,
                 'constraints' => [
                     new NotBlank(null, 'La latitude est obligatoire. Avez-vous bien cliqué sur le bouton pour placer le marqueur ?'),
@@ -211,6 +214,7 @@ class EventType extends AbstractType
             ->add('long', HiddenType::class, [
                 'label' => false,
                 'required' => true,
+                'mapped' => false,
                 'data' => $long,
                 'constraints' => [
                     new NotBlank(null, 'La longitude est obligatoire. Avez-vous bien cliqué sur le bouton pour placer le marqueur ?'),
@@ -522,6 +526,16 @@ class EventType extends AbstractType
                         $evt->setLongDepart((float) $commune->getLongitude());
                         $evt->setPlace($commune->getLabel());
                     }
+                }
+
+                // marqueur (champ non mappé) : recopié dans l'entité si valide
+                $lat = $form->get('lat')->getData();
+                $long = $form->get('long')->getData();
+                if (is_numeric($lat) && is_numeric($long)) {
+                    /** @var Evt $evt */
+                    $evt = $form->getData();
+                    $evt->setLat((float) $lat);
+                    $evt->setLong((float) $long);
                 }
 
                 // cohérence dates début et fin

--- a/tests/Form/EventTypeTest.php
+++ b/tests/Form/EventTypeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\Form;
+
+use App\Entity\Evt;
+use App\Entity\User;
+use App\Form\EventType;
+use App\Tests\WebTestCase;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class EventTypeTest extends WebTestCase
+{
+    private function buildForm(Evt $event, User $user): FormInterface
+    {
+        return self::getContainer()->get(FormFactoryInterface::class)->create(EventType::class, $event, [
+            'is_edit' => false,
+            'editoLineLink' => '',
+            'imageRightLink' => '',
+            'user' => $user,
+            'csrf_protection' => false,
+        ]);
+    }
+
+    private function newEvent(User $user): Evt
+    {
+        return new Evt($user, $this->createCommission(), null, null, null, null, 'RDV', 45.75, 4.85, null, null, null, new \DateTimeImmutable());
+    }
+
+    /** Régression Sentry CLUBALPINLYONFR-1E6 : marqueur non placé (lat/long vides) → 500. */
+    public function testSubmitWithEmptyCoordinatesIsInvalidWithoutCrashing(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        $form = $this->buildForm($event, $user);
+
+        $form->submit(['lat' => '', 'long' => ''], false);
+
+        self::assertFalse($form->isValid());
+        self::assertSame(45.75, (float) $event->getLat());
+        self::assertSame(4.85, (float) $event->getLong());
+        self::assertStringContainsString('marqueur', strtolower((string) $form->getErrors(true)));
+    }
+
+    public function testValidCoordinatesAreWrittenToEntity(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        $form = $this->buildForm($event, $user);
+
+        $form->submit(['lat' => '46.12345678', 'long' => '6.87654321'], false);
+
+        self::assertSame(46.12345678, (float) $event->getLat());
+        self::assertSame(6.87654321, (float) $event->getLong());
+    }
+}


### PR DESCRIPTION
## Contexte

Issue Sentry [`CLUBALPINLYONFR-1E6`](https://club-alpin-lyon.sentry.io/issues/) — fatal récurrent sur `/creer-une-sortie` :

```
Symfony\Component\PropertyAccess\Exception\InvalidArgumentException:
Expected argument of type "string|float", "null" given at property path "lat".
```

## Cause racine

Les champs `lat`/`long` (marqueur carte) étaient **mappés** sur les setters non-nullables de `Evt` (`setLat(string|float)`). Le binding du formulaire écrit la valeur soumise dans l'entité **avant** la validation : si l'utilisateur ne place pas le marqueur, `lat` est vide → `null` → `setLat(null)` → `TypeError` → **500**. Conséquence : le `NotBlank` « Avez-vous bien cliqué sur le bouton pour placer le marqueur ? » ne se déclenchait jamais.

## Correctif

On reprend **exactement le pattern introduit par #1744** pour le champ `place` (`mapped => false` + écriture serveur en `POST_SUBMIT`) :

1. `lat`/`long` passent en **`mapped => false`** → le binding ne touche plus jamais le setter non-nullable (plus aucun crash possible, quelle que soit la saisie) ;
2. en **`POST_SUBMIT`**, le serveur recopie les coordonnées dans l'entité **uniquement si elles sont numériques** (`(float)`, comme `latDepart` dérivé de la commune dans #1744) ;
3. sinon, les contraintes `NotBlank`/`Type` existantes produisent l'erreur, affichée dans l'encart « Le formulaire contient des erreurs » du template (`formulaire.html.twig`, via `form.vars.errors`).

**Pas de migration** : le constructeur de `Evt` initialise déjà `lat`/`long` (valeurs par défaut du club) et `latDepart`/`longDepart`, donc les colonnes `NOT NULL` ont toujours une valeur. Le contrat non-nullable de l'entité est **préservé** — on déplace simplement l'écriture des coordonnées au bon endroit (serveur, après validation).

## Scope

Limité à `lat`/`long` (le bug exact). `latDepart`/`longDepart` ne sont pas touchés : le template les rend avec la valeur (numérique) de l'entité, ils ne sont donc pas soumis vides — pas de crash de ce côté, et c'est le périmètre de #1744.

## Tests

- **Régression** `tests/Form/EventTypeTest.php` : reproduit d'abord le crash exact (`"null" given at property path "lat"`), puis valide le comportement corrigé (form invalide + message clair, entité non corrompue) et le cas nominal (coordonnées valides → écrites dans l'entité).
- **Non-régression** : `SortieControllerTest` + `EventManagementControllerTest` → 37 tests / 109 assertions OK.
- PHPStan : 0 erreur. php-cs-fixer : 0 fichier à corriger.

## Après merge / déploiement

Marquer l'issue Sentry `CLUBALPINLYONFR-1E6` comme *resolved*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)