### PR TITLE
fix(sync): empêche la collision de cafnum à la fusion (look-before-write)

### DIFF
--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -46,8 +46,7 @@ class FfcamSynchronizer
         $this->archiveFile($ffcamFilePath, $stats);
         $this->logResults($ffcamFilePath, $stats);
 
-        // Si la synchro a été interrompue (EntityManager fermé), on ne bloque pas les
-        // comptes : sinon on dégraderait des adhérents que la synchro n'a pas pu traiter.
+        // Synchro interrompue : ne pas bloquer les comptes, on dégraderait des adhérents non traités.
         if (empty($stats['aborted'])) {
             $stats['blocked'] = $this->userRepository->blockExpiredAccounts($licenseExpirationDate);
             $stats['filiations_removed'] = $this->userRepository->removeExpiredFiliations();
@@ -125,11 +124,9 @@ class FfcamSynchronizer
                         $parsedUser->getCafnum()
                     ));
 
-                    // Look-before-write : si une fiche vivante détient déjà le cafnum du
-                    // fichier, la fusion réécrirait ce cafnum -> violation d'unicité (qui
-                    // fermait l'EntityManager et cassait toute la suite du fichier). On
-                    // consolide en parquant cette fiche en double, sauf si elle porte un
-                    // compte : dans ce cas (ambigu) on ne détruit rien, on alerte.
+                    // Si une fiche vivante détient déjà ce cafnum, la fusion le réécrirait
+                    // -> violation d'unicité (qui fermait l'EM). On consolide, sauf si la
+                    // fiche en double porte un compte (ambigu) : on alerte sans rien détruire.
                     if ($existingUser instanceof User) {
                         if (!empty($existingUser->getPassword())) {
                             $errorMessage = sprintf(
@@ -147,6 +144,7 @@ class FfcamSynchronizer
                                 'message' => $errorMessage,
                             ];
 
+                            $this->entityManager->clear();
                             continue;
                         }
 
@@ -222,6 +220,10 @@ class FfcamSynchronizer
                     $this->logger->error('Flush error: ' . $exception->getMessage());
                     \Sentry\captureException($exception);
                     ++$stats['errors'];
+                    $stats['error_details'][] = [
+                        'cafnum' => $parsedUser->getCafnum(),
+                        'message' => $exception->getMessage(),
+                    ];
 
                     if ($this->abortIfManagerClosed($stats)) {
                         break;
@@ -260,13 +262,9 @@ class FfcamSynchronizer
         return $stats;
     }
 
-    /**
-     * Fail-safe : un flush en échec ferme l'EntityManager. Continuer corromprait le
-     * statut des adhérents suivants (cascade « EntityManager is closed »). On marque
-     * alors la synchro comme interrompue pour arrêter la boucle proprement plutôt que
-     * de poursuivre sur un manager mort. Le look-before-write couvre le cas connu
-     * (collision de cafnum) ; ceci ne se déclenche que sur un échec inattendu.
-     */
+    // Si un flush a fermé l'EntityManager, poursuivre cascaderait sur les adhérents
+    // suivants : on interrompt la routine plutôt que de continuer sur un manager mort.
+    // Ne se déclenche que sur un échec inattendu (le look-before-write couvre le cas connu).
     private function abortIfManagerClosed(array &$stats): bool
     {
         if ($this->entityManager->isOpen()) {

--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -7,21 +7,32 @@ use App\Repository\UserRepository;
 use App\Utils\MemberMerger;
 use App\Utils\NicknameGenerator;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 
 class FfcamSynchronizer
 {
     private bool $hasTolerancyPeriodPassed;
 
+    // Reconstruits par recoverEntityManager() si un flush ferme l'EntityManager.
+    private EntityManagerInterface $entityManager;
+    private UserRepository $userRepository;
+    private MemberMerger $memberMerger;
+
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly UserRepository $userRepository,
+        EntityManagerInterface $entityManager,
+        UserRepository $userRepository,
         private readonly FfcamFileParser $fileParser,
-        private readonly MemberMerger $memberMerger,
+        MemberMerger $memberMerger,
         private readonly UserLicenseHelper $userLicenseHelper,
+        private readonly ManagerRegistry $managerRegistry,
         private readonly ?FfcamSyncReportMailer $syncReportMailer = null,
     ) {
+        $this->entityManager = $entityManager;
+        $this->userRepository = $userRepository;
+        $this->memberMerger = $memberMerger;
+
         $today = new \DateTime();
         $endDate = new \DateTime($today->format('Y') . '-' . UserLicenseHelper::LICENSE_TOLERANCY_PERIOD_END);
 
@@ -193,8 +204,7 @@ class FfcamSynchronizer
                     $this->logger->error('Flush error: ' . $exception->getMessage());
                     ++$stats['errors'];
 
-                    // Clear l'entity manager pour continuer le traitement
-                    $this->entityManager->clear();
+                    $this->recoverEntityManager();
                 }
             } catch (\Exception $exception) {
                 $cafnum = $parsedUser->getCafnum() ?? 'inconnu';
@@ -214,12 +224,38 @@ class FfcamSynchronizer
                     'message' => $errorMessage,
                 ];
 
+                $this->recoverEntityManager();
+
                 // Continue avec le prochain membre
                 continue;
             }
         }
 
         return $stats;
