### PR TITLE
fix(sync): une ville trop longue ne coupe plus la synchro FFCAM

### DIFF
--- a/migrations/Version20260902120000.php
+++ b/migrations/Version20260902120000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260902120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adhérents : élargit ville_user à 50 caractères (la FFCAM en annonce 33, la colonne en acceptait 30)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE caf_user CHANGE ville_user ville_user VARCHAR(50) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('UPDATE caf_user SET ville_user = LEFT(ville_user, 30)');
+        $this->addSql('ALTER TABLE caf_user CHANGE ville_user ville_user VARCHAR(30) DEFAULT NULL');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -108,7 +108,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \JsonSe
     #[SerializedName('codePostal')]
     private ?string $cp = null;
 
-    #[ORM\Column(name: 'ville_user', type: 'string', length: 30, nullable: true)]
+    #[ORM\Column(name: 'ville_user', type: 'string', length: 50, nullable: true)]
     #[Groups('user:details')]
     private ?string $ville = null;
 

--- a/src/Service/FfcamFileParser.php
+++ b/src/Service/FfcamFileParser.php
@@ -6,6 +6,21 @@ use App\Entity\User;
 
 class FfcamFileParser
 {
+    // La FFCAM livre des valeurs parfois plus longues que nos colonnes (ville sur 33 caractères,
+    // adresse concaténée depuis 4 champs...). Sans troncature, le flush échoue, ferme
+    // l'EntityManager et la synchro s'interrompt pour tous les adhérents suivants du fichier.
+    private const COLUMN_MAX_LENGTHS = [
+        'firstname' => 50,
+        'lastname' => 50,
+        'civ' => 10,
+        'cp' => 10,
+        'ville' => 50,
+        'adresse' => 100,
+        'tel' => 100,
+        'tel2' => 100,
+        'email' => 200,
+    ];
+
     /**
      * @throws \Exception
      */
@@ -59,21 +74,21 @@ class FfcamFileParser
 
         $email = null;
         if (!empty(trim($line[28]))) {
-            $email = strtolower(trim($line[28]));
+            $email = $this->truncate(strtolower(trim($line[28])), 'email');
         }
 
         $user
             ->setCafnum(trim($line[0]))
-            ->setFirstname($firstname)
-            ->setLastname($lastname)
+            ->setFirstname($this->truncate($firstname, 'firstname'))
+            ->setLastname($this->truncate($lastname, 'lastname'))
             ->setBirthdate($birthdate)
-            ->setCiv($this->normalizeNames(str_replace('MLLE', 'MME', trim($line[8]))))
+            ->setCiv($this->truncate($this->normalizeNames(str_replace('MLLE', 'MME', trim($line[8]))), 'civ'))
             ->setCafnumParent((int) $line[5] > 0 ? trim($line[1] . $line[5]) : null)
-            ->setTel(trim($line[27]) ?: trim($line[29]))
-            ->setTel2(trim($line[26]))
-            ->setAdresse(trim($line[11] . " \n" . $line[12] . " \n" . $line[13] . " \n" . $line[14]))
-            ->setCp($this->normalizeNames(trim($line[15])))
-            ->setVille($this->normalizeNames(trim($line[16])))
+            ->setTel($this->truncate(trim($line[27]) ?: trim($line[29]), 'tel'))
+            ->setTel2($this->truncate(trim($line[26]), 'tel2'))
+            ->setAdresse($this->truncate(trim($line[11] . " \n" . $line[12] . " \n" . $line[13] . " \n" . $line[14]), 'adresse'))
+            ->setCp($this->truncate($this->normalizeNames(trim($line[15])), 'cp'))
+            ->setVille($this->truncate($this->normalizeNames(trim($line[16])), 'ville'))
             ->setDoitRenouveler($isLicenceExpired)
             ->setAlerteRenouveler($isLicenceExpired)
             ->setJoinDate($joinDate)
@@ -119,21 +134,21 @@ class FfcamFileParser
 
         $email = null;
         if (!empty(trim($line[16]))) {
-            $email = strtolower(trim($line[16]));
+            $email = $this->truncate(strtolower(trim($line[16])), 'email');
         }
 
         $user
             ->setCafnum(trim($line[0]))
-            ->setFirstname($firstname)
-            ->setLastname($lastname)
+            ->setFirstname($this->truncate($firstname, 'firstname'))
+            ->setLastname($this->truncate($lastname, 'lastname'))
             ->setBirthdate($birthdate)
-            ->setCiv($this->normalizeNames(str_replace('MLLE', 'MME', trim($line[5]))))
+            ->setCiv($this->truncate($this->normalizeNames(str_replace('MLLE', 'MME', trim($line[5]))), 'civ'))
             ->setCafnumParent(null)
-            ->setTel(trim($line[17]) ?: trim($line[14]))
-            ->setTel2(trim($line[18]))
-            ->setAdresse(trim($line[8]) . " \n" . trim($line[9]) . " \n" . trim($line[10]) . " \n" . trim($line[11]))
-            ->setCp($this->normalizeNames(trim($line[12])))
-            ->setVille($this->normalizeNames(trim($line[13])))
+            ->setTel($this->truncate(trim($line[17]) ?: trim($line[14]), 'tel'))
+            ->setTel2($this->truncate(trim($line[18]), 'tel2'))
+            ->setAdresse($this->truncate(trim($line[8]) . " \n" . trim($line[9]) . " \n" . trim($line[10]) . " \n" . trim($line[11]), 'adresse'))
+            ->setCp($this->truncate($this->normalizeNames(trim($line[12])), 'cp'))
+            ->setVille($this->truncate($this->normalizeNames(trim($line[13])), 'ville'))
             ->setDoitRenouveler($doitRenouveler)
             ->setAlerteRenouveler($doitRenouveler)
             ->setJoinDate($joinDate)
@@ -194,6 +209,11 @@ class FfcamFileParser
         ) {
             throw new \Exception("Can't process line $lineNumber : Multiple values are wrong");
         }
