### PR TITLE
Déploiement prod : fix synchro FFCAM (cascade) + brevets BFM

### DIFF
--- a/src/Service/FfcamSkillsService.php
+++ b/src/Service/FfcamSkillsService.php
@@ -35,13 +35,13 @@ class FfcamSkillsService
         }
 
         return match ($commission->getCode()) {
-            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'],
-            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
+            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BFM-SN-RN', 'BF2-RA-RAL', 'BF1-RA-RM'],
+            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BFM-AL-EG', 'BF2-AL-GVE', 'BF2-AL-EG', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
             'snowboard-alpin' => ['BF3-SN-NA', 'BRV-BFSU10', 'BRV-BFST10'],
             'marche-nordique' => ['BRV-QFMN10'],
             'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BFM-SN-SWL', 'BF2-SN-SWA', 'BF1-SN-SW'],
             'canyon' => ['BF3-CA-CA', 'BFM-CA-CA', 'BF1-CA-CA'],
-            'escalade' => ['BF3-ES-ES', 'BFM-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
+            'escalade' => ['BF3-ES-ES', 'BFM-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BFM-AL-EG', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-EG', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
             'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BFM-SN-RN', 'BF2-SN-RQ'],
             'ski-de-randonnee' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SA', 'BFM-SN-SR', 'BF2-SN-SA', 'BF1-SN-SR'],
             'ski-de-piste' => ['BF3-SN-NA', 'BRV-BFSA10', 'BRV-BFST10'],

--- a/src/Service/FfcamSkillsService.php
+++ b/src/Service/FfcamSkillsService.php
@@ -35,15 +35,15 @@ class FfcamSkillsService
         }
 
         return match ($commission->getCode()) {
-            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BF2-RA-RAL', 'BF1-RA-RM'],
-            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
+            'randonnee' => ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'],
+            'alpinisme' => ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'],
             'snowboard-alpin' => ['BF3-SN-NA', 'BRV-BFSU10', 'BRV-BFST10'],
             'marche-nordique' => ['BRV-QFMN10'],
-            'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BF2-SN-SWA', 'BF1-SN-SW'],
+            'snowboard-rando' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SWA', 'BFM-SN-SWL', 'BF2-SN-SWA', 'BF1-SN-SW'],
             'canyon' => ['BF3-CA-CA', 'BFM-CA-CA', 'BF1-CA-CA'],
-            'escalade' => ['BF3-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
-            'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF2-SN-RQ'],
-            'ski-de-randonnee' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SA', 'BF2-SN-SA', 'BF1-SN-SR'],
+            'escalade' => ['BF3-ES-ES', 'BFM-ES-ES', 'BFM-ES-PF', 'BFM-ES-GVE', 'BFM-ES-GV', 'BF2-ES-VF', 'BF2-ES-PS', 'BF2-ES-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-ES-SNE', 'BF1-ES-SAE'],
+            'raquette' => ['BF3-SN-NA', 'BF3-FC-CO', 'BFM-SN-RN', 'BF2-SN-RQ'],
+            'ski-de-randonnee' => ['BF3-SN-NA', 'BF3-FC-CO', 'BF3-SN-SA', 'BFM-SN-SR', 'BF2-SN-SA', 'BF1-SN-SR'],
             'ski-de-piste' => ['BF3-SN-NA', 'BRV-BFSA10', 'BRV-BFST10'],
             'ski-de-fond' => ['BRV-BFSF13', 'BRV-BFSF10'],
             'trail' => ['BF3-RA-TR', 'BF1-RA-TR'],

--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -46,11 +46,11 @@ class FfcamSynchronizer
         $this->archiveFile($ffcamFilePath, $stats);
         $this->logResults($ffcamFilePath, $stats);
 
-        $blockedCount = $this->userRepository->blockExpiredAccounts($licenseExpirationDate);
-        $filiationsRemoved = $this->userRepository->removeExpiredFiliations();
-
-        $stats['blocked'] = $blockedCount;
-        $stats['filiations_removed'] = $filiationsRemoved;
+        // Synchro interrompue : ne pas bloquer les comptes, on dégraderait des adhérents non traités.
+        if (empty($stats['aborted'])) {
+            $stats['blocked'] = $this->userRepository->blockExpiredAccounts($licenseExpirationDate);
+            $stats['filiations_removed'] = $this->userRepository->removeExpiredFiliations();
+        }
 
         $endTime = new \DateTime();
 
