### PR TITLE
fix: page explicite pour un lien de paiement invalide

### DIFF
--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -44,7 +44,7 @@ class PaymentController extends AbstractController
         $signature = $request->query->get('signature', '');
 
         if ($reservationId <= 0 || $amount <= 0 || $amount > self::MAX_AMOUNT_CENTS) {
-            return new Response(sprintf('Paramètres reservation_id et amount obligatoires (entiers positifs, max %d€).', (int) (self::MAX_AMOUNT_CENTS / 100)), Response::HTTP_BAD_REQUEST);
+            return $this->invalidLinkResponse(Response::HTTP_BAD_REQUEST);
         }
 
         // Format canonique HMAC convenu avec Loxya : "{reservation_id}|{amount}" (entiers en base 10, séparés par "|").
@@ -55,7 +55,7 @@ class PaymentController extends AbstractController
                 'amount' => $amount,
             ]);
 
-            return new Response('Signature invalide.', Response::HTTP_FORBIDDEN);
+            return $this->invalidLinkResponse(Response::HTTP_FORBIDDEN);
         }
 
         // Risque résiduel assumé : la signature (reservation_id|amount) n'ayant ni timestamp ni nonce,
@@ -223,6 +223,15 @@ class PaymentController extends AbstractController
         $response->headers->set('X-Frame-Options', 'DENY');
 
         return $response;
+    }
+
+    // Page dédiée (≠ error.html.twig « réessaie ») : un lien malformé ne se répare pas en retentant.
+    private function invalidLinkResponse(int $statusCode): Response
+    {
+        $response = $this->render('payment/invalid_link.html.twig');
+        $response->setStatusCode($statusCode);
+
+        return $this->withSecurityHeaders($response);
     }
 
     // Defense in depth : on n'accepte un redirect HelloAsso que si l'URL est en HTTPS,

--- a/templates/payment/invalid_link.html.twig
+++ b/templates/payment/invalid_link.html.twig
@@ -1,0 +1,17 @@
+{% extends 'payment/base.html.twig' %}
+
+{% block title %}Lien de paiement invalide{% endblock %}
+
+{% block body %}
+    <div class="pay-icon pay-icon--warn" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1 1 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4 4 0 0 1-.128-1.287z"/>
+            <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.792.793c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243z"/>
+        </svg>
+    </div>
+    <span class="pay-badge pay-badge--warn">Lien invalide</span>
+    <h1 class="pay-title">Ce lien de paiement n'est pas valide</h1>
+    <p class="pay-lead">Ce lien semble incorrect, incomplet ou expiré — et rassure-toi, aucun paiement n'a été lancé. Vérifie que tu as bien copié le lien <strong>en entier</strong> depuis ton e-mail, ou demande un nouveau lien à l'équipe matériel.</p>
+    <a class="pay-cta" href="/">Retour sur le site</a>
+    <p class="pay-note"><a href="https://forms.clickup.com/42653954/f/18np82-775/1BKP6TIKU0RIYXCRWE" target="_blank" rel="noopener noreferrer">Signaler le problème →</a></p>
+{% endblock %}

--- a/tests/Controller/PaymentControllerTest.php
+++ b/tests/Controller/PaymentControllerTest.php
@@ -34,6 +34,8 @@ class PaymentControllerTest extends WebTestCase
         $client->request('GET', '/paiement');
 
         $this->assertResponseStatusCodeSame(400);
+        $this->assertSelectorTextContains('.pay-badge', 'Lien invalide');
+        $this->assertResponseHeaderSame('X-Frame-Options', 'DENY');
     }
 
     public function testCheckoutWithMissingAmountReturns400(): void
@@ -193,6 +195,8 @@ class PaymentControllerTest extends WebTestCase
         $client->request('GET', '/paiement?reservation_id=42&amount=3500&signature=bad-signature');
 
         $this->assertResponseStatusCodeSame(403);
+        $this->assertSelectorTextContains('.pay-badge', 'Lien invalide');
+        $this->assertResponseHeaderSame('X-Frame-Options', 'DENY');
     }
 
     public function testCheckoutRejectsSignatureWithTamperedAmount(): void


### PR DESCRIPTION
## Contexte

Le checkout de location de matériel (`GET /paiement`) répond à un lien Loxya invalide par un **texte brut** cryptique :
- `Signature invalide.` (403)
- `Paramètres reservation_id et amount obligatoires (...).` (400)

Côté membre, un lien cassé arrive surtout dans deux cas réels :
1. **Lien tronqué par la messagerie** (URL longue coupée à la copie) — corrigeable par le membre.
2. **Lien mal généré côté Loxya** (ex. signature calculée sur l'id de _request_ au lieu de l'id de réservation) — non corrigeable par le membre.

Dans les deux cas, le membre tombe sur un message technique illisible.

## Changement

- Nouvelle page **`templates/payment/invalid_link.html.twig`** : même thème que les autres écrans de paiement (`base.html.twig`), badge ambre `warn` (ce n'est pas un crash mais un lien à corriger), message qui dédramatise (« aucun paiement n'a été lancé ») et oriente vers une action utile (copier le lien complet / demander un nouveau lien). Lien « Signaler le problème » conservé pour faire remonter les liens mal générés.
- **`PaymentController`** : les deux réponses texte passent par un helper `invalidLinkResponse(int $statusCode)` qui rend la page **en conservant le status** (400/403) pour la sémantique des logs/monitoring, plus `X-Frame-Options`.
- La page est **statique** : `reservation_id`/`amount` ne sont **pas** réinjectés → aucun risque XSS.

## Tests

- `php bin/phpunit tests/Controller/PaymentControllerTest.php` → **OK (24 tests, 51 assertions)**.
- Ajout de deux assertions (`.pay-badge` = « Lien invalide ») sur les cas « sans params » et « signature invalide » pour figer le rendu de la page, pas seulement le code HTTP.

## Note

Indépendant du bug de génération de lien côté Loxya (qui doit signer le **même** id que celui injecté dans l'URL) — ce PR rend juste l'échec lisible quand il survient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)