### PR TITLE
feat: sortie à l'étranger (commune facultative, sorties repérables)

### DIFF
--- a/assets/autocomplete-communes.js
+++ b/assets/autocomplete-communes.js
@@ -226,6 +226,11 @@ function searchCommunes(context) {
             if (submitter && /eventDraftSave/.test(submitter.name || submitter.id || '')) {
                 return;
             }
+            // sortie à l'étranger : la commune de départ est facultative
+            const etrangerField = document.getElementById('event_etranger');
+            if (etrangerField && etrangerField.checked) {
+                return;
+            }
             const val = field.value.trim();
             if (val === '' || val !== selectedLabel) {
                 e.preventDefault();
@@ -242,6 +247,34 @@ function searchCommunes(context) {
     // si — et seulement si — elle correspond exactement à une commune du référentiel.
     if (field.value.trim() !== '') {
         verifyPrefilled(field.value.trim());
+    }
+
+    // sortie à l'étranger : on désactive le champ commune (facultatif) et on le vide
+    const etrangerField = document.getElementById('event_etranger');
+    if (etrangerField) {
+        const latDepart = document.getElementById('event_latDepart');
+        const longDepart = document.getElementById('event_longDepart');
+        const defaultPlaceholder = field.placeholder;
+        const syncEtranger = () => {
+            const abroad = etrangerField.checked;
+            field.disabled = abroad;
+            field.placeholder = abroad ? 'Non requis pour une sortie à l\'étranger' : defaultPlaceholder;
+            if (abroad) {
+                field.value = '';
+                selectedLabel = '';
+                closeList();
+                setFeedback('');
+                // 0 = pas de départ (sentinelle numérique, pas '')
+                if (latDepart) {
+                    latDepart.value = '0';
+                }
+                if (longDepart) {
+                    longDepart.value = '0';
+                }
+            }
+        };
+        etrangerField.addEventListener('change', syncEtranger);
+        syncEtranger();
     }
 }
 

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -88,6 +88,7 @@ a .notification, a:hover .notification{text-decoration:none;}
 select.type1{border-color:#eaeaea; padding-top:5px; padding-bottom:6px;}
 .type2{font-family:Verdana; color:black; background-color:#e6e6e6; border:none; box-shadow:inset 0 0 5px 0 #b4b2b2;padding:8px 5px; width:180px; font-weight:100; margin:3px 3px 3px 0;}
 .type2:focus{background-color:#ccff99; outline:0;}
+.type2:disabled{background-color:#ededed; color:#a0a0a0; box-shadow:none; cursor:not-allowed; opacity:.7;}
 .type1::placeholder, .type2::placeholder{color: #666; opacity: 1}
 .userlink{font-weight:inherit;}
 .userlink:hover, .userlink:focus {text-decoration:underline;}

--- a/migrations/Version20260606101500.php
+++ b/migrations/Version20260606101500.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260606101500 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return "Sorties : ajoute l'indicateur « sortie à l'étranger » (commune de départ facultative)";
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE caf_evt ADD is_etranger TINYINT(1) DEFAULT 0 NOT NULL COMMENT 'Sortie à l''étranger : commune de départ non requise'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_evt DROP is_etranger');
+    }
+}

--- a/src/Controller/SortieController.php
+++ b/src/Controller/SortieController.php
@@ -155,6 +155,7 @@ class SortieController extends AbstractController
             $originalEntityData['long'] = (float) $event->getLong();
             $originalEntityData['latDepart'] = (float) $event->getLatDepart();
             $originalEntityData['longDepart'] = (float) $event->getLongDepart();
+            $originalEntityData['etranger'] = $event->isEtranger();
         }
 
         $form = $this->createForm(EventType::class, $event, ['is_edit' => $isUpdate, 'editoLineLink' => $this->editoLineLink, 'imageRightLink' => $this->imageRightLink, 'user' => $user]);
@@ -286,6 +287,7 @@ class SortieController extends AbstractController
                         || $originalEntityData['paymentAmount'] !== $event->getPaymentAmount()
                         || $originalEntityData['encadrants'] !== $newEncadrants['encadrants']
                         || $originalEntityData['initiateurs'] !== $newEncadrants['initiateurs']
+                        || $originalEntityData['etranger'] !== $event->isEtranger()
                     )
                 ) {
                     $event->setStatus(Evt::STATUS_PUBLISHED_UNSEEN);
@@ -315,7 +317,10 @@ class SortieController extends AbstractController
                 || (float) $event->getLatDepart() !== $originalEntityData['latDepart']
                 || (float) $event->getLongDepart() !== $originalEntityData['longDepart'];
 
-            if ($coordsChanged || !$event->getNbKm()) {
+            if ($event->isEtranger()) {
+                // à l'étranger : pas de commune de départ, donc pas de bilan carbone
+                $event->setNbKm(null);
+            } elseif ($coordsChanged || !$event->getNbKm()) {
                 $nbKm = $distanceHelper->calculate($event);
                 // Conserver l'ancienne distance si l'appel OSRM échoue (retourne 0)
                 if ($nbKm > 0 || !$isUpdate) {
@@ -994,6 +999,7 @@ class SortieController extends AbstractController
         $newEvent->setIsDraft(true);
         $newEvent->setLatDepart($event->getLatDepart());
         $newEvent->setLongDepart($event->getLongDepart());
+        $newEvent->setEtranger($event->isEtranger());
         $newEvent->setNbVehicules($event->getNbVehicules());
         $newEvent->setModeTransport($event->getModeTransport());
         $newEvent->setNbKm($event->getNbKm());

--- a/src/Entity/Evt.php
+++ b/src/Entity/Evt.php
@@ -64,6 +64,9 @@ class Evt
     #[ORM\Column(name: 'is_draft', type: 'boolean', nullable: false, options: ['default' => true])]
     private bool $isDraft = true;
 
+    #[ORM\Column(name: 'is_etranger', type: 'boolean', nullable: false, options: ['default' => false, 'comment' => 'Sortie à l\'étranger : commune de départ non requise'])]
+    private bool $etranger = false;
+
     #[ORM\ManyToOne(targetEntity: 'User')]
     #[ORM\JoinColumn(name: 'status_who_evt', referencedColumnName: 'id_user', nullable: true)]
     private ?User $statusWho;
@@ -316,6 +319,7 @@ class Evt
         $this->articles = new ArrayCollection();
         $this->expenseReports = new ArrayCollection();
         $this->isDraft = false;
+        $this->etranger = false;
         $this->unrecognizedPayers = new ArrayCollection();
         $this->setCreatedAt(new \DateTime());
         $this->setUpdatedAt(new \DateTime());
@@ -883,6 +887,18 @@ class Evt
     public function setIsDraft(bool $isDraft): self
     {
         $this->isDraft = $isDraft;
+
+        return $this;
+    }
+
+    public function isEtranger(): bool
+    {
+        return $this->etranger;
+    }
+
+    public function setEtranger(bool $etranger): self
+    {
+        $this->etranger = $etranger;
 
         return $this;
     }

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -123,10 +123,17 @@ class EventType extends AbstractType
                     ]),
                 ],
             ])
+            ->add('etranger', CheckboxType::class, [
+                'label' => 'Sortie à l\'étranger',
+                'required' => false,
+                'help' => 'Cochez si le départ de l\'activité est hors de France.',
+                'help_attr' => [
+                    'class' => 'mini',
+                ],
+            ])
             ->add('place', TextType::class, [
-                'label' => 'Lieu de départ de l\'activité encadrée <span class="revalidation">*</span>',
-                'label_html' => true,
-                'required' => true,
+                'label' => 'Commune de départ',
+                'required' => false,
                 'attr' => [
                     'placeholder' => 'ex : 69510 Messimy, 74400 Chamonix',
                     'class' => 'type2 wide',
@@ -499,19 +506,32 @@ class EventType extends AbstractType
             ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
                 $form = $event->getForm();
 
-                // lieu de départ : obligatoire et contraint au référentiel des communes,
-                // y compris en édition. Le serveur est l'autorité : il re-matche le libellé
-                // saisi et dérive lui-même latDepart/longDepart (le JS ne remplit plus ces
-                // coordonnées). Seuls les brouillons (incomplets par nature) en sont dispensés.
+                // commune de départ : le serveur re-matche le libellé et dérive latDepart/longDepart.
+                // Dispensés de la commune : brouillons et sorties à l'étranger.
                 $isDraftSave = $form->has('eventDraftSave') && $form->get('eventDraftSave')->isClicked();
+                $estEtranger = true === $form->get('etranger')->getData();
                 $placeField = $form->get('place');
                 $place = trim((string) $placeField->getData());
 
                 if ($isDraftSave) {
-                    // brouillon : on laisse s'enregistrer en l'état
+                    // brouillon : incomplet par nature
+                } elseif ($estEtranger) {
+                    // commune facultative ; on refuse une commune saisie en même temps
+                    // (incohérence) et on efface un départ résiduel (bascule FR→étranger).
+                    if ('' !== $place) {
+                        $placeField->addError(new FormError(
+                            'Une sortie à l\'étranger ne doit pas indiquer de commune de départ française. Décochez « Sortie à l\'étranger » ou videz la commune.'
+                        ));
+                    } else {
+                        /** @var Evt $evt */
+                        $evt = $form->getData();
+                        $evt->setPlace('');
+                        $evt->setLatDepart(0.0);
+                        $evt->setLongDepart(0.0);
+                    }
                 } elseif ('' === $place) {
                     $placeField->addError(new FormError(
-                        'Le lieu de départ est obligatoire, choisissez une commune dans la liste.'
+                        'La commune de départ est obligatoire, choisissez une commune dans la liste.'
                     ));
                 } else {
                     $commune = $this->communeRepository->findOneByLabel($place);

--- a/templates/macros/event-line.html.twig
+++ b/templates/macros/event-line.html.twig
@@ -92,6 +92,7 @@
                     <h2 class="tw-flex tw-items-center tw-gap-2">
                         {% if event.cancelled %}<span style="padding:1px 3px; color:red; font-family:Arial;white-space: nowrap;">ANNULÉE - </span>{% endif %}
                         {{ event.titre }}
+                        {% if event.etranger %}<span class="tw-inline-flex tw-items-center tw-gap-1 tw-text-xs tw-font-medium tw-text-gray-600 tw-whitespace-nowrap" title="Sortie à l'étranger : commune de départ facultative, bilan carbone non calculé">🌍 Étranger</span>{% endif %}
 
                         {% set participation = event.participation(user) %}
                         {% if participation and display_participation_status %}

--- a/templates/sortie/agenda-evt-debut.html.twig
+++ b/templates/sortie/agenda-evt-debut.html.twig
@@ -33,6 +33,9 @@
             {% if event.place %}
                 - <b>{{ event.place }}</b>
             {% endif %}
+            {% if event.etranger %}
+                - <b>🌍 À l'étranger</b>
+            {% endif %}
             {% if my_status %}
                 - Votre rôle : <b>{{ my_status.role }}</b>
             {% endif %}

--- a/templates/sortie/formulaire.html.twig
+++ b/templates/sortie/formulaire.html.twig
@@ -87,6 +87,13 @@
                 <ul id="place_suggestions"></ul>
             </div>
             <small id="place_feedback" class="place-feedback"></small>
+            <div>
+                <label for="{{ form.etranger.vars.id }}" class="{% if form.etranger.vars.data %}up{% else %}down{% endif %}">
+                    {{ form_widget(form.etranger) }}
+                    {{ field_label(form.etranger) }}
+                </label>
+                {{ form_help(form.etranger) }}
+            </div>
             {{ form_row(form.latDepart) }}
             {{ form_row(form.longDepart) }}
         </div>

--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1043,6 +1043,16 @@
                         </a>
                     </div>
                 </div>
+            {% elseif event.etranger %}
+                <div style="background: #f0f7f0; border-left: 4px solid #4a9c5b; border-radius: 4px; padding: 12px 16px; margin: 12px 0;">
+                    <div style="display: flex; align-items: center; gap: 8px;">
+                        <span style="font-size: 1.3em;">🌍</span>
+                        <b style="color: #2d6a3f;">Sortie à l'étranger</b>
+                    </div>
+                    <div style="color: #444; font-size: 0.95em; margin-top: 4px;">
+                        Le départ étant hors de France, l'empreinte carbone du transport n'est pas calculée.
+                    </div>
+                </div>
             {% endif %}
 
             <ul class="nice-list">

--- a/tests/Form/EventTypeTest.php
+++ b/tests/Form/EventTypeTest.php
@@ -53,4 +53,61 @@ class EventTypeTest extends WebTestCase
         self::assertSame(46.12345678, (float) $event->getLat());
         self::assertSame(6.87654321, (float) $event->getLong());
     }
+
+    public function testEmptyCommuneIsRejectedWhenNotAbroad(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        $form = $this->buildForm($event, $user);
+
+        // case décochée : un navigateur n'envoie pas le champ
+        $form->submit(['place' => '', 'lat' => '45.7', 'long' => '4.8'], false);
+
+        self::assertFalse($event->isEtranger());
+        self::assertStringContainsString('commune de départ est obligatoire', strtolower((string) $form->getErrors(true)));
+    }
+
+    public function testAbroadMakesCommuneOptional(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        $form = $this->buildForm($event, $user);
+
+        $form->submit(['etranger' => '1', 'place' => '', 'lat' => '45.7', 'long' => '4.8'], false);
+
+        self::assertTrue($event->isEtranger());
+        self::assertStringNotContainsString('commune de départ est obligatoire', strtolower((string) $form->getErrors(true)));
+    }
+
+    public function testAbroadWithFrenchCommuneIsRejected(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        $form = $this->buildForm($event, $user);
+
+        // case cochée + commune renseignée : incohérence, on refuse (il faut choisir l'un ou l'autre)
+        $form->submit(['etranger' => '1', 'place' => '69510 Messimy', 'lat' => '45.7', 'long' => '4.8'], false);
+
+        self::assertTrue($event->isEtranger());
+        self::assertStringContainsString('ne doit pas indiquer de commune', strtolower((string) $form->getErrors(true)));
+    }
+
+    public function testAbroadClearsResidualFrenchDeparture(): void
+    {
+        $user = $this->signup();
+        $event = $this->newEvent($user);
+        // sortie initialement française : commune + coordonnées de départ renseignées
+        $event->setPlace('69510 Messimy');
+        $event->setLatDepart(45.78);
+        $event->setLongDepart(4.66);
+        $form = $this->buildForm($event, $user);
+
+        // bascule en étranger sans commune : le point de départ français résiduel doit être effacé
+        $form->submit(['etranger' => '1', 'place' => '', 'lat' => '45.7', 'long' => '4.8'], false);
+
+        self::assertTrue($event->isEtranger());
+        self::assertSame('', $event->getPlace());
+        self::assertSame(0.0, (float) $event->getLatDepart());
+        self::assertSame(0.0, (float) $event->getLongDepart());
+    }
 }


### PR DESCRIPTION
## Objectif

Permettre de déposer une sortie dont le **départ est à l'étranger**, sans bloquer sur la commune de départ (désormais verrouillée sur le référentiel français des communes), tout en gardant ces sorties **repérables** et en préservant la **fiabilité du bilan carbone**.

## Comportement

1. **Commune obligatoire par défaut.** Inchangé : une sortie en France exige une commune du référentiel.
2. **Case « Sortie à l'étranger ».** Si cochée, la commune de départ devient facultative et le bilan carbone n'est pas calculé (pas de point de départ référencé → `nbKm` nul → coût carbone vidé).
3. **Facilement identifiables :**
   - fiche publique : un bloc explicite « 🌍 Sortie à l'étranger » remplace le bilan carbone ;
   - listes de gestion / profil : badge « 🌍 Étranger » à côté du titre (macro `event-line`), visible notamment dans la file de validation des gestionnaires ;
   - agenda : marqueur « 🌍 À l'étranger ».
4. **Fiabilité du bilan carbone** — l'usage de la case reste clair et cohérent :
   - la mention « à l'étranger » est affichée sur la sortie et dans les listes → information transparente pour tous (participants, encadrants, gestionnaires) ;
   - **cohérence serveur** : une commune française renseignée **en même temps** que la case est refusée (il faut choisir l'un ou l'autre) ; la commune et les coordonnées de départ sont vidées quand la case est cochée (pas de point de départ français résiduel) ;
   - **UX JS** : le champ commune est masqué quand la case est cochée ;
   - **libellé d'aide** rappelant l'usage attendu.

## Détails techniques

- Nouveau champ `Evt::$etranger` + migration `Version20260606101500` (`caf_evt.is_etranger`).
- `EventType` : case à cocher, commune non requise, validation `POST_SUBMIT` revue (brouillon → étranger → commune requise/résolue) ; en étranger, `place`/`latDepart`/`longDepart` remis à vide.
- `SortieController` : si étranger, `nbKm = null` → `CarbonCostHelper::updateForEvent` vide le coût carbone. La bascule du flag dépublie une sortie validée (revalidation).
- `autocomplete-communes.js` : dispense de validation, masquage du champ commune et neutralisation des coordonnées cachées.

## Tests

- `tests/Form/EventTypeTest.php` : commune obligatoire hors étranger, commune facultative si étranger, refus commune française + case cochée, nettoyage du point de départ résiduel en bascule FR→étranger.
- `EventTypeTest` : ✅ OK (6 tests, 16 assertions).
- `SortieControllerTest` : ✅ OK (37 tests, 109 assertions).
- `lint:twig` sur les 3 templates modifiés : ✅ OK.

> Note : l'entrée de changelog public correspondante a été ajoutée au brouillon `docs/changelog-ajouts-avril-juin-2026.md` (fichier de travail non suivi), volontairement hors de ce commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)