+    }
+
+    /**
+     * Un flush en échec ferme l'EntityManager : sans réinitialisation, tous les
+     * adhérents traités ensuite échoueraient en cascade (« The EntityManager is
+     * closed »). On rouvre alors un EntityManager neuf et on reconstruit les
+     * dépendances qui lui étaient liées (repository, merger).
+     */
+    private function recoverEntityManager(): void
+    {
+        if ($this->entityManager->isOpen()) {
+            $this->entityManager->clear();
+
+            return;
+        }
+
+        $this->managerRegistry->resetManager();
+
+        $manager = $this->managerRegistry->getManager();
+        \assert($manager instanceof EntityManagerInterface);
+
+        $this->entityManager = $manager;
+        $this->userRepository = new UserRepository($this->managerRegistry);
+        $this->memberMerger = new MemberMerger($this->userRepository, $this->entityManager);
     }
 
     private function updateExistingUser(User $existingUser, User $parsedUser): void

--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -7,32 +7,21 @@ use App\Repository\UserRepository;
 use App\Utils\MemberMerger;
 use App\Utils\NicknameGenerator;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
 
 class FfcamSynchronizer
 {
     private bool $hasTolerancyPeriodPassed;
 
-    // Reconstruits par recoverEntityManager() si un flush ferme l'EntityManager.
-    private EntityManagerInterface $entityManager;
-    private UserRepository $userRepository;
-    private MemberMerger $memberMerger;
-
     public function __construct(
         private readonly LoggerInterface $logger,
-        EntityManagerInterface $entityManager,
-        UserRepository $userRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly UserRepository $userRepository,
         private readonly FfcamFileParser $fileParser,
-        MemberMerger $memberMerger,
+        private readonly MemberMerger $memberMerger,
         private readonly UserLicenseHelper $userLicenseHelper,
-        private readonly ManagerRegistry $managerRegistry,
         private readonly ?FfcamSyncReportMailer $syncReportMailer = null,
     ) {
-        $this->entityManager = $entityManager;
-        $this->userRepository = $userRepository;
-        $this->memberMerger = $memberMerger;
-
         $today = new \DateTime();
         $endDate = new \DateTime($today->format('Y') . '-' . UserLicenseHelper::LICENSE_TOLERANCY_PERIOD_END);
 
@@ -57,11 +46,12 @@ class FfcamSynchronizer
         $this->archiveFile($ffcamFilePath, $stats);
         $this->logResults($ffcamFilePath, $stats);
 
-        $blockedCount = $this->userRepository->blockExpiredAccounts($licenseExpirationDate);
-        $filiationsRemoved = $this->userRepository->removeExpiredFiliations();
-
-        $stats['blocked'] = $blockedCount;
-        $stats['filiations_removed'] = $filiationsRemoved;
+        // Si la synchro a été interrompue (EntityManager fermé), on ne bloque pas les
+        // comptes : sinon on dégraderait des adhérents que la synchro n'a pas pu traiter.
+        if (empty($stats['aborted'])) {
+            $stats['blocked'] = $this->userRepository->blockExpiredAccounts($licenseExpirationDate);
+            $stats['filiations_removed'] = $this->userRepository->removeExpiredFiliations();
+        }
 
         $endTime = new \DateTime();
 
@@ -135,7 +125,35 @@ class FfcamSynchronizer
                         $parsedUser->getCafnum()
                     ));
 