@@ -124,7 +124,34 @@ class FfcamSynchronizer
                         $parsedUser->getCafnum()
                     ));
 
-                    $this->memberMerger->mergeNewMember($oldCafNum, $parsedUser);
+                    // Si une fiche vivante détient déjà ce cafnum, la fusion le réécrirait
+                    // -> violation d'unicité (qui fermait l'EM). On consolide, sauf si la
+                    // fiche en double porte un compte (ambigu) : on alerte sans rien détruire.
+                    if ($existingUser instanceof User) {
+                        if (!empty($existingUser->getPassword())) {
+                            $errorMessage = sprintf(
+                                'Doublon ambigu %s %s : deux fiches avec compte (cafnum fichier %s, cafnum existant %s) — non fusionné automatiquement',
+                                $parsedUser->getFirstname(),
+                                $parsedUser->getLastname(),
+                                $parsedUser->getCafnum(),
+                                $oldCafNum
+                            );
+                            $this->logger->error($errorMessage);
+                            \Sentry\captureMessage($errorMessage);
+                            ++$stats['errors'];
+                            $stats['error_details'][] = [
+                                'cafnum' => $parsedUser->getCafnum(),
+                                'message' => $errorMessage,
+                            ];
+
+                            $this->entityManager->clear();
+                            continue;
+                        }
+
+                        $this->memberMerger->consolidateDuplicate($existingUser, $oldCafNum, $parsedUser);
+                    } else {
+                        $this->memberMerger->mergeNewMember($oldCafNum, $parsedUser);
+                    }
                     ++$stats['merged'];
 
                     // Stocker les détails de la fusion (tous pour debug)
@@ -191,9 +218,17 @@ class FfcamSynchronizer
                     $this->entityManager->clear();
                 } catch (\Exception $exception) {
                     $this->logger->error('Flush error: ' . $exception->getMessage());
+                    \Sentry\captureException($exception);
                     ++$stats['errors'];
+                    $stats['error_details'][] = [
+                        'cafnum' => $parsedUser->getCafnum(),
+                        'message' => $exception->getMessage(),
+                    ];
 
-                    // Clear l'entity manager pour continuer le traitement
+                    if ($this->abortIfManagerClosed($stats)) {
+                        break;
+                    }
+
                     $this->entityManager->clear();
                 }
             } catch (\Exception $exception) {
@@ -205,6 +240,7 @@ class FfcamSynchronizer
                     $cafnum,
                     $errorMessage
                 ));
+                \Sentry\captureException($exception);
 
                 ++$stats['errors'];
 
@@ -214,12 +250,31 @@ class FfcamSynchronizer
                     'message' => $errorMessage,
                 ];
 
+                if ($this->abortIfManagerClosed($stats)) {
+                    break;
+                }
+
                 // Continue avec le prochain membre
                 continue;
             }
         }
 
         return $stats;
+    }
+
+    // Si un flush a fermé l'EntityManager, poursuivre cascaderait sur les adhérents
+    // suivants : on interrompt la routine plutôt que de continuer sur un manager mort.
+    // Ne se déclenche que sur un échec inattendu (le look-before-write couvre le cas connu).
+    private function abortIfManagerClosed(array &$stats): bool
+    {
+        if ($this->entityManager->isOpen()) {
+            return false;
+        }
+
+        $this->logger->critical('EntityManager fermé pendant la synchro FFCAM : routine interrompue.');
+        $stats['aborted'] = true;
+
+        return true;
     }
 
     private function updateExistingUser(User $existingUser, User $parsedUser): void

--- a/src/Utils/MemberMerger.php
+++ b/src/Utils/MemberMerger.php
@@ -85,6 +85,51 @@ class MemberMerger
         }
     }
 
