### PR TITLE
fix: précise que c'est le départ de l'activité qui est hors de France (bilan carbone)

### DIFF
--- a/templates/sortie/sortie.html.twig
+++ b/templates/sortie/sortie.html.twig
@@ -1050,7 +1050,7 @@
                         <b style="color: #2d6a3f;">Sortie à l'étranger</b>
                     </div>
                     <div style="color: #444; font-size: 0.95em; margin-top: 4px;">
-                        Le départ étant hors de France, l'empreinte carbone du transport n'est pas calculée.
+                        Le départ de l'activité étant hors de France, l'empreinte carbone du transport n'est pas calculée.
                     </div>
                 </div>
             {% endif %}


### PR DESCRIPTION
## Problème

Dans l'encart bilan carbone d'une sortie à l'étranger, le message indiquait :

> Le départ étant hors de France, l'empreinte carbone du transport n'est pas calculée.

La formulation « le départ » était ambiguë : ce n'est pas le départ (au sens du point de RDV) qui est hors de France, mais **le départ de l'activité**.

## Correction

`templates/sortie/sortie.html.twig` :

> Le départ **de l'activité** étant hors de France, l'empreinte carbone du transport n'est pas calculée.

Formulation alignée sur le libellé du champ dans le formulaire (`EventType.php` : « Cochez si le départ de l'activité est hors de France »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)