### PR TITLE
chore(mailerlite): ne planifie pas encore le cron des circuits d'accueil

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -6,6 +6,5 @@
   "54 8 * * * $ROOT/clevercloud/crons/clean-alerts.sh",
   "36 6 * * * $ROOT/clevercloud/crons/google-groups-sync.sh",
   "30 7 * * * $ROOT/clevercloud/crons/license-renew-reminder.sh",
-  "45 2 1 9 * $ROOT/clevercloud/crons/auto-renew-special-accounts.sh",
-  "45 7 * * * $ROOT/clevercloud/crons/mailerlite-accueil-sync.sh"
+  "45 2 1 9 * $ROOT/clevercloud/crons/auto-renew-special-accounts.sh"
 ]

--- a/docs/email-marketing-integration.md
+++ b/docs/email-marketing-integration.md
@@ -131,8 +131,16 @@ perdue.
 
 ## Planification
 
-Le cron `clevercloud/crons/mailerlite-accueil-sync.sh` appelle `bin/console mailerlite-accueil-sync
---execute` tous les jours à `45 7` (heure UTC de `clevercloud/cron.json`), soit 9 h 45 à Paris en heure d'été et 8 h 45 en heure d'hiver. Ce
+**Le cron n'est pas planifié pour l'instant** : la ligne correspondante a été retirée de
+`clevercloud/cron.json` tant que les circuits ne sont pas validés. Aucun envoi n'a donc lieu, même
+en production. Pour activer la fonctionnalité, il suffit de remettre cette ligne :
+
+```json
+"45 7 * * * $ROOT/clevercloud/crons/mailerlite-accueil-sync.sh"
+```
+
+Une fois planifié, le cron `clevercloud/crons/mailerlite-accueil-sync.sh` appelle
+`bin/console mailerlite-accueil-sync --execute` tous les jours à `45 7` (heure UTC de `clevercloud/cron.json`), soit 9 h 45 à Paris en heure d'été et 8 h 45 en heure d'hiver. Ce
 créneau laisse passer la synchronisation FFCAM (`3 7`, 9h03 à Paris) puis l'anonymisation des
 comptes (`28 7`, 9h28 à Paris), pour ne traiter que des fiches à jour.
 


### PR DESCRIPTION
Les circuits d'accueil MailerLite (#1765) sont sur `main` et partent donc dans le prochain push to prod, alors que la fonctionnalité n'est pas prête à envoyer.

## Ce que fait cette PR

Retire une ligne de `clevercloud/cron.json` :

```json
"45 7 * * * $ROOT/clevercloud/crons/mailerlite-accueil-sync.sh"
```

Le cron est **l'unique déclencheur** de la fonctionnalité en production. Sans lui, le code part en prod sans que rien ne s'envoie. Pour l'activer le jour venu : remettre cette ligne, rien d'autre.

Le script shell et la doc précisent l'état et la marche à suivre.

## Pourquoi pas un revert de #1765

- #1765 **ajoute un garde-fou `DEPLOY_ENV`** dans `MailerLiteService::pushToGroup()`, qui n'existait pas avant. Revenir dessus rendrait à staging la capacité d'écrire dans le vrai compte MailerLite — les deux environnements partageant la même clé API. Ce serait une régression.
- #1765 refactore aussi le flux d'inscription existant (`syncNewMembers` → `pushToGroup`) et ajoute la migration `accueil_season`, déjà appliquée sur staging. Un revert impliquerait de supprimer une colonne déjà en place.
- Le push to prod embarque aussi la page méthodologie carbone et le fix Loxya : un revert ciblé y serait plus lourd qu'une ligne retirée.

## Garde-fous restants

Même si le cron était réactivé par erreur, trois protections subsistent :

1. le script ne s'exécute que si `DEPLOY_ENV = production` ;
2. `pushToGroup()` sort immédiatement hors production ;
3. la commande refuse de tourner si `MAILERLITE_RENEWAL_GROUP_ID` est vide ou égal au groupe de bienvenue — cette variable n'est définie ni dans `.env` ni sur Clever Cloud.

La commande est par ailleurs en dry-run par défaut ; seul le `--execute` du cron l'arme.

## Vérifications

- `cron.json` reste un JSON valide (parsé après modification)
- `bash -n` sur le script du cron
- aucun code applicatif ni migration touchés

🤖 Generated with [Claude Code](https://claude.com/claude-code)