+    /**
+     * Consolide deux fiches vivantes d'une même personne : parque la fiche au cafnum du
+     * fichier ($existingDuplicate, sans compte) pour libérer ce cafnum, puis fusionne les
+     * données du fichier sur la fiche historique ($oldCafNum). En une transaction.
+     */
+    public function consolidateDuplicate(User $existingDuplicate, string $oldCafNum, User $parsedUser): void
+    {
+        try {
+            $this->entityManager->beginTransaction();
+
+            $oldCafUser = $this->userRepository->findOneByLicenseNumber($oldCafNum);
+
+            if (!$oldCafUser) {
+                throw new \Exception('Unable to find an user with this cafnum ' . $oldCafNum);
+            }
+
+            // La fiche en double est parquée (non supprimée) : on rapatrie ses inscriptions
+            // sur la fiche gardée, sans recréer un doublon (evt, user).
+            $connection = $this->entityManager->getConnection();
+            $connection->executeStatement(
+                'DELETE d FROM caf_evt_join d
+                 INNER JOIN caf_evt_join k ON k.evt_evt_join = d.evt_evt_join AND k.user_evt_join = :keep
+                 WHERE d.user_evt_join = :drop',
+                ['keep' => $oldCafUser->getId(), 'drop' => $existingDuplicate->getId()]
+            );
+            $connection->executeStatement(
+                'UPDATE caf_evt_join SET user_evt_join = :keep WHERE user_evt_join = :drop',
+                ['keep' => $oldCafUser->getId(), 'drop' => $existingDuplicate->getId()]
+            );
+
+            $existingDuplicate
+                ->setCafnum('obs_' . $existingDuplicate->getCafnum())
+                ->setEmail('obs_' . time() . '_' . bin2hex(random_bytes(8)))
+                ->setIsDeleted(true);
+            $this->entityManager->flush();
+
+            $this->mergeUser($oldCafUser, $parsedUser);
+            $this->entityManager->flush();
+            $this->entityManager->commit();
+        } catch (\Exception $e) {
+            $this->entityManager->rollback();
+            throw $e;
+        }
+    }
+
     private function mergeUser(User $oldCafUser, User $newCafUser): void
     {
         $oldCafUser->setFirstname($newCafUser->getFirstname())

--- a/tests/Service/FfcamSkillsServiceTest.php
+++ b/tests/Service/FfcamSkillsServiceTest.php
@@ -67,7 +67,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Randonnée', 'randonnee', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BF2-RA-RAL', 'BF1-RA-RM'];
+        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -76,7 +76,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Alpinisme', 'alpinisme', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
+        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -86,7 +86,7 @@ class FfcamSkillsServiceTest extends TestCase
         $brevets = $this->service->getBrevets($commission);
 
         $this->assertIsArray($brevets);
-        $this->assertCount(11, $brevets);
+        $this->assertCount(12, $brevets);
         $this->assertContains('BF3-ES-ES', $brevets);
         $this->assertContains('BF1-ES-SAE', $brevets);
     }

--- a/tests/Service/FfcamSkillsServiceTest.php
+++ b/tests/Service/FfcamSkillsServiceTest.php
@@ -67,7 +67,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Randonnée', 'randonnee', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BF2-RA-RAL', 'BF1-RA-RM'];
+        $expected = ['BF3-FC-CO', 'BF3-RA-RM', 'BFM-RA-RM', 'BFM-RA-RA', 'BFM-SN-RN', 'BF2-RA-RAL', 'BF1-RA-RM'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -76,7 +76,7 @@ class FfcamSkillsServiceTest extends TestCase
         $commission = new Commission('Alpinisme', 'alpinisme', 1);
         $brevets = $this->service->getBrevets($commission);
 
-        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BF2-AL-GVE', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
+        $expected = ['BF3-AL-AL', 'BFM-AL-GV', 'BFM-AL-CG', 'BFM-AL-GVE', 'BFM-AL-EG', 'BF2-AL-GVE', 'BF2-AL-EG', 'BF2-AL-GV', 'BF2-AL-CG', 'BF1-AL-AL'];
         $this->assertEquals($expected, $brevets);
     }
 
@@ -86,7 +86,7 @@ class FfcamSkillsServiceTest extends TestCase
         $brevets = $this->service->getBrevets($commission);
 
         $this->assertIsArray($brevets);
-        $this->assertCount(12, $brevets);
+        $this->assertCount(14, $brevets);
         $this->assertContains('BF3-ES-ES', $brevets);
         $this->assertContains('BF1-ES-SAE', $brevets);
     }

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -470,4 +470,172 @@ class FfcamSynchronizerTest extends WebTestCase
         // Check that user2 has not been merged (ie cafnum is not changed)
         $this->assertEquals($identifiant2, $user2->getCafnum());
     }