-                    $this->memberMerger->mergeNewMember($oldCafNum, $parsedUser);
+                    // Look-before-write : si une fiche vivante détient déjà le cafnum du
+                    // fichier, la fusion réécrirait ce cafnum -> violation d'unicité (qui
+                    // fermait l'EntityManager et cassait toute la suite du fichier). On
+                    // consolide en parquant cette fiche en double, sauf si elle porte un
+                    // compte : dans ce cas (ambigu) on ne détruit rien, on alerte.
+                    if ($existingUser instanceof User) {
+                        if (!empty($existingUser->getPassword())) {
+                            $errorMessage = sprintf(
+                                'Doublon ambigu %s %s : deux fiches avec compte (cafnum fichier %s, cafnum existant %s) — non fusionné automatiquement',
+                                $parsedUser->getFirstname(),
+                                $parsedUser->getLastname(),
+                                $parsedUser->getCafnum(),
+                                $oldCafNum
+                            );
+                            $this->logger->error($errorMessage);
+                            \Sentry\captureMessage($errorMessage);
+                            ++$stats['errors'];
+                            $stats['error_details'][] = [
+                                'cafnum' => $parsedUser->getCafnum(),
+                                'message' => $errorMessage,
+                            ];
+
+                            continue;
+                        }
+
+                        $this->memberMerger->consolidateDuplicate($existingUser, $oldCafNum, $parsedUser);
+                    } else {
+                        $this->memberMerger->mergeNewMember($oldCafNum, $parsedUser);
+                    }
                     ++$stats['merged'];
 
                     // Stocker les détails de la fusion (tous pour debug)
@@ -202,9 +220,14 @@ class FfcamSynchronizer
                     $this->entityManager->clear();
                 } catch (\Exception $exception) {
                     $this->logger->error('Flush error: ' . $exception->getMessage());
+                    \Sentry\captureException($exception);
                     ++$stats['errors'];
 
-                    $this->recoverEntityManager();
+                    if ($this->abortIfManagerClosed($stats)) {
+                        break;
+                    }
+
+                    $this->entityManager->clear();
                 }
             } catch (\Exception $exception) {
                 $cafnum = $parsedUser->getCafnum() ?? 'inconnu';
@@ -215,6 +238,7 @@ class FfcamSynchronizer
                     $cafnum,
                     $errorMessage
                 ));
+                \Sentry\captureException($exception);
 
                 ++$stats['errors'];
 
@@ -224,7 +248,9 @@ class FfcamSynchronizer
                     'message' => $errorMessage,
                 ];
 
-                $this->recoverEntityManager();
+                if ($this->abortIfManagerClosed($stats)) {
+                    break;
+                }
 
                 // Continue avec le prochain membre
                 continue;
@@ -235,27 +261,22 @@ class FfcamSynchronizer
     }
 
     /**
-     * Un flush en échec ferme l'EntityManager : sans réinitialisation, tous les
-     * adhérents traités ensuite échoueraient en cascade (« The EntityManager is
-     * closed »). On rouvre alors un EntityManager neuf et on reconstruit les
-     * dépendances qui lui étaient liées (repository, merger).
+     * Fail-safe : un flush en échec ferme l'EntityManager. Continuer corromprait le
+     * statut des adhérents suivants (cascade « EntityManager is closed »). On marque
+     * alors la synchro comme interrompue pour arrêter la boucle proprement plutôt que
+     * de poursuivre sur un manager mort. Le look-before-write couvre le cas connu
+     * (collision de cafnum) ; ceci ne se déclenche que sur un échec inattendu.
      */
-    private function recoverEntityManager(): void
+    private function abortIfManagerClosed(array &$stats): bool
     {
         if ($this->entityManager->isOpen()) {
-            $this->entityManager->clear();
-
-            return;
+            return false;
         }
 
-        $this->managerRegistry->resetManager();
+        $this->logger->critical('EntityManager fermé pendant la synchro FFCAM : routine interrompue.');
+        $stats['aborted'] = true;
 
-        $manager = $this->managerRegistry->getManager();
-        \assert($manager instanceof EntityManagerInterface);
-
-        $this->entityManager = $manager;
-        $this->userRepository = new UserRepository($this->managerRegistry);
-        $this->memberMerger = new MemberMerger($this->userRepository, $this->entityManager);
+        return true;
     }
 
     private function updateExistingUser(User $existingUser, User $parsedUser): void

--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -85,6 +85,39 @@ class MemberMerger
         }
     }
 
