### PR TITLE
fix: évite un TypeError JS sur la fiche sortie pour les non-gestionnaires

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1364,13 +1364,14 @@
             const contact_message = document.getElementById('contact_message');
             const contact_reply_to = document.querySelector('input[name="reply_to_option"]');
 
-            btn1.addEventListener('click', () => {
+            // les contrôles de gestion (btn1/btn2/select) ne sont rendus qu'aux encadrants
+            btn1?.addEventListener('click', () => {
                 contact_subject.required = false;
                 contact_message.required = false;
                 contact_reply_to.required = false;
             });
 
-            btn2.addEventListener('click', (event) => {
+            btn2?.addEventListener('click', (event) => {
                 contact_subject.required = true;
                 contact_message.required = true;
                 contact_reply_to.required = true;
@@ -1417,7 +1418,7 @@
             const checkboxes = document.querySelectorAll('.contact-cb');
             const select = document.getElementById('contact_participants_type');
 
-            select.addEventListener('change', () => {
+            select?.addEventListener('change', () => {
                 // reset la sélection actuelle
                 checkboxes.forEach(checkbox => checkbox.checked = false);
 


### PR DESCRIPTION
## Problème

Sur la fiche détail d'une sortie (`sortie.html.twig`), le script inline lie des listeners sur les boutons de gestion des participants (`submit_update_participants`, `submit_contact_participants`, `contact_participants_type`) **sans vérifier leur présence**.

Ces éléments ne sont rendus qu'aux encadrants/gestionnaires (`is_granted('SORTIE_INSCRIPTIONS_MODIFICATION'/'SORTIE_CONTACT_PARTICIPANTS', event)`). Pour **tout autre visiteur** (anonyme, ou simple adhérent sur la sortie d'un autre), `btn1` est `null` → `btn1.addEventListener(...)` lève un `TypeError` qui **avorte le reste du callback `DOMContentLoaded`**.

```
TypeError: Cannot read properties of null (reading 'addEventListener')
```

Bug pré-existant, repéré en vérifiant la prod avec Chrome. La carte Leaflet et le bouton « ajouter au calendrier » sont dans d'autres blocs, non affectés — l'impact est cosmétique (console polluée) mais le code est fragile.

## Correctif

Garde chaque accès par optional chaining (`el?.addEventListener(...)`). `toggle` est déjà protégé par `{% if afficher_competences %}` côté template et JS, donc inchangé.

## Vérifications

- `php bin/console lint:twig` ✅
- Syntaxe JS du bloc validée (`node --check`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)