+    }
+
+    private function truncate(string $value, string $field): string
+    {
+        return mb_substr($value, 0, self::COLUMN_MAX_LENGTHS[$field]);
     }
 
     private function normalizeNames(string $name): string

--- a/tests/Service/FfcamFileParserTest.php
+++ b/tests/Service/FfcamFileParserTest.php
@@ -32,6 +32,22 @@ LINE;
         unlink($filePath);
     }
 
+    public function testParseTruncatesValuesLongerThanColumns()
+    {
+        $ville = str_repeat('A', 80);
+        $line = str_replace(';75000;Paris;;;', ';75000;' . $ville . ';;;', $this->validLine);
+
+        $filePath = tempnam(sys_get_temp_dir(), 'ffcam_test_');
+        file_put_contents($filePath, $line . \PHP_EOL);
+
+        $parser = new FfcamFileParser();
+        $user = $parser->parse($filePath)->current();
+
+        $this->assertEquals(50, mb_strlen($user->getVille()));
+
+        unlink($filePath);
+    }
+
     public function testParseInvalidLineSkipped()
     {
         $filePath = tempnam(sys_get_temp_dir(), 'ffcam_test_');

--- a/tests/Service/FfcamSynchronizerTest.php
+++ b/tests/Service/FfcamSynchronizerTest.php
@@ -638,4 +638,42 @@ class FfcamSynchronizerTest extends WebTestCase
 
         return [$row, $oldCafnum, $newCafnum, $historic->getId()];
     }
+
+    // Régression prod 02/09/2026 : une ville de 33 caractères dépassait ville_user(30),
+    // le flush fermait l'EntityManager et les 34 adhérents suivants du fichier étaient perdus.
+    public function testSynchronizeImportsMembersFollowingAnOverlongCity(): void
+    {
+        $identifiantVilleLongue = rand(100000000000, 999999999999);
+        $identifiantSuivant = rand(100000000000, 999999999999);
+
+        $filePath = FfcamTestHelper::generateFile([
+            [
+                'cafnum' => $identifiantVilleLongue,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => $this->faker->email(),
+                'ville' => 'VILLENEUVE-LA-GARENNE, 92, FRANCE',
+            ],
+            [
+                'cafnum' => $identifiantSuivant,
+                'lastname' => $this->faker->lastName(),
+                'firstname' => $this->faker->firstName(),
+                'email' => $this->faker->email(),
+            ],
+        ]);
+
+        $synchronizer = self::getContainer()->get(FfcamSynchronizer::class);
+        $synchronizer->synchronize($filePath);
+
+        $userRepository = self::getContainer()->get(UserRepository::class);
+
+        $userVilleLongue = $userRepository->findOneByLicenseNumber($identifiantVilleLongue);
+        $this->assertNotNull($userVilleLongue, "L'adhérent dont la ville dépasse 30 caractères doit être importé");
+        $this->assertEquals('Villeneuve-La-Garenne, 92, France', $userVilleLongue->getVille());
+
+        $this->assertNotNull(
+            $userRepository->findOneByLicenseNumber($identifiantSuivant),
+            'Les adhérents suivants ne doivent pas être perdus'
+        );
+    }
 }