+    /**
+     * Consolide un doublon détecté pendant la synchro : la personne possède deux fiches
+     * vivantes — celle au cafnum du fichier ($existingDuplicate, sans compte) et la fiche
+     * historique ($oldCafNum, qui porte le compte/l'historique). On parque la première
+     * (ce qui libère le cafnum) puis on fusionne les données du fichier sur la fiche
+     * historique, le tout dans une seule transaction.
+     */
+    public function consolidateDuplicate(User $existingDuplicate, string $oldCafNum, User $parsedUser): void
+    {
+        try {
+            $this->entityManager->beginTransaction();
+
+            $oldCafUser = $this->userRepository->findOneByLicenseNumber($oldCafNum);
+
+            if (!$oldCafUser) {
+                throw new \Exception('Unable to find an user with this cafnum ' . $oldCafNum);
+            }
+
+            $existingDuplicate
+                ->setCafnum('obs_' . $existingDuplicate->getCafnum())
+                ->setEmail('obs_' . time() . '_' . bin2hex(random_bytes(8)))
+                ->setIsDeleted(true);
+            $this->entityManager->flush();
+
+            $this->mergeUser($oldCafUser, $parsedUser);
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+        } catch (\Exception $e) {
+            $this->entityManager->rollback();
+            throw $e;
+        }
+    }
+
     private function mergeUser(User $oldCafUser, User $newCafUser): void
     {
         $oldCafUser->setFirstname($newCafUser->getFirstname())

--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -86,11 +86,9 @@ class MemberMerger
     }
 
     /**
-     * Consolide un doublon détecté pendant la synchro : la personne possède deux fiches
-     * vivantes — celle au cafnum du fichier ($existingDuplicate, sans compte) et la fiche
-     * historique ($oldCafNum, qui porte le compte/l'historique). On parque la première
-     * (ce qui libère le cafnum) puis on fusionne les données du fichier sur la fiche
-     * historique, le tout dans une seule transaction.
+     * Consolide deux fiches vivantes d'une même personne : parque la fiche au cafnum du
+     * fichier ($existingDuplicate, sans compte) pour libérer ce cafnum, puis fusionne les
+     * données du fichier sur la fiche historique ($oldCafNum). En une transaction.
      */
     public function consolidateDuplicate(User $existingDuplicate, string $oldCafNum, User $parsedUser): void
     {
@@ -103,10 +101,16 @@ class MemberMerger
                 throw new \Exception('Unable to find an user with this cafnum ' . $oldCafNum);
             }
 
-            // Rattacher les inscriptions aux sorties de la fiche en double à la fiche
-            // gardée : la fiche en double n'est pas supprimée mais parquée, ses
-            // participations resteraient sinon attachées à une fiche invisible.
-            $this->entityManager->getConnection()->executeStatement(
+            // La fiche en double est parquée (non supprimée) : on rapatrie ses inscriptions
+            // sur la fiche gardée, sans recréer un doublon (evt, user).
+            $connection = $this->entityManager->getConnection();
+            $connection->executeStatement(
+                'DELETE d FROM caf_evt_join d
+                 INNER JOIN caf_evt_join k ON k.evt_evt_join = d.evt_evt_join AND k.user_evt_join = :keep
+                 WHERE d.user_evt_join = :drop',
+                ['keep' => $oldCafUser->getId(), 'drop' => $existingDuplicate->getId()]
+            );
+            $connection->executeStatement(
                 'UPDATE caf_evt_join SET user_evt_join = :keep WHERE user_evt_join = :drop',
                 ['keep' => $oldCafUser->getId(), 'drop' => $existingDuplicate->getId()]
             );

--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -103,6 +103,14 @@ class MemberMerger
                 throw new \Exception('Unable to find an user with this cafnum ' . $oldCafNum);
             }
 
+            // Rattacher les inscriptions aux sorties de la fiche en double à la fiche
+            // gardée : la fiche en double n'est pas supprimée mais parquée, ses
+            // participations resteraient sinon attachées à une fiche invisible.
+            $this->entityManager->getConnection()->executeStatement(
+                'UPDATE caf_evt_join SET user_evt_join = :keep WHERE user_evt_join = :drop',
+                ['keep' => $oldCafUser->getId(), 'drop' => $existingDuplicate->getId()]
+            );
+
             $existingDuplicate
                 ->setCafnum('obs_' . $existingDuplicate->getCafnum())
                 ->setEmail('obs_' . time() . '_' . bin2hex(random_bytes(8)))

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -534,6 +534,28 @@ class FfcamSynchronizerTest extends WebTestCase
         $this->assertNotNull($repository->findOneByLicenseNumber($nextCafnum));
     }
 