+
+    public function testSynchronizeConsolidatesUnmergedDuplicate(): void
+    {
+        // Incident juin 2026 : une personne avec DEUX fiches vivantes — l'historique
+        // (compte + email propre) et une fiche au cafnum du fichier (sans compte, email
+        // masqué). La fusion réécrivait un cafnum déjà pris -> violation -> EM fermé ->
+        // cascade. Désormais on consolide : la fiche en double est parquée et l'historique
+        // récupère le cafnum du fichier en conservant son compte.
+        [$row, $oldCafnum, $newCafnum, $historicId] = $this->createDuplicatePair(null);
+
+        $nextCafnum = (string) rand(100000000000, 999999999999);
+        $filePath = FfcamTestHelper::generateFile([
+            $row,
+            [
+                'cafnum' => $nextCafnum,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => 'suivant-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr',
+            ],
+        ]);
+
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+
+        // Le cafnum du fichier pointe désormais sur la fiche HISTORIQUE, compte conservé.
+        $survivor = $repository->findOneByLicenseNumber($newCafnum);
+        $this->assertNotNull($survivor);
+        $this->assertSame($historicId, $survivor->getId(), 'La fiche historique doit survivre et porter le cafnum du fichier');
+        $this->assertSame('hashedpassword', $survivor->getPassword(), 'Le compte (mot de passe) doit être conservé');
+
+        // L'ancien cafnum n'existe plus, et l'adhérent suivant a bien été traité (pas de cascade).
+        $this->assertNull($repository->findOneByLicenseNumber($oldCafnum));
+        $this->assertNotNull($repository->findOneByLicenseNumber($nextCafnum));
+    }
+
+    public function testSynchronizeDoesNotAutoMergeWhenDuplicateHasAccount(): void
+    {
+        // Garde-fou : si la fiche au cafnum du fichier porte AUSSI un compte, on ne détruit
+        // rien automatiquement (ambigu) — on alerte et on saute, sans casser la suite.
+        [$row, $oldCafnum, $newCafnum] = $this->createDuplicatePair('hashedpassword-dup');
+
+        $nextCafnum = (string) rand(100000000000, 999999999999);
+        $filePath = FfcamTestHelper::generateFile([
+            $row,
+            [
+                'cafnum' => $nextCafnum,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => 'suivant-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr',
+            ],
+        ]);
+
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+
+        // Aucune fusion automatique : les deux fiches subsistent à leur cafnum d'origine.
+        $this->assertNotNull($repository->findOneByLicenseNumber($oldCafnum));
+        $this->assertNotNull($repository->findOneByLicenseNumber($newCafnum));
+        // La suite du fichier est quand même traitée (skip, pas de cascade).
+        $this->assertNotNull($repository->findOneByLicenseNumber($nextCafnum));
+    }
+
+    public function testSynchronizeConsolidationKeepsDuplicateParticipations(): void
+    {
+        // La consolidation parque la fiche en double : ses inscriptions aux sorties
+        // doivent suivre la fiche gardée, sinon elles deviendraient invisibles.
+        [$row, , $newCafnum, $historicId] = $this->createDuplicatePair(null);
+
+        // La fiche en double a une inscription à une sortie.
+        $duplicate = self::getContainer()->get(UserRepository::class)->findOneByLicenseNumber($newCafnum);
+        $duplicateId = $duplicate->getId();
+        $this->createEvent($duplicate);
+
+        $filePath = FfcamTestHelper::generateFile([$row]);
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $connection = self::getContainer()->get(EntityManagerInterface::class)->getConnection();
+        $onHistoric = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$historicId]);
+        $onDuplicate = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$duplicateId]);
+
+        $this->assertSame(1, $onHistoric, "L'inscription doit être rattachée à la fiche gardée");
+        $this->assertSame(0, $onDuplicate, "La fiche parquée ne doit plus porter d'inscription");
+    }
+
+    public function testSynchronizeConsolidationDeduplicatesParticipations(): void
+    {
+        // Si les deux fiches sont déjà inscrites à la MÊME sortie, la consolidation ne doit
+        // pas créer de double inscription sur la fiche gardée.
+        [$row, , $newCafnum, $historicId] = $this->createDuplicatePair(null);
+
+        $repository = self::getContainer()->get(UserRepository::class);
+        $historic = $repository->find($historicId);
+        $duplicate = $repository->findOneByLicenseNumber($newCafnum);
+        $duplicateId = $duplicate->getId();
+
+        // Une sortie où les DEUX fiches sont inscrites.
+        $event = $this->createEvent($historic);
+        $event->addParticipation($duplicate);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($event);
+        $em->flush();
+        $eventId = $event->getId();
+
+        $filePath = FfcamTestHelper::generateFile([$row]);
+        self::getContainer()->get(FfcamSynchronizer::class)->synchronize($filePath);
+
+        $connection = $em->getConnection();
+        $onEventForHistoric = (int) $connection->fetchOne(
+            'SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ? AND evt_evt_join = ?',
+            [$historicId, $eventId]
+        );
+        $onDuplicate = (int) $connection->fetchOne('SELECT COUNT(*) FROM caf_evt_join WHERE user_evt_join = ?', [$duplicateId]);
+
+        $this->assertSame(1, $onEventForHistoric, 'Pas de double inscription sur la fiche gardée');
+        $this->assertSame(0, $onDuplicate, "La fiche parquée ne porte plus d'inscription");
+    }
+
+    /**
+     * Crée une personne avec deux fiches vivantes : l'historique (compte + email propre)
+     * et une fiche au cafnum du fichier (email masqué). $duplicatePassword contrôle si la
+     * fiche en double porte un compte (pour tester le garde-fou d'ambiguïté).
+     *
+     * @return array{0: array<string, string>, 1: string, 2: string, 3: int} [ligne fichier, ancien cafnum, nouveau cafnum, id historique]
+     */
+    private function createDuplicatePair(?string $duplicatePassword): array
+    {
+        $oldCafnum = (string) rand(100000000000, 999999999999);
+        $newCafnum = (string) rand(100000000000, 999999999999);
+        $lastname = $this->faker->lastName();
+        $firstname = $this->faker->firstName();
+        $email = 'poison-' . bin2hex(random_bytes(8)) . '@clubalpinlyon.fr';
+
+        // Fiche historique : possède un compte (mot de passe) et l'email propre.
+        $historic = $this->signup(null, 'hashedpassword');
+        $historic
+            ->setCafnum($oldCafnum)
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setBirthdate(new \DateTimeImmutable('1990-01-01'))
+            ->setEmail($email)
+            ->setDoitRenouveler(true);
+
+        // Fiche en double au cafnum du fichier : email masqué, compte selon le paramètre.
+        $duplicate = $this->signup(null, $duplicatePassword);
+        $duplicate
+            ->setCafnum($newCafnum)
+            ->setFirstname($firstname)
+            ->setLastname($lastname)
+            ->setBirthdate(new \DateTimeImmutable('1990-01-01'))
+            ->setEmail('doublon.' . $newCafnum . '-' . $email);
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        $em->persist($historic);
+        $em->persist($duplicate);
+        $em->flush();
+
+        $row = [
+            'cafnum' => $newCafnum,
+            'lastname' => $lastname,
+            'firstname' => $firstname,
+            'birthday' => '1990-01-01',
+            'email' => $email,
+        ];
+
+        return [$row, $oldCafnum, $newCafnum, $historic->getId()];
+    }
 }


