### PR TITLE
fix(brevets): afficher les brevets Moniteur (BFM) manquants par commission

### DIFF
--- a/src/Service/FfcamSkillsService.php
+++ b/src/Service/FfcamSkillsService.php
@@ -39,7 +39,7 @@ class FfcamSkillsService
             'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
             'snowboard-alpin' => ['BF3-SN-NA', 'BRV-BFSU10', 'BRV-BFST10'],
             'marche-nordique' => ['BRV-QFMN10'],
-            'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BF2-SN-SWA', 'BF1-SN-SW'],
+            'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BFM-SN-SWL', 'BF2-SN-SWA', 'BF1-SN-SW'],
             'canyon' => ['BF3-CA-CA', 'BFM-CA-CA', 'BF1-CA-CA'],
             'escalade' => ['BF3-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
             'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF2-SN-RQ'],

--- a/src/Service/FfcamSkillsService.php
+++ b/src/Service/FfcamSkillsService.php
@@ -35,15 +35,15 @@ class FfcamSkillsService
         }
 
         return match ($commission->getCode()) {
-            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BF2-RA-RAL', 'BF1-RA-RM'],
-            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
+            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'],
+            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
             'snowboard-alpin' => ['BF3-SN-NA', 'BRV-BFSU10', 'BRV-BFST10'],
             'marche-nordique' => ['BRV-QFMN10'],
             'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BFM-SN-SWL', 'BF2-SN-SWA', 'BF1-SN-SW'],
             'canyon' => ['BF3-CA-CA', 'BFM-CA-CA', 'BF1-CA-CA'],
-            'escalade' => ['BF3-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
-            'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF2-SN-RQ'],
-            'ski-de-randonnee' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SA', 'BF2-SN-SA', 'BF1-SN-SR'],
+            'escalade' => ['BF3-ES-ES', 'BFM-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
+            'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BFM-SN-RN', 'BF2-SN-RQ'],
+            'ski-de-randonnee' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SA', 'BFM-SN-SR', 'BF2-SN-SA', 'BF1-SN-SR'],
             'ski-de-piste' => ['BF3-SN-NA', 'BRV-BFSA10', 'BRV-BFST10'],
             'ski-de-fond' => ['BRV-BFSF13', 'BRV-BFSF10'],
             'trail' => ['BF3-RA-TR', 'BF1-RA-TR'],

--- a/tests/Service/FfcamSkillsServiceTest.php
+++ b/tests/Service/FfcamSkillsServiceTest.php
@@ -67,7 +67,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Randonnée', 'randonnee', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BF2-RA-RAL', 'BF1-RA-RM'];
+        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -76,7 +76,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Alpinisme', 'alpinisme', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
+        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -86,7 +86,7 @@ class FfcamSkillsServiceTest extends TestCase
         $brevets = $this->service->getBrevets($commission);
 
         $this->assertIsArray($brevets);
-        $this->assertCount(11, $brevets);
+        $this->assertCount(12, $brevets);
         $this->assertContains('BF3-ES-ES', $brevets);
         $this->assertContains('BF1-ES-SAE', $brevets);
     }


### PR DESCRIPTION
## Problème

Plusieurs brevets **Moniteur (BFM)** — détenus par des membres et déjà présents en base (`formation_referentiel_brevet` + liés dans `formation_commission_brevet`) — ne s'affichaient pas sur `/commissions/{id}/brevets`.

La liste des brevets par commission est **codée en dur** dans `FfcamSkillsService::getBrevets()` (la page n'utilise pas la table `formation_commission_brevet`, pourtant mappée par l'entité `Commission`). Les codes manquants devaient simplement y être ajoutés.

## Brevets ajoutés

| Commission | Code | Détenteurs |
|---|---|---|
| snowboard-rando | `BFM-SN-SWL` | 1 |
| escalade | `BFM-ES-ES` | 8 |
| alpinisme | `BFM-AL-GVE` | 1 |
| randonnee | `BFM-RA-RA` | 4 |
| raquette | `BFM-SN-RN` | 4 |
| ski-de-randonnee | `BFM-SN-SR` | 3 |

Intitulés et dates s'affichent automatiquement via le référentiel et les validations déjà en base.

## ⚠️ Distinction importante : « snowboard alpin » ≠ « snowboard alpinisme »

Le suffixe `SWA` (« Snowboard alpinisme ») relève de **snowboard-rando**, pas de la commission **snowboard-alpin**. `BF2-SN-SWA` / `BF3-SN-SWA` figurent donc déjà à juste titre dans `snowboard-rando` et **ne sont pas** déplacés vers snowboard-alpin.

## Hors périmètre (suivi séparé)

- **Bug de mapping côté scraper** : `BF\d?-SN-SWA → snowboard-alpin` et `BF\d?-SN-SA → ski-de-piste` sont erronés (« snowboard alpinisme » → snowboard-rando ; « ski alpinisme » → ski-de-randonnee). À corriger dans le repo `ffcam-formations-scraper`.
- **Liste hardcodée** : à terme, brancher le contrôleur sur `$commission->getBrevets()` (table alimentée par le scraper) supprimerait ce hardcode.
- **Backlog legacy `BRV-*`** : ~40 codes détenus par des membres (certains 40–55 détenteurs) ne sont mappés nulle part et restent invisibles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)