### PR TITLE
fix(paiement): confirme le paiement sans annoncer un retrait immédiat du matériel

### DIFF
--- a/templates/payment/return.html.twig
+++ b/templates/payment/return.html.twig
@@ -72,7 +72,7 @@
     {% if status == 'success' %}
         <span class="pay-badge pay-badge--ok fade-up d1">✓ Paiement confirmé</span>
         <h1 class="pay-title fade-up d1">Au sommet ! 🏔️</h1>
-        <p class="pay-lead fade-up d2">Ton paiement est bien passé et ton matos t'attend. Y'a plus qu'à enfiler les chaussures. Bonne course&nbsp;!</p>
+        <p class="pay-lead fade-up d2">Ton paiement a bien été accepté.</p>
         <p class="pay-note fade-up d3">Tu peux fermer cette page tranquille.</p>
         <a class="pay-cta fade-up d4" href="/">Retour sur le site</a>
     {% elseif status == 'cancel' %}


### PR DESCRIPTION
## Problème

Après un paiement de réservation de matériel (passerelle Loxya / HelloAsso), la page de retour affichait :

> Ton paiement est bien passé et ton matos t'attend. Y'a plus qu'à enfiler les chaussures. Bonne course !

Deux suppositions fausses : que la sortie est de la marche, et que le matériel est à venir chercher au club. Or il est parfois apporté par l'encadrant — des adhérents se déplaçaient pour rien.

## Changement

Une ligne, dans `templates/payment/return.html.twig` :

> Ton paiement a bien été accepté.

Le reste de la page ne bouge pas : badge « ✓ Paiement confirmé », « Tu peux fermer cette page tranquille », lien de retour.

## À trancher si vous voulez

Le titre `Au sommet ! 🏔️` reste en place. Il ne suppose ni activité ni déplacement, mais il célèbre un paiement — dites-le si vous préférez quelque chose de plus neutre.

Vérifié : aucun email n'est envoyé par `HelloAssoWebhookController`, ce texte n'existait qu'à cet endroit, et aucun test n'en dépend. `lint:twig` passe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHZQFfErumoj7HAbJPLvaK