+    public function testSynchronizeConsolidationKeepsDuplicateParticipations(): void
+    {
+        // La consolidation parque la fiche en double : ses inscriptions aux sorties
+        // doivent suivre la fiche gardée, sinon elles deviendraient invisibles.
+        [$row, , $newCafnum, $historicId] = $this->createDuplicatePair(null);
+
+        // La fiche en double a une inscription à une sortie.
+        $duplicate = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($newCafnum);
+        $duplicateId = $duplicate->getId();
+        $this->createEvent($duplicate);
+
+        $filePath = FfcamTestHelper::generateFile([$row]);
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $connection = self::getContainer()->get(EntityManagerInterface::class)->getConnection();
+        $onHistoric = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$historicId]);
+        $onDuplicate = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$duplicateId]);
+
+        $this->assertSame(1, $onHistoric, "L'inscription doit être rattachée à la fiche gardée");
+        $this->assertSame(0, $onDuplicate, "La fiche parquée ne doit plus porter d'inscription");
+    }
+
     /**
      * Crée une personne avec deux fiches vivantes : l'historique (compte + email propre)
      * et une fiche au cafnum du fichier (email masqué). $duplicatePassword contrôle si la

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -556,6 +556,39 @@ class FfcamSynchronizerTest extends WebTestCase
         $this->assertSame(0, $onDuplicate, "La fiche parquée ne doit plus porter d'inscription");
     }
 
+    public function testSynchronizeConsolidationDeduplicatesParticipations(): void
+    {
+        // Si les deux fiches sont déjà inscrites à la MÊME sortie, la consolidation ne doit
+        // pas créer de double inscription sur la fiche gardée.
+        [$row, , $newCafnum, $historicId] = $this->createDuplicatePair(null);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+        $historic = $repository->find($historicId);
+        $duplicate = $repository->findOneByLicenseNumber($newCafnum);
+        $duplicateId = $duplicate->getId();
+
+        // Une sortie où les DEUX fiches sont inscrites.
+        $event = $this->createEvent($historic);
+        $event->addParticipation($duplicate);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($event);
+        $em->flush();
+        $eventId = $event->getId();
+
+        $filePath = FfcamTestHelper::generateFile([$row]);
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $connection = $em->getConnection();
+        $onEventForHistoric = (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ? AND evt_evt_join = ?',
+            [$historicId, $eventId]
+        );
+        $onDuplicate = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$duplicateId]);
+
+        $this->assertSame(1, $onEventForHistoric, 'Pas de double inscription sur la fiche gardée');
+        $this->assertSame(0, $onDuplicate, "La fiche parquée ne porte plus d'inscription");
+    }
+
     /**
      * Crée une personne avec deux fiches vivantes : l'historique (compte + email propre)
      * et une fiche au cafnum du fichier (email masqué). $duplicatePassword contrôle si la

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -471,21 +471,18 @@ class FfcamSynchronizerTest extends WebTestCase
         $this->assertEquals($identifiant2, $user2->getCafnum());
     }
 
-    public function testSynchronizeContinuesAfterDuplicateCafnumFailures(): void
+    public function testSynchronizeConsolidatesUnmergedDuplicate(): void
     {
-        // Reproduit l'incident de juin 2026 : des adhérents « poison » (fusion qui
-        // tente de recréer un cafnum déjà pris) fermaient l'EntityManager et faisaient
-        // échouer en cascade tous les adhérents suivants. Le fichier annuel en contenait
-        // PLUSIEURS (Lagrange puis Blom) : on vérifie la reprise après plusieurs échecs.
-        [$poison1, $old1, $new1] = $this->createPoisonPair();
-        [$poison2, $old2, $new2] = $this->createPoisonPair();
+        // Incident juin 2026 : une personne avec DEUX fiches vivantes — l'historique
+        // (compte + email propre) et une fiche au cafnum du fichier (sans compte, email
+        // masqué). La fusion réécrivait un cafnum déjà pris -> violation -> EM fermé ->
+        // cascade. Désormais on consolide : la fiche en double est parquée et l'historique
+        // récupère le cafnum du fichier en conservant son compte.
+        [$row, $oldCafnum, $newCafnum, $historicId] = $this->createDuplicatePair(null);
 
         $nextCafnum = (string) rand(100000000000, 999999999999);
-
-        // Fichier : deux poisons d'affilée PUIS un nouvel adhérent qui doit être créé.
         $filePath = FfcamTestHelper::generateFile([
-            $poison1,
-            $poison2,
+            $row,
             [
                 'cafnum' => $nextCafnum,
                 'lastname' => $this->faker->lastName(),
@@ -494,35 +491,57 @@ class FfcamSynchronizerTest extends WebTestCase
             ],
         ]);
 
-        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
-        $synchronizer->synchronize($filePath);
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
 
         $repository = self::getContainer()->get(UserRepository::class);
 
-        // 1) L'adhérent traité après DEUX poisons doit avoir été créé : pas de cascade,
-        //    et la reprise survit à plusieurs échecs consécutifs.
-        $this->assertNotNull(
-            $repository->findOneByLicenseNumber($nextCafnum),
-            "L'adhérent suivant les poisons doit être créé malgré leurs échecs"
-        );
+        // Le cafnum du fichier pointe désormais sur la fiche HISTORIQUE, compte conservé.
+        $survivor = $repository->findOneByLicenseNumber($newCafnum);
+        $this->assertNotNull($survivor);
+        $this->assertSame($historicId, $survivor->getId(), 'La fiche historique doit survivre et porter le cafnum du fichier');
+        $this->assertSame('hashedpassword', $survivor->getPassword(), 'Le compte (mot de passe) doit être conservé');
 
-        // 2) Une fusion en échec ne doit pas corrompre les fiches (rollback) :
-        //    chaque fiche conserve son cafnum d'origine.
-        foreach ([[$old1, $new1], [$old2, $new2]] as [$oldCafnum, $newCafnum]) {
-            $this->assertNotNull($repository->findOneByLicenseNumber($oldCafnum), 'La fiche historique doit subsister');
-            $this->assertNotNull($repository->findOneByLicenseNumber($newCafnum), 'La fiche en double doit subsister');
-        }
+        // L'ancien cafnum n'existe plus, et l'adhérent suivant a bien été traité (pas de cascade).
+        $this->assertNull($repository->findOneByLicenseNumber($oldCafnum));
+        $this->assertNotNull($repository->findOneByLicenseNumber($nextCafnum));
+    }
+
+    public function testSynchronizeDoesNotAutoMergeWhenDuplicateHasAccount(): void
+    {
+        // Garde-fou : si la fiche au cafnum du fichier porte AUSSI un compte, on ne détruit
+        // rien automatiquement (ambigu) — on alerte et on saute, sans casser la suite.
+        [$row, $oldCafnum, $newCafnum] = $this->createDuplicatePair('hashedpassword-dup');
+
+        $nextCafnum = (string) rand(100000000000, 999999999999);
+        $filePath = FfcamTestHelper::generateFile([
+            $row,
+            [
+                'cafnum' => $nextCafnum,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => 'suivant-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr',
+            ],
+        ]);
+
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+
+        // Aucune fusion automatique : les deux fiches subsistent à leur cafnum d'origine.
+        $this->assertNotNull($repository->findOneByLicenseNumber($oldCafnum));
+        $this->assertNotNull($repository->findOneByLicenseNumber($newCafnum));
+        // La suite du fichier est quand même traitée (skip, pas de cascade).
+        $this->assertNotNull($repository->findOneByLicenseNumber($nextCafnum));
     }
 
     /**
-     * Crée une paire « poison » : une ancienne fiche (email propre) et une nouvelle
-     * fiche au même cafnum que la ligne du fichier (email déjà masqué par le
-     * dédoublonnage). Au traitement de la ligne, la fusion tente de réécrire le
-     * cafnum déjà détenu par la nouvelle fiche -> violation d'unicité.
+     * Crée une personne avec deux fiches vivantes : l'historique (compte + email propre)
+     * et une fiche au cafnum du fichier (email masqué). $duplicatePassword contrôle si la
+     * fiche en double porte un compte (pour tester le garde-fou d'ambiguïté).
      *
-     * @return array{0: array<string, string>, 1: string, 2: string} [ligne fichier, ancien cafnum, nouveau cafnum]
+     * @return array{0: array<string, string>, 1: string, 2: string, 3: int} [ligne fichier, ancien cafnum, nouveau cafnum, id historique]
      */
