### PR TITLE
fix(sync): compte les emails partagés en warning, pas en erreur

### DIFF
--- a/src/Service/FfcamSynchronizer.php
+++ b/src/Service/FfcamSynchronizer.php
@@ -168,13 +168,12 @@ class FfcamSynchronizer
                             $parsedUser->getCafnum()
                         );
                         if ($duplicateEmailUser instanceof User) {
-                            $errorMessage = sprintf('Email %s is already used by Cafnum %s (so it has been deduplicated)', $parsedUser->getEmail(), $duplicateEmailUser->getCafnum());
-                            $this->logger->warning($errorMessage);
-                            ++$stats['errors'];
-                            $stats['error_details'][] = [
-                                'cafnum' => $parsedUser->getCafnum(),
-                                'message' => $errorMessage,
-                            ];
+                            // Email partagé (couple/famille) : neutralisé pour respecter l'unicité.
+                            // Cas légitime et fréquent -> warning, pas erreur.
+                            $warningMessage = sprintf('Email %s is already used by Cafnum %s (so it has been deduplicated)', $parsedUser->getEmail(), $duplicateEmailUser->getCafnum());
+                            $this->logger->warning($warningMessage);
+                            ++$stats['warnings'];
+                            $stats['warning_details'][] = $warningMessage;
 
                             // email unique même si faux
                             $parsedUser->setEmail('doublon.' . $parsedUser->getCafnum() . '-' . $parsedUser->getEmail());


### PR DESCRIPTION
## Contexte

Le rapport de synchro FFCAM affiche en permanence ~56 « erreurs » du type :

> `Email xxx@yyy.fr is already used by Cafnum 690… (so it has been deduplicated)`

Après vérification en base, **ces cas ne sont pas des erreurs** : ce sont des **couples ou des familles partageant un même email** (un parent qui inscrit ses enfants sous son adresse). L'adhérent est correctement traité ; on neutralise seulement son email pour respecter la contrainte d'unicité.

Le code était d'ailleurs incohérent : le message était **logué en `warning`** mais **compté dans `stats['errors']`**.

## Changement

On bascule ce cas de `stats['errors']` vers `stats['warnings']`.

## Effet

- Le compteur d'« erreurs » du rapport retombe à ~0 au lieu de ~56.
- Le staff ne panique plus à chaque synchro, et une **vraie** erreur redevient visible.
- Aucun changement de comportement métier : la déduplication de l'email est inchangée.

## Validation

- ✅ `php bin/phpunit --filter FfcamSynchronizer` : 14 tests, 45 assertions
- ✅ phpstan : no errors
- ✅ php-cs-fixer : clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)