--- a/tests/TestHelpers/FfcamTestHelper.php
+++ b/tests/TestHelpers/FfcamTestHelper.php
@@ -4,7 +4,7 @@ namespace App\Tests\TestHelpers;
 
 class FfcamTestHelper
 {
-    private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;LYON;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;%s;%s;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
+    private const TEMPLATE = '%s;6900;%s;99;A1;;%s;%s;M;%s;%s;;LE BELVEDERE;12 RUE DES LILAS;;69001;%s;0;0;0000-00-00;0;;0;;0;;0472000001 0630000001;%s;%s;04.72.00.00.01;0000-00-00;;contact;RANDONNEE,SKI ALPIN,SKI NORDIQUE;;0;;;;;;;;;;;;;;;;;;;;;;;;;A;0;3;;;O;,';
 
     public static function generateFile(array $members, ?string $filePath = null): string
     {
@@ -23,6 +23,7 @@ class FfcamTestHelper
             $birthday = $member['birthday'] ?? '1990-01-01';
             $tel = $member['tel'] ?? '0687000001';
             $email = $member['email'] ?? 'test-email@clubalpinlyon.fr';
+            $ville = $member['ville'] ?? 'LYON';
 
             $content .= sprintf(
                 self::TEMPLATE,
@@ -32,6 +33,7 @@ class FfcamTestHelper
                 $adhesionDate,
                 $lastname,
                 $firstname,
+                $ville,
                 $tel,
                 $email,
             ) . "\n";


### PR DESCRIPTION
## Symptôme

Signalé ce matin : « la synchro avec l'extranet ne fonctionne pas ». Un adhérent licencié au 1er septembre sur l'extranet FFCAM n'apparaissait pas sur le site.

## Diagnostic

Le fichier FFCAM du 02/09/2026 fait 2543 lignes. La synchro s'est arrêtée nette à la **ligne 2510**, sur un adhérent dont la ville est renseignée `VILLENEUVE-LA-GARENNE, 92, FRANCE`.

Cette valeur fait **33 caractères**, or `caf_user.ville_user` est un `varchar(30)` et MySQL tourne en `STRICT_TRANS_TABLES` → *Data too long* → Doctrine ferme l'EntityManager → `abortIfManagerClosed()` interrompt la routine.

Éléments concordants relevés en prod :

- le dernier compte créé correspond à la ligne 2509 ; l'adhérent de la ligne 2510 est absent de la base ;
- `caf_log_admin` : `INSERT: 50, UPDATE: 2455, MERGE: 5` = 2510 lignes traitées sur 2543 ;
- c'est la **seule** ligne du fichier dont la ville dépasse 30 caractères.

**34 adhérents (lignes 2510 à 2543) manquants.** Le problème se reproduit à chaque passage du cron tant que cette ligne est dans le fichier.

La spec FFCAM annonce 33 caractères pour la ville : la colonne a toujours été sous-dimensionnée, le cas n'était juste jamais tombé.

## Correctif

- migration : `ville_user` passe en `varchar(50)` ;
- garde-fou dans `FfcamFileParser` : les champs issus du fichier sont tronqués à la taille de leur colonne, pour qu'un enregistrement hors gabarit ne puisse plus décapiter la fin du fichier.

## Tests

- `FfcamSynchronizerTest::testSynchronizeImportsMembersFollowingAnOverlongCity` — test de régression sur base réelle : reproduit l'échec avant correctif (l'adhérent suivant était perdu) ;
- `FfcamFileParserTest::testParseTruncatesValuesLongerThanColumns` ;
- suite complète verte : 668 tests, 12014 assertions.

## Après merge

Relancer `bin/console ffcam-file-sync` en prod pour rattraper les 34 adhérents sans attendre le cron du lendemain.

## À part

`decouverte_6900.txt` est vide (0 octet) et n'est plus rafraîchi depuis le 26 août : plus aucune carte découverte importée depuis. Ça vient du côté FFCAM, à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjLscFnUs1BTkpebrAWxRy