-    private function createPoisonPair(): array
+    private function createDuplicatePair(?string $duplicatePassword): array
     {
         $oldCafnum = (string) rand(100000000000, 999999999999);
         $newCafnum = (string) rand(100000000000, 999999999999);
@@ -530,8 +549,9 @@ class FfcamSynchronizerTest extends WebTestCase
         $firstname = $this->faker->firstName();
         $email = 'poison-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr';
 
-        $oldUser = $this->signup();
-        $oldUser
+        // Fiche historique : possède un compte (mot de passe) et l'email propre.
+        $historic = $this->signup(null, 'hashedpassword');
+        $historic
             ->setCafnum($oldCafnum)
             ->setFirstname($firstname)
             ->setLastname($lastname)
@@ -539,8 +559,9 @@ class FfcamSynchronizerTest extends WebTestCase
             ->setEmail($email)
             ->setDoitRenouveler(true);
 
-        $newUser = $this->signup();
-        $newUser
+        // Fiche en double au cafnum du fichier : email masqué, compte selon le paramètre.
+        $duplicate = $this->signup(null, $duplicatePassword);
+        $duplicate
             ->setCafnum($newCafnum)
             ->setFirstname($firstname)
             ->setLastname($lastname)
@@ -548,8 +569,8 @@ class FfcamSynchronizerTest extends WebTestCase
             ->setEmail('doublon.' . $newCafnum . '-' . $email);
 
         $em = self::getContainer()->get(EntityManagerInterface::class);
-        $em->persist($oldUser);
-        $em->persist($newUser);
+        $em->persist($historic);
+        $em->persist($duplicate);
         $em->flush();
 
         $row = [
@@ -560,6 +581,6 @@ class FfcamSynchronizerTest extends WebTestCase
             'email' => $email,
         ];
 
-        return [$row, $oldCafnum, $newCafnum];
+        return [$row, $oldCafnum, $newCafnum, $historic->getId()];
     }
 }

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -470,4 +470,96 @@ class FfcamSynchronizerTest extends WebTestCase
         // Check that user2 has not been merged (ie cafnum is not changed)
         $this->assertEquals($identifiant2, $user2->getCafnum());
     }