### PR DESCRIPTION
Déploiement en production des commits actuellement sur `main`.

## Contenu

- **fix(sync) : collision de cafnum à la fusion — look-before-write (#1760)** ⚠️ **incident en cours**
  Corrige la cascade de la synchro FFCAM (depuis le 13/06) : un doublon de cafnum fermait l'EntityManager et faisait échouer tous les adhérents suivants → ~714 adhérents invisibles, 4 nouveaux jamais créés (Berger, Desrosiers, les 2 Lafond).
- fix(brevets) : dry-tooling (EG) en escalade/alpinisme + BFM-SN-RN en randonnée (#1761)
- fix(brevets) : afficher les brevets Moniteur (BFM) manquants par commission (#1759)

## Effet attendu après déploiement

Au prochain sync planifié (06:16 découverte / 09:03 annuel) :
- les **4 adhérents manquants sont créés** ;
- les **3 fiches en double** (Lagrange, Blom, Vuaille) sont **consolidées automatiquement** (la fiche historique récupère le cafnum + garde son compte ; les participations sont migrées) ;
- les **~714 adhérents** en cascade repassent en mise à jour normale.

Aucune action data manuelle requise. Un script SQL de secours existe (`docs/remediation-doublons-ffcam-2026-06.sql`) mais n'est pas nécessaire.

## Vérification post-déploiement

Rapport de synchro (mail `supervision-licences@`) : les « erreurs de traitement » doivent retomber de ~750 à ~0, et « nouveaux adhérents » / « fusionnés » refléter les créations + consolidations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)