### PR TITLE
fix: rétablit l'inscription manuelle pour les encadrants sans user_see_all

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -48,6 +48,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class UserController extends AbstractController
 {
+    /** Vues de l'écran d'inscription manuelle ; toutes excluent les comptes supprimés. */
+    private const MANUAL_ADD_VIEWS = ['allvalid', 'discovery', 'nomade', 'external', 'all'];
+
     /**
      * @throws NonUniqueResultException
      * @throws NoResultException
@@ -537,6 +540,10 @@ class UserController extends AbstractController
         string $page = 'users-list',
         ?string $show = null
     ): JsonResponse {
+        if (!$show) {
+            $show = 'allvalid';
+        }
+
         $eventId = $request->query->getInt('event', 0);
 
         // la liste d'inscription manuelle suit le droit de la sortie, pas celui de la liste des adhérents
@@ -545,13 +552,13 @@ class UserController extends AbstractController
             if (!$event instanceof Evt || !$this->isGranted('EVENT_JOINING_ADD', $event)) {
                 throw $this->createAccessDeniedException('Not allowed');
             }
+            if (!in_array($show, self::MANUAL_ADD_VIEWS, true)) {
+                throw $this->createAccessDeniedException('Not allowed');
+            }
         } elseif (!$userRights->allowed('user_see_all')) {
             throw $this->createAccessDeniedException('Not allowed');
         }
 
-        if (!$show) {
-            $show = 'allvalid';
-        }
         $start = $request->query->getInt('start', 0);
         $length = $request->query->getInt('length', 100);
         $searchText = $request->query->all()['search']['value'] ?? null;

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -537,7 +537,15 @@ class UserController extends AbstractController
         string $page = 'users-list',
         ?string $show = null
     ): JsonResponse {
-        if (!$userRights->allowed('user_see_all')) {
+        $eventId = $request->query->getInt('event', 0);
+
+        // la liste d'inscription manuelle suit le droit de la sortie, pas celui de la liste des adhérents
+        if ('manual-add' === $page) {
+            $event = $eventRepository->find($eventId);
+            if (!$event instanceof Evt || !$this->isGranted('EVENT_JOINING_ADD', $event)) {
+                throw $this->createAccessDeniedException('Not allowed');
+            }
+        } elseif (!$userRights->allowed('user_see_all')) {
             throw $this->createAccessDeniedException('Not allowed');
         }
 
@@ -548,7 +556,6 @@ class UserController extends AbstractController
         $length = $request->query->getInt('length', 100);
         $searchText = $request->query->all()['search']['value'] ?? null;
         $order = $request->query->all()['order'] ?? null;
-        $eventId = $request->query->getInt('event', 0);
         $usersToIgnore = $this->getEventParticipants($eventId, $eventRepository);
 
         $recordsFiltered = $userRepository->getUsersCount($show, $searchText, $usersToIgnore);
@@ -675,12 +682,12 @@ class UserController extends AbstractController
                 'renew' => $renew,
                 'nickname' => '<a href="' . $this->generateUrl('user_profile', ['id' => $user->getId()]) . '" class="fancyframe userlink" title="Voir la fiche">' . $user->getNickname() . '</a>',
                 'age' => $age,
-                'tel' => $tel,
-                'email' => $email,
             ];
             if ('users-list' === $page) {
                 $resultLine = array_merge($resultLine, [
                     'tools' => $tools,
+                    'tel' => $tel,
+                    'email' => $email,
                     'cp' => $user->getCp(),
                     'ville' => $user->getVille(),
                     'license' => $license,

--- a/tests/Controller/ManualAddDataTest.php
+++ b/tests/Controller/ManualAddDataTest.php
@@ -69,6 +69,48 @@ class ManualAddDataTest extends WebTestCase
         }
     }
 
+    /**
+     * Les comptes supprimés ne sont proposés que par la liste des adhérents, jamais à l'inscription.
+     */
+    public function testLaVueDesComptesSupprimesEstRefusee(): void
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $supprime = $this->signup();
+        $supprime->setIsDeleted(true);
+        $em->flush();
+
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/manual-add/deleted', $this->datatablesQuery($event->getId()));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * @dataProvider vuesDeLEcranDInscriptionManuelle
+     */
+    public function testLesVuesDeLEcranRestentAccessibles(string $show): void
+    {
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/manual-add/' . $show, $this->datatablesQuery($event->getId()));
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public static function vuesDeLEcranDInscriptionManuelle(): iterable
+    {
+        yield 'adhérents club' => ['allvalid'];
+        yield 'cartes découverte' => ['discovery'];
+        yield 'adhérents autres clubs' => ['nomade'];
+        yield 'personnes externes' => ['external'];
+        yield 'tous' => ['all'];
+    }
+
     public function testAdherentSansLienAvecLaSortieEstRefuse(): void
     {
         $organizer = $this->signup();

--- a/tests/Controller/ManualAddDataTest.php
+++ b/tests/Controller/ManualAddDataTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\WebTestCase;
+
+class ManualAddDataTest extends WebTestCase
+{
+    /**
+     * Paramètres envoyés par DataTables en mode serverSide.
+     */
+    private function datatablesQuery(int $eventId): array
+    {
+        return [
+            'draw' => 1,
+            'start' => 0,
+            'length' => 100,
+            'search' => ['value' => '', 'regex' => 'false'],
+            'order' => [['column' => 2, 'dir' => 'asc']],
+            'event' => $eventId,
+        ];
+    }
+
+    public function testOrganisateurSansDroitSurLaListeDesAdherentsChargeLeTableau(): void
+    {
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery($event->getId()));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+    }
+
+    public function testLeTableauNExposePasLesCoordonneesDesAdherents(): void
+    {
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery($event->getId()));
+
+        $payload = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertNotEmpty($payload['data']);
+        foreach ($payload['data'] as $line) {
+            $this->assertArrayNotHasKey('email', $line);
+            $this->assertArrayNotHasKey('tel', $line);
+        }
+    }
+
+    public function testAdherentSansLienAvecLaSortieEstRefuse(): void
+    {
+        $organizer = $this->signup();
+        $event = $this->createEvent($organizer);
+
+        $this->signin($this->signup());
+        $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery($event->getId()));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testSortieInconnueEstRefusee(): void
+    {
+        $this->signin($this->signup());
+        $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery(0));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testListeDesAdherentsResteReserveeAuDroitDedie(): void
+    {
+        $this->signin($this->signup());
+        $this->client->request('GET', '/users/data/users-list/allvalid', $this->datatablesQuery(0));
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Controller/ManualAddDataTest.php
+++ b/tests/Controller/ManualAddDataTest.php
@@ -46,6 +46,25 @@ class ManualAddDataTest extends WebTestCase
         foreach ($payload['data'] as $line) {
             $this->assertArrayNotHasKey('email', $line);
             $this->assertArrayNotHasKey('tel', $line);
+            $this->assertArrayNotHasKey('tools', $line);
+        }
+    }
+
+    /**
+     * Sans user_read_private, l'âge reste masqué : la sortie ne donne pas accès aux dates de naissance.
+     */
+    public function testLAgeResteMasqueSansDroitSurLesDonneesPrivees(): void
+    {
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery($event->getId()));
+
+        $payload = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertNotEmpty($payload['data']);
+        foreach ($payload['data'] as $line) {
+            $this->assertStringContainsString('lock_gray.png', $line['age']);
         }
     }
 

--- a/tests/Controller/ManualAddDataTest.php
+++ b/tests/Controller/ManualAddDataTest.php
@@ -65,6 +65,7 @@ class ManualAddDataTest extends WebTestCase
         $this->assertNotEmpty($payload['data']);
         foreach ($payload['data'] as $line) {
             $this->assertStringContainsString('lock_gray.png', $line['age']);
+            $this->assertDoesNotMatchRegularExpression('/\d+\s*ans/', $line['age']);
         }
     }
 