+
+    public function testSynchronizeContinuesAfterDuplicateCafnumFailures(): void
+    {
+        // Reproduit l'incident de juin 2026 : des adhérents « poison » (fusion qui
+        // tente de recréer un cafnum déjà pris) fermaient l'EntityManager et faisaient
+        // échouer en cascade tous les adhérents suivants. Le fichier annuel en contenait
+        // PLUSIEURS (Lagrange puis Blom) : on vérifie la reprise après plusieurs échecs.
+        [$poison1, $old1, $new1] = $this->createPoisonPair();
+        [$poison2, $old2, $new2] = $this->createPoisonPair();
+
+        $nextCafnum = (string) rand(100000000000, 999999999999);
+
+        // Fichier : deux poisons d'affilée PUIS un nouvel adhérent qui doit être créé.
+        $filePath = FfcamTestHelper::generateFile([
+            $poison1,
+            $poison2,
+            [
+                'cafnum' => $nextCafnum,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => 'suivant-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr',
+            ],
+        ]);
+
+        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
+        $synchronizer->synchronize($filePath);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+
+        // 1) L'adhérent traité après DEUX poisons doit avoir été créé : pas de cascade,
+        //    et la reprise survit à plusieurs échecs consécutifs.
+        $this->assertNotNull(
+            $repository->findOneByLicenseNumber($nextCafnum),
+            "L'adhérent suivant les poisons doit être créé malgré leurs échecs"
+        );
+
+        // 2) Une fusion en échec ne doit pas corrompre les fiches (rollback) :
+        //    chaque fiche conserve son cafnum d'origine.
+        foreach ([[$old1, $new1], [$old2, $new2]] as [$oldCafnum, $newCafnum]) {
+            $this->assertNotNull($repository->findOneByLicenseNumber($oldCafnum), 'La fiche historique doit subsister');
+            $this->assertNotNull($repository->findOneByLicenseNumber($newCafnum), 'La fiche en double doit subsister');
+        }
+    }
+
+    /**
+     * Crée une paire « poison » : une ancienne fiche (email propre) et une nouvelle
+     * fiche au même cafnum que la ligne du fichier (email déjà masqué par le
+     * dédoublonnage). Au traitement de la ligne, la fusion tente de réécrire le
+     * cafnum déjà détenu par la nouvelle fiche -> violation d'unicité.
+     *
+     * @return array{0: array<string, string>, 1: string, 2: string} [ligne fichier, ancien cafnum, nouveau cafnum]
+     */
+    private function createPoisonPair(): array
+    {
+        $oldCafnum = (string) rand(100000000000, 999999999999);
+        $newCafnum = (string) rand(100000000000, 999999999999);
+        $lastname = $this->faker->lastName();
+        $firstname = $this->faker->firstName();
+        $email = 'poison-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr';
+
+        $oldUser = $this->signup();
+        $oldUser
+            ->setCafnum($oldCafnum)
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setBirthdate(new \DateTimeImmutable('1990-01-01'))
+            ->setEmail($email)
+            ->setDoitRenouveler(true);
+
+        $newUser = $this->signup();
+        $newUser
+            ->setCafnum($newCafnum)
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setBirthdate(new \DateTimeImmutable('1990-01-01'))
+            ->setEmail('doublon.' . $newCafnum . '-' . $email);
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($oldUser);
+        $em->persist($newUser);
+        $em->flush();
+
+        $row = [
+            'cafnum' => $newCafnum,
+            'lastname' => $lastname,
+            'firstname' => $firstname,
+            'birthday' => '1990-01-01',
+            'email' => $email,
+        ];
+
+        return [$row, $oldCafnum, $newCafnum];
+    }
 }


### PR DESCRIPTION
## Problème

Depuis le 13/06/2026, la synchro FFCAM signalait ~750 « erreurs » par jour et des adhérents (dont 4 nouveaux : Berger, Desrosiers, les 2 Lafond) n'apparaissaient plus / n'étaient jamais créés.

## Cause racine (logs prod)

Quand une personne a **deux fiches vivantes** — une historique et une au cafnum du fichier (cas des renouvellements mal fusionnés) — le chemin de fusion fait `oldUser->setCafnum($cafnumDuFichier)`, **cafnum déjà détenu** par l'autre fiche → `Duplicate entry … cafnum_user` → **Doctrine ferme l'EntityManager** → tous les adhérents traités ensuite échouent en « EntityManager is closed », ne sont pas mis à jour, puis sont bloqués/invisibles. Le 18/06 : 1 vraie erreur + 738 en cascade.

## Approche (suite à la revue)

On s'attaque à la **cause**, pas au symptôme :

- **Look-before-write** : si une fiche vivante détient déjà le cafnum du fichier, on consolide via `MemberMerger::consolidateDuplicate` — on parque la fiche en double (libère le cafnum) et on fusionne les données du fichier sur la fiche **historique**, en conservant son compte et son historique. Plus de violation, donc plus de cascade.
- **Garde-fou d'ambiguïté** : si la fiche en double porte **aussi** un compte, on ne détruit rien automatiquement → alerte Sentry + skip (résolution manuelle).
- **Observabilité** : les erreurs de traitement / flush remontent à Sentry (avant, le catch global ne faisait que logger → incident invisible plusieurs jours).
- **Fail-safe** : si un flush ferme malgré tout l'EntityManager (cas inattendu), on **arrête** la routine et on **ne bloque pas** les comptes — au lieu de poursuivre sur un manager mort et de dégrader les adhérents non traités.
- DI inchangée (injection readonly).

## Effet une fois déployé

Au prochain run : les 3 doublons existants (Lagrange, Blom, Vuaille) sont **consolidés automatiquement** (leurs fiches en double n'ont pas de compte), les **4 nouveaux adhérents sont créés**, et tout le reste du fichier est re-synchronisé. Le script `docs/remediation-doublons-ffcam-2026-06.sql` n'est plus qu'un filet de secours.

## Tests

- `testSynchronizeConsolidatesUnmergedDuplicate` : la fiche historique survit, prend le cafnum du fichier, garde son compte ; l'ancien cafnum disparaît ; l'adhérent suivant est traité (pas de cascade).
- `testSynchronizeDoesNotAutoMergeWhenDuplicateHasAccount` : deux comptes → aucune fusion auto, les deux fiches subsistent, la suite est traitée.
- `FfcamSynchronizerTest` 12/41, `MemberMergerTest` 6/11, phpstan + php-cs-fixer OK.

## Suites (hors PR)

- Repenser le masquage d'email du dédoublonnage, qui empêche `findDuplicateUser` de matcher et **fabrique** ces doublons (la consolidation les rattrape désormais, mais autant ne pas les créer).
- `blockExpiredAccounts` : ne pas dégrader un adhérent présent au fichier mais non mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)