@@ -81,16 +82,25 @@ class ManualAddDataTest extends WebTestCase
 
     public function testSortieInconnueEstRefusee(): void
     {
-        $this->signin($this->signup());
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $this->createEvent($organizer);
+
         $this->client->request('GET', '/users/data/manual-add/allvalid', $this->datatablesQuery(0));
 
         $this->assertResponseStatusCodeSame(403);
     }
 
+    /**
+     * Le droit sur une sortie n'ouvre pas la liste des adhérents.
+     */
     public function testListeDesAdherentsResteReserveeAuDroitDedie(): void
     {
-        $this->signin($this->signup());
-        $this->client->request('GET', '/users/data/users-list/allvalid', $this->datatablesQuery(0));
+        $organizer = $this->signup();
+        $this->signin($organizer);
+        $event = $this->createEvent($organizer);
+
+        $this->client->request('GET', '/users/data/users-list/allvalid', $this->datatablesQuery($event->getId()));
 
         $this->assertResponseStatusCodeSame(403);
     }


### PR DESCRIPTION
## Symptôme

À l'ouverture de « Inscrire manuellement des participants », le tableau reste vide et affiche :

> DataTables warning: table id=DataTables_Table_0 - Invalid JSON response.

Signalé sur Slack, avec l'observation « fonctionne quand on est admin ».

## Cause

L'écran `event_manual_add_select` est protégé par le voter `EVENT_JOINING_ADD` (organisateur ou encadrant de la sortie), mais le tableau DataTables qu'il affiche va chercher ses lignes en AJAX sur `users_data`, qui exige un droit différent et plus élevé : `user_see_all`.

Pour un encadrant qui n'a pas ce droit, la page s'ouvre mais l'appel AJAX renvoie une page d'erreur **403 en HTML** — d'où le message de DataTables, qui attendait du JSON.

Régression introduite par d6bfac84 (23/01/2026, en production depuis), qui a basculé cette liste d'un rendu Twig côté serveur — couvert par le droit de la sortie — vers un DataTables `serverSide`.

## Qui est touché

`user_see_all` n'est pas accordé en production aux profils `coencadrant` ni `benevole_encadrement` : **109 comptes** concernés (60 co-encadrants, 54 bénévoles d'encadrement), plus tout adhérent ayant créé une sortie sans attribut d'encadrement. Sur les 276 sorties depuis le 1er juin, 15 ont au moins un encadrant dans ce cas.

⚠️ Le bug est invisible en local et en CI : `legacy/data/data_caf.sql` accorde `user_see_all` à ces deux profils, contrairement à la production.

## Correctif

La branche `manual-add` suit désormais le droit de la sortie (`EVENT_JOINING_ADD`), la branche `users-list` garde `user_see_all`.

Puisque cette route s'ouvre à plus de monde, sa charge utile est resserrée : `tel` et `email` ne sont plus envoyés pour `manual-add` — ils étaient sérialisés dans le JSON alors que le tableau ne les affiche pas. Le périmètre visible redevient exactement celui d'avant janvier (licence, nom, prénom, pseudo, date d'adhésion, âge, e-mail renseigné oui/non), l'âge restant masqué sans `user_read_private`.

## Durcissement complémentaire (revue)

Le contrôle d'accès portait sur la page et la sortie, mais pas sur la vue demandée : `manual-add/deleted` renvoyait les **comptes supprimés** (nom, prénom, pseudo, n° de licence) à tout organisateur autorisé — vérifié, 39 lignes retournées en test. Le repository générique introduit en janvier avait perdu le `isDeleted = false` que `findUsersToRegister()` imposait en dur ; `user_see_all` masquait le trou jusqu'ici.

Seules les cinq vues de l'écran sont désormais acceptées (`allvalid`, `discovery`, `nomade`, `external`, `all`), toutes filtrant déjà les comptes supprimés.

## Tests

5 tests fonctionnels dans `tests/Controller/ManualAddDataTest.php`, avec les paramètres réels de DataTables en `serverSide` :

- l'organisateur sans `user_see_all` obtient bien du JSON (cas de la régression) ;
- la réponse ne contient ni `email` ni `tel` ;
- un adhérent sans lien avec la sortie est refusé ;
- une sortie inexistante est refusée ;
- la liste des adhérents reste réservée à `user_see_all` ;
- la vue des comptes supprimés est refusée, et les cinq vues de l'écran restent accessibles.

`php-cs-fixer` et `phpstan` passent ; `SortieControllerTest` (37 tests) reste vert.

## Suites possibles, hors périmètre

1. **Aligner `data_caf.sql` sur la matrice de droits de production**, sans quoi ce type de bug continuera de passer les tests.
2. `users_data` lève un `TypeError` (500 en HTML) si `search[value]` ou `order` est absent de la requête — `$searchText` et `$order` peuvent valoir `null` alors que le repository attend une `string` et un `array`. DataTables les envoie toujours, mais tout autre appelant casse.
3. `UserRepository::getAttributeByColNumber()` mappe des index de colonnes qui ne correspondent ni à l'écran `manual-add`, ni tout à fait à `users-list` : les tris par pseudo, date d'adhésion, ville et code postal sont décalés.

## Vérification en recette

Le diagnostic explique le symptôme et le mécanisme est reproduit en test, mais la personne effectivement bloquée n'a pas été identifiée — aucun log HTTP n'est disponible côté production. À confirmer avec un compte `coencadrant` sans autre responsabilité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9Qro8UWrYZotVPUSNQYTw
